### PR TITLE
docs: add themed light/dark SVG diagrams across the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ default and need no change.
 
 ---
 
+## How it works
+
+`kvm-pilot` runs a **see → decide → act** loop, and the screen is its only sensor:
+it pulls a screenshot from the KVM, a vision model classifies the boot phase, and
+`kvm-pilot` acts back through the KVM's keyboard and power. Because it works at the
+pixel level, there is **no agent on the target** — the same loop drives POST,
+firmware, the bootloader, and an OS install.
+
+![kvm-pilot reads a screenshot from the KVM, a vision backend (Claude or a local VLM) classifies the boot phase, and kvm-pilot drives keyboard and power back through the KVM — a closed loop with no agent on the target machine.](docs/how-it-works.svg)
+
 ## Install
 
 ```bash
@@ -91,6 +101,16 @@ The CLI prompts for confirmation before any destructive action. Use `--yes` to
 skip prompts in automation, or `--dry-run` to log intended actions without
 sending them.
 
+## Boot-phase detection
+
+The vision classifier maps each screenshot to a **phase** — `bios_menu`,
+`grub_menu`, `installer_progress`, `login_prompt`, `crash_screen`, and so on.
+`wait_for_state()` polls the screen and blocks until the phase you asked for
+appears (or a timeout fires), so an unattended install becomes a few waits with
+actions wired between them:
+
+![Timeline of boot phases — POST, bios_menu, grub_menu, installer_progress, installer_complete, login_prompt — with the unattended-install example wiring mount_iso and hard_cycle at the start, wait_for_state on grub_menu then Enter, and wait_for_state on installer_complete; any phase can branch to crash_screen.](docs/boot-phases.svg)
+
 ## Safety model
 
 Power-offs, hard resets, virtual-media connect/disconnect, GPIO, and Redfish
@@ -100,6 +120,8 @@ resets are classified as **destructive** and pass through a safety layer:
 - **confirmation** — a callback that can veto any destructive call. The library
   default allows everything (so plain scripts work); the CLI installs an
   interactive `y/N` prompt unless you pass `--yes`.
+
+![Decision flow for a destructive call: if the op is not in DESTRUCTIVE_OPS it executes directly; if it is, dry-run logs and skips it, otherwise a confirm callback can veto it, and only an allowed call is sent to the device.](docs/safety.svg)
 
 The destructive set is defined explicitly in `kvm_pilot.safety.DESTRUCTIVE_OPS`
 so it is auditable rather than guessed. A vision classification can never

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,80 +1,87 @@
 <svg viewBox="0 0 860 588" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ttl dsc">
-  <title id="ttl">Proposed driver-plugin architecture for kvm-pilot</title>
-  <desc id="dsc">A layered stack: consumers (CLI, KVMClient facade, ScreenAnalyzer) talk to a KVMDriver capability-protocol interface, resolved by a driver registry into concrete drivers (PiKVM family, Redfish, JetKVM, Fake) over pluggable transports. Safety, config, errors and vision are shared cross-cutting concerns.</desc>
+  <title id="ttl">kvm-pilot driver-plugin architecture</title>
+  <desc id="dsc">A layered stack. Consumers — the CLI, the KVMClient facade, and ScreenAnalyzer — talk to a KVMDriver capability-protocol interface, resolved by a driver registry into concrete drivers: the PiKVM family today, plus Redfish, JetKVM, and a Fake driver to add. Drivers run over pluggable transports. Safety, config, errors and the vision backends are shared cross-cutting concerns. Purple marks new components to add; grey marks code that exists today and is refactored in place.</desc>
   <style>
-    .b{fill:var(--color-background-primary,#fff);stroke:var(--color-border-secondary,#d4d4d8);stroke-width:1.5;}
-    .bn{fill:var(--color-background-primary,#fff);stroke:#3b82f6;stroke-width:2;}
-    .band{fill:var(--color-border-tertiary,#f3f4f6);stroke:var(--color-border-secondary,#d4d4d8);stroke-width:1;}
     text{font-family:var(--font-sans,ui-sans-serif,system-ui,sans-serif);}
-    .ti{fill:var(--color-text-primary,#18181b);font-weight:600;font-size:13.5px;}
-    .tia{fill:#2563eb;font-weight:700;font-size:13.5px;}
-    .su{fill:var(--color-text-secondary,#71717a);font-size:11px;}
-    .mono{font-family:var(--font-mono,ui-monospace,monospace);fill:var(--color-text-secondary,#71717a);font-size:11.5px;}
-    .lab{fill:var(--color-text-secondary,#9598a1);font-weight:700;font-size:10px;letter-spacing:.08em;}
-    .h{fill:var(--color-text-primary,#18181b);font-weight:700;font-size:16px;}
-    .lg{fill:var(--color-text-secondary,#71717a);font-size:10.5px;}
-    .pill{fill:#3b82f6;}
-    .pt{fill:#fff;font-size:8.5px;font-weight:700;}
+    .card{fill:#fff;stroke:#d3d1c7;stroke-width:1.5;}
+    .band{fill:#f1efe8;stroke:#d3d1c7;stroke-width:1;}
+    .purple{fill:#eeedfe;stroke:#534ab7;stroke-width:1.75;}
+    .pill{fill:#534ab7;}
+    .h{fill:#2c2c2a;font-weight:500;font-size:18px;}
+    .sub{fill:#5f5e5a;font-weight:400;font-size:12px;}
+    .t{fill:#2c2c2a;font-weight:500;font-size:13px;}
+    .ts{fill:#5f5e5a;font-weight:400;font-size:11px;}
+    .tp{fill:#3c3489;font-weight:500;font-size:13px;}
+    .monop{font-family:var(--font-mono,ui-monospace,monospace);fill:#3c3489;font-weight:400;font-size:11.5px;}
+    .lab{fill:#888780;font-weight:500;font-size:11px;}
+    .pillt{fill:#fff;font-size:11px;font-weight:500;}
+    .cn{stroke:#888780;}
+    .mkn{fill:#888780;}
+    @media (prefers-color-scheme:dark){
+      .card{fill:#2a2723;stroke:#4a4641;}
+      .band{fill:#211f1b;stroke:#4a4641;}
+      .purple{fill:#3c3489;stroke:#afa9ec;}
+      .h{fill:#f1efe8;} .sub{fill:#b4b2a9;} .t{fill:#f1efe8;} .ts{fill:#b4b2a9;} .lab{fill:#908d85;}
+      .tp{fill:#cecbf6;} .monop{fill:#cecbf6;}
+    }
   </style>
 
-  <text x="30" y="26" class="h">kvm-pilot — driver-plugin architecture</text>
-  <text x="30" y="44" class="lg">Blue = new components to add · grey = exists today (refactored in place)</text>
+  <text x="30" y="30" class="h">kvm-pilot — driver-plugin architecture</text>
+  <text x="30" y="50" class="sub">Purple = new components to add · grey = exists today, refactored in place.</text>
 
   <defs>
-    <marker id="ar" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto">
-      <path d="M0,0 L6,3 L0,6 Z" fill="var(--color-border-secondary,#b8b8be)"/>
-    </marker>
+    <marker id="ar" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path class="mkn" d="M0,0 L6,3 L0,6 Z"/></marker>
   </defs>
 
-  <text x="30" y="68" class="lab">CONSUMERS</text>
+  <text x="30" y="78" class="lab">Consumers</text>
   <g>
-    <rect class="b" x="30" y="74" width="250" height="54" rx="8"/>
-    <text x="46" y="98" class="ti">CLI</text><text x="46" y="116" class="su">argparse · --driver flag</text>
-    <rect class="b" x="305" y="74" width="250" height="54" rx="8"/>
-    <text x="321" y="98" class="ti">KVMClient (facade)</text><text x="321" y="116" class="su">resolves + delegates to driver</text>
-    <rect class="b" x="580" y="74" width="250" height="54" rx="8"/>
-    <text x="596" y="98" class="ti">ScreenAnalyzer</text><text x="596" y="116" class="su">needs Video capability only</text>
+    <rect class="card" x="30" y="84" width="250" height="54" rx="4"/>
+    <text x="46" y="108" class="t">CLI</text><text x="46" y="126" class="ts">argparse · --driver flag</text>
+    <rect class="card" x="305" y="84" width="250" height="54" rx="4"/>
+    <text x="321" y="108" class="t">KVMClient (facade)</text><text x="321" y="126" class="ts">resolves + delegates to driver</text>
+    <rect class="card" x="580" y="84" width="250" height="54" rx="4"/>
+    <text x="596" y="108" class="t">ScreenAnalyzer</text><text x="596" y="126" class="ts">needs Video capability only</text>
   </g>
-  <line x1="430" y1="128" x2="430" y2="150" stroke="var(--color-border-secondary,#b8b8be)" stroke-width="1.5" marker-end="url(#ar)"/>
+  <line x1="430" y1="138" x2="430" y2="160" class="cn" stroke-width="1.5" marker-end="url(#ar)"/>
 
-  <text x="30" y="146" class="lab">DRIVER INTERFACE · the plugin seam</text>
-  <rect class="bn" x="30" y="152" width="800" height="60" rx="8"/>
-  <rect class="pill" x="772" y="160" width="34" height="15" rx="7.5"/><text x="789" y="171" class="pt" text-anchor="middle">NEW</text>
-  <text x="430" y="178" class="tia" text-anchor="middle">KVMDriver — capability protocols (implement only what the hardware has)</text>
-  <text x="430" y="199" class="mono" text-anchor="middle">Power · HID · Video · VirtualMedia · GPIO · Events · SystemInfo</text>
-  <line x1="430" y1="212" x2="430" y2="234" stroke="var(--color-border-secondary,#b8b8be)" stroke-width="1.5" marker-end="url(#ar)"/>
+  <text x="30" y="156" class="lab">Driver interface — the plugin seam</text>
+  <rect class="purple" x="30" y="162" width="800" height="60" rx="4"/>
+  <rect class="pill" x="768" y="170" width="38" height="16" rx="8"/><text x="787" y="182" class="pillt" text-anchor="middle">new</text>
+  <text x="430" y="188" class="tp" text-anchor="middle">KVMDriver — capability protocols, implement only what the hardware has</text>
+  <text x="430" y="209" class="monop" text-anchor="middle">Power · HID · Video · VirtualMedia · GPIO · Events · SystemInfo</text>
+  <line x1="430" y1="222" x2="430" y2="244" class="cn" stroke-width="1.5" marker-end="url(#ar)"/>
 
-  <text x="30" y="230" class="lab">REGISTRY</text>
-  <rect class="bn" x="30" y="236" width="800" height="50" rx="8"/>
-  <rect class="pill" x="772" y="243" width="34" height="15" rx="7.5"/><text x="789" y="254" class="pt" text-anchor="middle">NEW</text>
-  <text x="430" y="258" class="tia" text-anchor="middle">Driver registry</text>
-  <text x="430" y="276" class="mono" text-anchor="middle">make_driver(kind) · entry-points (kvm_pilot.drivers) · autodetect(host)</text>
-  <line x1="430" y1="286" x2="430" y2="308" stroke="var(--color-border-secondary,#b8b8be)" stroke-width="1.5" marker-end="url(#ar)"/>
+  <text x="30" y="240" class="lab">Registry</text>
+  <rect class="purple" x="30" y="246" width="800" height="50" rx="4"/>
+  <rect class="pill" x="768" y="253" width="38" height="16" rx="8"/><text x="787" y="265" class="pillt" text-anchor="middle">new</text>
+  <text x="430" y="268" class="tp" text-anchor="middle">Driver registry</text>
+  <text x="430" y="286" class="monop" text-anchor="middle">make_driver(kind) · entry-points (kvm_pilot.drivers) · autodetect(host)</text>
+  <line x1="430" y1="296" x2="430" y2="318" class="cn" stroke-width="1.5" marker-end="url(#ar)"/>
 
-  <text x="30" y="304" class="lab">DRIVERS</text>
+  <text x="30" y="314" class="lab">Drivers</text>
   <g>
-    <rect class="b" x="30" y="310" width="185" height="62" rx="8"/>
-    <text x="44" y="333" class="ti">PiKVMDriver</text><text x="44" y="350" class="su">+ GLKVM · BliKVM</text><text x="44" y="365" class="su">(today's code, refactored)</text>
-    <rect class="bn" x="235" y="310" width="185" height="62" rx="8"/>
-    <text x="249" y="333" class="tia">RedfishDriver</text><text x="249" y="350" class="su">iDRAC · iLO · OpenBMC</text><text x="249" y="365" class="su">huge BMC coverage</text>
-    <rect class="bn" x="440" y="310" width="185" height="62" rx="8"/>
-    <text x="454" y="333" class="tia">JetKVMDriver</text><text x="454" y="350" class="su">WS JSON-RPC</text><text x="454" y="365" class="su">(community)</text>
-    <rect class="bn" x="645" y="310" width="185" height="62" rx="8"/>
-    <text x="659" y="333" class="tia">FakeDriver</text><text x="659" y="350" class="su">tests / CI</text><text x="659" y="365" class="su">smoke harness (#2)</text>
+    <rect class="card" x="30" y="320" width="185" height="62" rx="4"/>
+    <text x="44" y="343" class="t">PiKVMDriver</text><text x="44" y="360" class="ts">+ GLKVM · BliKVM</text><text x="44" y="375" class="ts">today's code, refactored</text>
+    <rect class="purple" x="235" y="320" width="185" height="62" rx="4"/>
+    <text x="249" y="343" class="tp">RedfishDriver</text><text x="249" y="360" class="ts">iDRAC · iLO · OpenBMC</text><text x="249" y="375" class="ts">huge BMC coverage</text>
+    <rect class="purple" x="440" y="320" width="185" height="62" rx="4"/>
+    <text x="454" y="343" class="tp">JetKVMDriver</text><text x="454" y="360" class="ts">WS JSON-RPC</text><text x="454" y="375" class="ts">community</text>
+    <rect class="purple" x="645" y="320" width="185" height="62" rx="4"/>
+    <text x="659" y="343" class="tp">FakeDriver</text><text x="659" y="360" class="ts">tests / CI</text><text x="659" y="375" class="ts">smoke harness (#2)</text>
   </g>
-  <line x1="430" y1="372" x2="430" y2="394" stroke="var(--color-border-secondary,#b8b8be)" stroke-width="1.5" marker-end="url(#ar)"/>
+  <line x1="430" y1="382" x2="430" y2="404" class="cn" stroke-width="1.5" marker-end="url(#ar)"/>
 
-  <text x="30" y="390" class="lab">TRANSPORT</text>
+  <text x="30" y="400" class="lab">Transport</text>
   <g>
-    <rect class="b" x="30" y="396" width="250" height="52" rx="8"/>
-    <text x="46" y="419" class="ti">HttpTransport + Auth</text><text x="46" y="437" class="su">urllib · retry · redaction</text>
-    <rect class="b" x="305" y="396" width="250" height="52" rx="8"/>
-    <text x="321" y="419" class="ti">WS transport</text><text x="321" y="437" class="su">JSON-RPC devices</text>
-    <rect class="b" x="580" y="396" width="250" height="52" rx="8"/>
-    <text x="596" y="419" class="ti">IPMI / ipmitool</text><text x="596" y="437" class="su">legacy BMCs (optional)</text>
+    <rect class="card" x="30" y="406" width="250" height="52" rx="4"/>
+    <text x="46" y="429" class="t">HttpTransport + Auth</text><text x="46" y="447" class="ts">urllib · retry · redaction</text>
+    <rect class="card" x="305" y="406" width="250" height="52" rx="4"/>
+    <text x="321" y="429" class="t">WS transport</text><text x="321" y="447" class="ts">JSON-RPC devices</text>
+    <rect class="card" x="580" y="406" width="250" height="52" rx="4"/>
+    <text x="596" y="429" class="t">IPMI / ipmitool</text><text x="596" y="447" class="ts">legacy BMCs (optional)</text>
   </g>
 
-  <rect class="band" x="30" y="472" width="800" height="44" rx="8"/>
-  <text x="430" y="491" class="ti" text-anchor="middle" font-size="12px">Cross-cutting &amp; shared (one implementation, all drivers)</text>
-  <text x="430" y="507" class="su" text-anchor="middle">SafetyPolicy (gates destructive ops) · Config(driver=) · Errors · Vision backends — already pluggable</text>
+  <rect class="band" x="30" y="482" width="800" height="46" rx="8"/>
+  <text x="430" y="502" class="t" text-anchor="middle">Cross-cutting and shared — one implementation, all drivers</text>
+  <text x="430" y="519" class="ts" text-anchor="middle">SafetyPolicy (gates destructive ops) · Config(driver=) · Errors · Vision backends, already pluggable</text>
 </svg>

--- a/docs/boot-phases.svg
+++ b/docs/boot-phases.svg
@@ -1,0 +1,99 @@
+<svg viewBox="0 0 860 410" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ttl dsc">
+  <title id="ttl">Boot-phase detection and wait_for_state</title>
+  <desc id="dsc">A left-to-right timeline of boot phases the vision classifier recognizes — POST, bios_menu, grub_menu, installer_progress, installer_complete, login_prompt. Above the timeline, the unattended-install example wires actions to phases: mount_iso and hard_cycle to start, wait_for_state on grub_menu then press Enter, and wait_for_state on installer_complete. Below, any phase can transition to crash_screen, which you branch on. Each check is a snapshot followed by a classify call; wait_for_state polls until the phase matches or the timeout fires.</desc>
+  <style>
+    text{font-family:var(--font-sans,ui-sans-serif,system-ui,sans-serif);}
+    .band{fill:#f1efe8;stroke:#d3d1c7;stroke-width:1;}
+    .pill{fill:#fff;stroke:#b4b2a9;stroke-width:1.5;}
+    .purple{fill:#eeedfe;stroke:#534ab7;stroke-width:1.25;}
+    .red{fill:#fcebeb;stroke:#a32d2d;stroke-width:1.5;}
+    .h{fill:#2c2c2a;font-weight:500;font-size:18px;}
+    .sub{fill:#5f5e5a;font-weight:400;font-size:12px;}
+    .lab{fill:#888780;font-weight:500;font-size:11px;}
+    .ts{fill:#5f5e5a;font-weight:400;font-size:11.5px;}
+    .pillt{fill:#2c2c2a;font-family:var(--font-mono,ui-monospace,monospace);font-weight:500;font-size:11px;}
+    .mono{fill:#2c2c2a;font-family:var(--font-mono,ui-monospace,monospace);font-weight:400;font-size:11px;}
+    .actm{fill:#3c3489;font-family:var(--font-mono,ui-monospace,monospace);font-weight:400;font-size:11px;}
+    .crasht{fill:#791f1f;font-family:var(--font-mono,ui-monospace,monospace);font-weight:500;font-size:11.5px;}
+    .cn{stroke:#888780;}
+    .cr{stroke:#a32d2d;}
+    .mkn{fill:#888780;}
+    .mkr{fill:#a32d2d;}
+    @media (prefers-color-scheme:dark){
+      .band{fill:#211f1b;stroke:#4a4641;}
+      .pill{fill:#2a2723;stroke:#5f5e5a;}
+      .purple{fill:#3c3489;stroke:#afa9ec;}
+      .red{fill:#791f1f;stroke:#f09595;}
+      .h{fill:#f1efe8;} .sub{fill:#b4b2a9;} .lab{fill:#908d85;} .ts{fill:#b4b2a9;}
+      .pillt{fill:#f1efe8;} .mono{fill:#f1efe8;} .actm{fill:#cecbf6;} .crasht{fill:#f7c1c1;}
+      .cr{stroke:#f09595;} .mkr{fill:#f09595;}
+    }
+  </style>
+
+  <text x="30" y="34" class="h">kvm-pilot — boot-phase detection</text>
+  <text x="30" y="54" class="sub">ScreenAnalyzer maps each screenshot to a phase. wait_for_state() blocks until the phase you asked for appears.</text>
+
+  <defs>
+    <marker id="af" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path class="mkn" d="M0,0 L6,3 L0,6 Z"/></marker>
+    <marker id="ad" markerWidth="8" markerHeight="8" refX="5" refY="3" orient="auto"><path class="mkn" d="M0,0 L5,3 L0,6 Z"/></marker>
+    <marker id="adr" markerWidth="8" markerHeight="8" refX="5" refY="3" orient="auto"><path class="mkr" d="M0,0 L5,3 L0,6 Z"/></marker>
+  </defs>
+
+  <text x="40" y="90" class="lab">Your script wires actions to phases</text>
+
+  <!-- action callouts -->
+  <rect class="purple" x="40" y="100" width="150" height="46" rx="4"/>
+  <text x="52" y="120" class="actm">mount_iso(url)</text>
+  <text x="52" y="137" class="actm">hard_cycle()</text>
+
+  <rect class="purple" x="258" y="100" width="210" height="46" rx="4"/>
+  <text x="270" y="120" class="actm">wait_for_state('grub_menu')</text>
+  <text x="270" y="137" class="actm">press_key('Enter')</text>
+
+  <rect class="purple" x="522" y="100" width="210" height="46" rx="4"/>
+  <text x="534" y="120" class="actm">wait_for_state(</text>
+  <text x="534" y="137" class="actm">  'installer_complete', 1800)</text>
+
+  <!-- connectors callout -> pill -->
+  <line x1="99" y1="146" x2="99" y2="196" class="cn" stroke-width="1.2" stroke-dasharray="3,3" marker-end="url(#ad)"/>
+  <line x1="363" y1="146" x2="363" y2="196" class="cn" stroke-width="1.2" stroke-dasharray="3,3" marker-end="url(#ad)"/>
+  <line x1="627" y1="146" x2="627" y2="196" class="cn" stroke-width="1.2" stroke-dasharray="3,3" marker-end="url(#ad)"/>
+
+  <text x="40" y="190" class="ts">power on</text>
+
+  <!-- phase pills -->
+  <rect class="pill" x="40" y="200" width="118" height="46" rx="10"/>
+  <text x="99" y="228" class="pillt" text-anchor="middle">POST</text>
+  <rect class="pill" x="172" y="200" width="118" height="46" rx="10"/>
+  <text x="231" y="228" class="pillt" text-anchor="middle">bios_menu</text>
+  <rect class="pill" x="304" y="200" width="118" height="46" rx="10"/>
+  <text x="363" y="228" class="pillt" text-anchor="middle">grub_menu</text>
+  <rect class="pill" x="436" y="200" width="118" height="46" rx="10"/>
+  <text x="495" y="224" class="pillt" text-anchor="middle">installer_</text>
+  <text x="495" y="238" class="pillt" text-anchor="middle">progress</text>
+  <rect class="pill" x="568" y="200" width="118" height="46" rx="10"/>
+  <text x="627" y="224" class="pillt" text-anchor="middle">installer_</text>
+  <text x="627" y="238" class="pillt" text-anchor="middle">complete</text>
+  <rect class="pill" x="700" y="200" width="118" height="46" rx="10"/>
+  <text x="759" y="228" class="pillt" text-anchor="middle">login_prompt</text>
+
+  <!-- arrows between pills -->
+  <line x1="159" y1="223" x2="171" y2="223" class="cn" stroke-width="1.5" marker-end="url(#af)"/>
+  <line x1="291" y1="223" x2="303" y2="223" class="cn" stroke-width="1.5" marker-end="url(#af)"/>
+  <line x1="423" y1="223" x2="435" y2="223" class="cn" stroke-width="1.5" marker-end="url(#af)"/>
+  <line x1="555" y1="223" x2="567" y2="223" class="cn" stroke-width="1.5" marker-end="url(#af)"/>
+  <line x1="687" y1="223" x2="699" y2="223" class="cn" stroke-width="1.5" marker-end="url(#af)"/>
+
+  <!-- crash branch -->
+  <rect class="red" x="304" y="296" width="250" height="40" rx="10"/>
+  <text x="429" y="321" class="crasht" text-anchor="middle">crash_screen</text>
+  <text x="572" y="313" class="ts">any phase →</text>
+  <text x="572" y="329" class="ts">you branch to recovery</text>
+  <line x1="363" y1="246" x2="363" y2="294" class="cr" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#adr)"/>
+  <line x1="495" y1="246" x2="429" y2="294" class="cr" stroke-width="1.2" stroke-dasharray="4,3" marker-end="url(#adr)"/>
+
+  <!-- poll-loop note + legend -->
+  <rect class="band" x="30" y="356" width="800" height="44" rx="8"/>
+  <text x="430" y="375" class="ts" text-anchor="middle"><tspan class="mono">Every check = snapshot() → classify().</tspan>  wait_for_state polls until the phase matches, or raises at the timeout.</text>
+  <text x="430" y="392" class="lab" text-anchor="middle">grey = phase the classifier sees · purple = your script's calls · red = error branch</text>
+</svg>

--- a/docs/how-it-works.svg
+++ b/docs/how-it-works.svg
@@ -1,0 +1,98 @@
+<svg viewBox="0 0 860 400" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ttl dsc">
+  <title id="ttl">How kvm-pilot works — the vision control loop</title>
+  <desc id="dsc">A closed loop. A headless target machine outputs video to a KVM device. kvm-pilot pulls a screenshot from the KVM and sends the image to a vision backend — Claude in the cloud or a local VLM — which returns a boot phase. kvm-pilot then sends keyboard or power actions back through the KVM to the target. The perception path runs left to right; the action path runs right to left. No agent runs on the target.</desc>
+  <style>
+    text{font-family:var(--font-sans,ui-sans-serif,system-ui,sans-serif);}
+    .card{fill:#fff;stroke:#d3d1c7;stroke-width:1.5;}
+    .band{fill:#f1efe8;stroke:#d3d1c7;stroke-width:1;}
+    .purple{fill:#eeedfe;stroke:#534ab7;stroke-width:1.75;}
+    .green{fill:#eaf3de;stroke:#3b6d11;stroke-width:1;}
+    .h{fill:#2c2c2a;font-weight:500;font-size:18px;}
+    .sub{fill:#5f5e5a;font-weight:400;font-size:12px;}
+    .t{fill:#2c2c2a;font-weight:500;font-size:13px;}
+    .ts{fill:#5f5e5a;font-weight:400;font-size:11.5px;}
+    .lab{fill:#888780;font-weight:500;font-size:11px;}
+    .tp{fill:#3c3489;font-weight:500;font-size:13px;}
+    .tps{fill:#534ab7;font-weight:400;font-size:11.5px;}
+    .mps{font-family:var(--font-mono,ui-monospace,monospace);fill:#534ab7;font-weight:400;font-size:11.5px;}
+    .actp{fill:#534ab7;font-weight:500;font-size:11px;}
+    .tg{fill:#27500a;font-weight:500;font-size:11px;}
+    .dotp{fill:#534ab7;}
+    .dotg{fill:#3b6d11;}
+    .cn{stroke:#888780;}
+    .cp{stroke:#534ab7;}
+    .mkn{fill:#888780;}
+    .mkp{fill:#534ab7;}
+    @media (prefers-color-scheme:dark){
+      .card{fill:#2a2723;stroke:#4a4641;}
+      .band{fill:#211f1b;stroke:#4a4641;}
+      .purple{fill:#3c3489;stroke:#afa9ec;}
+      .green{fill:#27500a;stroke:#97c459;}
+      .h{fill:#f1efe8;} .sub{fill:#b4b2a9;} .t{fill:#f1efe8;} .ts{fill:#b4b2a9;} .lab{fill:#908d85;}
+      .tp{fill:#cecbf6;} .tps{fill:#afa9ec;} .mps{fill:#afa9ec;} .actp{fill:#afa9ec;} .tg{fill:#c0dd97;}
+      .dotp{fill:#afa9ec;} .dotg{fill:#97c459;} .cp{stroke:#afa9ec;} .mkp{fill:#afa9ec;}
+    }
+  </style>
+
+  <text x="30" y="34" class="h">kvm-pilot — how it works</text>
+  <text x="30" y="54" class="sub">See the screen with a vision model, decide, then act through the KVM — nothing runs on the target.</text>
+
+  <defs>
+    <marker id="ms" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path class="mkn" d="M0,0 L6,3 L0,6 Z"/></marker>
+    <marker id="ma" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path class="mkp" d="M0,0 L6,3 L0,6 Z"/></marker>
+  </defs>
+
+  <text x="30" y="100" class="lab">1 · see →</text>
+  <text x="30" y="266" class="lab">2 · act ←</text>
+
+  <!-- target -->
+  <rect class="card" x="30" y="124" width="175" height="108" rx="4"/>
+  <text x="46" y="152" class="t">Headless target</text>
+  <text x="46" y="176" class="ts">POST · BIOS · GRUB · OS</text>
+  <rect class="green" x="46" y="192" width="120" height="22" rx="4"/>
+  <text x="106" y="207" class="tg" text-anchor="middle">no agent · no SSH</text>
+
+  <!-- KVM -->
+  <rect class="card" x="225" y="124" width="175" height="108" rx="4"/>
+  <text x="241" y="152" class="t">KVM device</text>
+  <text x="241" y="176" class="ts">PiKVM · GL-RM1PE</text>
+  <text x="241" y="200" class="ts">HDMI · USB-HID · ATX</text>
+
+  <!-- pilot -->
+  <rect class="purple" x="420" y="124" width="180" height="108" rx="4"/>
+  <text x="436" y="152" class="tp">kvm-pilot</text>
+  <text x="436" y="176" class="tps">REST client + safety</text>
+  <text x="436" y="200" class="mps">see → decide → act</text>
+
+  <!-- vision -->
+  <rect class="purple" x="620" y="124" width="210" height="108" rx="4"/>
+  <text x="636" y="150" class="tp">Vision backend</text>
+  <circle class="dotp" cx="641" cy="170" r="3.5"/>
+  <text x="652" y="174" class="tps">Claude — cloud</text>
+  <circle class="dotg" cx="641" cy="190" r="3.5"/>
+  <text x="652" y="194" class="tps">Local VLM</text>
+  <text x="636" y="216" class="tps">LM Studio · Ollama · vLLM</text>
+
+  <!-- SEE arrows -->
+  <text x="215" y="116" class="ts" text-anchor="middle">video</text>
+  <line x1="207" y1="160" x2="223" y2="160" class="cn" stroke-width="1.5" marker-end="url(#ms)"/>
+  <text x="410" y="116" class="ts" text-anchor="middle">snapshot</text>
+  <line x1="402" y1="160" x2="418" y2="160" class="cn" stroke-width="1.5" marker-end="url(#ms)"/>
+  <text x="610" y="116" class="ts" text-anchor="middle">image</text>
+  <line x1="602" y1="160" x2="618" y2="160" class="cn" stroke-width="1.5" marker-end="url(#ms)"/>
+
+  <!-- ACT arrows -->
+  <line x1="618" y1="200" x2="602" y2="200" class="cp" stroke-width="1.5" marker-end="url(#ma)"/>
+  <text x="610" y="252" class="actp" text-anchor="middle">phase</text>
+  <line x1="418" y1="200" x2="402" y2="200" class="cp" stroke-width="1.5" marker-end="url(#ma)"/>
+  <text x="410" y="252" class="actp" text-anchor="middle">press_key / power</text>
+  <line x1="223" y1="200" x2="207" y2="200" class="cp" stroke-width="1.5" marker-end="url(#ma)"/>
+  <text x="215" y="252" class="actp" text-anchor="middle">USB-HID · ATX</text>
+
+  <!-- summary band -->
+  <rect class="band" x="30" y="288" width="800" height="96" rx="8"/>
+  <text x="430" y="312" class="t" text-anchor="middle">wait_for_state(phase) blocks until the screen matches — no agent on the target.</text>
+  <text x="430" y="333" class="ts" text-anchor="middle">Pixel-level classification drives POST, firmware, the bootloader and OS install alike.</text>
+  <text x="430" y="352" class="ts" text-anchor="middle">Choose the local backend and screenshots never leave your network.</text>
+  <text x="430" y="373" class="lab" text-anchor="middle">Purple = kvm-pilot and the vision loop · grey = the hardware it drives.</text>
+</svg>

--- a/docs/mcp-tools.svg
+++ b/docs/mcp-tools.svg
@@ -1,0 +1,73 @@
+<svg viewBox="0 0 860 320" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ttl dsc">
+  <title id="ttl">kvm-pilot MCP server tool surface</title>
+  <desc id="dsc">An MCP client such as Claude Desktop connects over stdio to the kvm-pilot MCP server, which exposes two groups of tools. Four read-only tools — info, power_state, snapshot, and classify_screen — are built with a deny-all confirm callback. One destructive tool, power, covers on, off, off-hard, and reset, and refuses unless the agent passes confirm equals true, after which it runs through the same safety gate. A model can never power-cycle a machine implicitly.</desc>
+  <style>
+    text{font-family:var(--font-sans,ui-sans-serif,system-ui,sans-serif);}
+    .card{fill:#fff;stroke:#d3d1c7;stroke-width:1.5;}
+    .band{fill:#f1efe8;stroke:#d3d1c7;stroke-width:1;}
+    .green{fill:#eaf3de;stroke:#3b6d11;stroke-width:1.25;}
+    .amber{fill:#faeeda;stroke:#854f0b;stroke-width:1.25;}
+    .h{fill:#2c2c2a;font-weight:500;font-size:18px;}
+    .sub{fill:#5f5e5a;font-weight:400;font-size:12px;}
+    .t{fill:#2c2c2a;font-weight:500;font-size:13px;}
+    .ts{fill:#5f5e5a;font-weight:400;font-size:11px;}
+    .lab{fill:#888780;font-weight:500;font-size:11px;}
+    .tg{fill:#27500a;font-family:var(--font-mono,ui-monospace,monospace);font-weight:500;font-size:11.5px;}
+    .ta{fill:#633806;font-family:var(--font-mono,ui-monospace,monospace);font-weight:500;font-size:11.5px;}
+    .dotg{fill:#3b6d11;}
+    .dota{fill:#854f0b;}
+    .cn{stroke:#888780;}
+    .mkn{fill:#888780;}
+    @media (prefers-color-scheme:dark){
+      .card{fill:#2a2723;stroke:#4a4641;}
+      .band{fill:#211f1b;stroke:#4a4641;}
+      .green{fill:#27500a;stroke:#97c459;}
+      .amber{fill:#633806;stroke:#ef9f27;}
+      .h{fill:#f1efe8;} .sub{fill:#b4b2a9;} .t{fill:#f1efe8;} .ts{fill:#b4b2a9;} .lab{fill:#908d85;}
+      .tg{fill:#c0dd97;} .ta{fill:#fac775;} .dotg{fill:#97c459;} .dota{fill:#ef9f27;}
+    }
+  </style>
+
+  <text x="30" y="30" class="h">kvm-pilot — MCP server tools</text>
+  <text x="30" y="50" class="sub">A model can never power-cycle a machine implicitly — read-only tools deny all; power needs confirm=true.</text>
+
+  <defs>
+    <marker id="a" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path class="mkn" d="M0,0 L6,3 L0,6 Z"/></marker>
+  </defs>
+
+  <!-- client -->
+  <rect class="card" x="30" y="104" width="150" height="72" rx="4"/>
+  <text x="46" y="130" class="t">MCP client</text>
+  <text x="46" y="150" class="ts">Claude Desktop</text>
+  <text x="46" y="166" class="ts">or other agents</text>
+  <line x1="180" y1="140" x2="216" y2="140" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+  <text x="198" y="132" class="lab" text-anchor="middle">stdio</text>
+
+  <!-- read-only group -->
+  <rect class="card" x="224" y="92" width="384" height="120" rx="4"/>
+  <circle class="dotg" cx="240" cy="111" r="4"/>
+  <text x="252" y="115" class="lab">Read-only — built with a deny-all confirm</text>
+  <rect class="green" x="240" y="128" width="164" height="30" rx="4"/>
+  <text x="322" y="147" class="tg" text-anchor="middle">info</text>
+  <rect class="green" x="240" y="166" width="164" height="30" rx="4"/>
+  <text x="322" y="185" class="tg" text-anchor="middle">power_state</text>
+  <rect class="green" x="416" y="128" width="176" height="30" rx="4"/>
+  <text x="504" y="147" class="tg" text-anchor="middle">snapshot</text>
+  <rect class="green" x="416" y="166" width="176" height="30" rx="4"/>
+  <text x="504" y="185" class="tg" text-anchor="middle">classify_screen</text>
+
+  <!-- gated group -->
+  <rect class="card" x="624" y="92" width="206" height="120" rx="4"/>
+  <circle class="dota" cx="640" cy="111" r="4"/>
+  <text x="652" y="115" class="lab">Gated — destructive</text>
+  <rect class="amber" x="640" y="128" width="174" height="30" rx="4"/>
+  <text x="727" y="147" class="ta" text-anchor="middle">power</text>
+  <text x="640" y="176" class="ts">on · off · off-hard · reset</text>
+  <text x="640" y="194" class="ts">refuses unless confirm=true</text>
+
+  <!-- footer -->
+  <rect class="band" x="30" y="232" width="800" height="72" rx="8"/>
+  <text x="430" y="258" class="t" text-anchor="middle">Read-only tools build the client with a deny-all confirm callback.</text>
+  <text x="430" y="278" class="ts" text-anchor="middle">power refuses unless an agent passes confirm=true — then it runs through the same safety gate as the library.</text>
+  <text x="430" y="296" class="lab" text-anchor="middle">green = read-only · amber = gated (destructive)</text>
+</svg>

--- a/docs/safety.svg
+++ b/docs/safety.svg
@@ -1,0 +1,105 @@
+<svg viewBox="0 0 860 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="ttl dsc">
+  <title id="ttl">Safety gate for destructive operations</title>
+  <desc id="dsc">A decision flow. A caller — CLI, script, or MCP server — issues an operation. If the op is not in DESTRUCTIVE_OPS it executes directly. If it is destructive, dry-run short-circuits to log-only; otherwise a confirm callback can veto it; only an allowed call is sent to the device. A side panel lists the explicit DESTRUCTIVE_OPS set and the default confirm behavior per consumer. A vision classification never enters this path on its own.</desc>
+  <style>
+    text{font-family:var(--font-sans,ui-sans-serif,system-ui,sans-serif);}
+    .band{fill:#f1efe8;stroke:#d3d1c7;stroke-width:1;}
+    .card{fill:#fff;stroke:#b4b2a9;stroke-width:1.5;}
+    .dia{fill:#f1efe8;stroke:#b4b2a9;stroke-width:1.5;}
+    .skip{fill:#fff;stroke:#b4b2a9;stroke-width:1.5;stroke-dasharray:5,3;}
+    .green{fill:#eaf3de;stroke:#3b6d11;stroke-width:1.5;}
+    .greenb{fill:#eaf3de;stroke:#3b6d11;stroke-width:1.75;}
+    .red{fill:#fcebeb;stroke:#a32d2d;stroke-width:1.5;}
+    .h{fill:#2c2c2a;font-weight:500;font-size:18px;}
+    .sub{fill:#5f5e5a;font-weight:400;font-size:12px;}
+    .t{fill:#2c2c2a;font-weight:500;font-size:12.5px;}
+    .ts{fill:#5f5e5a;font-weight:400;font-size:11px;}
+    .diat{fill:#2c2c2a;font-family:var(--font-mono,ui-monospace,monospace);font-weight:500;font-size:11px;}
+    .mono{fill:#5f5e5a;font-family:var(--font-mono,ui-monospace,monospace);font-weight:400;font-size:11px;}
+    .edge{fill:#5f5e5a;font-weight:500;font-size:11px;}
+    .lab{fill:#888780;font-weight:500;font-size:11px;}
+    .okt{fill:#27500a;font-weight:500;font-size:12px;}
+    .vetot{fill:#791f1f;font-weight:500;font-size:12px;}
+    .cn{stroke:#888780;}
+    .mkn{fill:#888780;}
+    .div{stroke:#d3d1c7;}
+    @media (prefers-color-scheme:dark){
+      .band{fill:#211f1b;stroke:#4a4641;}
+      .card{fill:#2a2723;stroke:#5f5e5a;}
+      .dia{fill:#2a2723;stroke:#5f5e5a;}
+      .skip{fill:#2a2723;stroke:#5f5e5a;}
+      .green,.greenb{fill:#27500a;stroke:#97c459;}
+      .red{fill:#791f1f;stroke:#f09595;}
+      .h{fill:#f1efe8;} .sub{fill:#b4b2a9;} .t{fill:#f1efe8;} .ts{fill:#b4b2a9;} .lab{fill:#908d85;}
+      .diat{fill:#f1efe8;} .mono{fill:#b4b2a9;} .edge{fill:#b4b2a9;}
+      .okt{fill:#c0dd97;} .vetot{fill:#f7c1c1;} .div{stroke:#4a4641;}
+    }
+  </style>
+
+  <text x="30" y="34" class="h">kvm-pilot — safety gate</text>
+  <text x="30" y="54" class="sub">Power, reset, virtual-media, GPIO and Redfish resets are gated. A vision result never enters this path on its own.</text>
+
+  <defs>
+    <marker id="a" markerWidth="9" markerHeight="9" refX="6" refY="3" orient="auto"><path class="mkn" d="M0,0 L6,3 L0,6 Z"/></marker>
+  </defs>
+
+  <!-- caller -->
+  <rect class="card" x="60" y="74" width="200" height="46" rx="4"/>
+  <text x="160" y="94" class="t" text-anchor="middle">Caller</text>
+  <text x="160" y="111" class="ts" text-anchor="middle">CLI · script · MCP server</text>
+  <line x1="160" y1="120" x2="160" y2="124" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+
+  <!-- D1 -->
+  <polygon class="dia" points="160,124 256,158 160,192 64,158"/>
+  <text x="160" y="154" class="diat" text-anchor="middle">op in</text>
+  <text x="160" y="168" class="diat" text-anchor="middle">DESTRUCTIVE_OPS?</text>
+  <line x1="256" y1="158" x2="330" y2="158" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+  <text x="293" y="150" class="edge" text-anchor="middle">no</text>
+  <rect class="green" x="330" y="136" width="210" height="44" rx="4"/>
+  <text x="435" y="156" class="okt" text-anchor="middle">execute — not gated</text>
+  <text x="435" y="171" class="ts" text-anchor="middle">info · snapshot · classify · key</text>
+  <line x1="160" y1="192" x2="160" y2="222" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+  <text x="171" y="211" class="edge">yes</text>
+
+  <!-- D2 -->
+  <polygon class="dia" points="160,222 256,256 160,290 64,256"/>
+  <text x="160" y="260" class="diat" text-anchor="middle">dry_run?</text>
+  <line x1="256" y1="256" x2="330" y2="256" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+  <text x="293" y="248" class="edge" text-anchor="middle">yes</text>
+  <rect class="skip" x="330" y="234" width="210" height="44" rx="4"/>
+  <text x="435" y="254" class="t" text-anchor="middle">log intended call, skip</text>
+  <text x="435" y="269" class="ts" text-anchor="middle">nothing sent to the device</text>
+  <line x1="160" y1="290" x2="160" y2="320" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+  <text x="171" y="309" class="edge">no</text>
+
+  <!-- D3 -->
+  <polygon class="dia" points="160,320 256,354 160,388 64,354"/>
+  <text x="160" y="350" class="diat" text-anchor="middle">confirm(op)</text>
+  <text x="160" y="364" class="diat" text-anchor="middle">allows?</text>
+  <line x1="256" y1="354" x2="330" y2="354" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+  <text x="293" y="346" class="edge" text-anchor="middle">no</text>
+  <rect class="red" x="330" y="332" width="210" height="44" rx="4"/>
+  <text x="435" y="352" class="vetot" text-anchor="middle">vetoed — not sent</text>
+  <text x="435" y="367" class="ts" text-anchor="middle">callback returned False</text>
+  <line x1="160" y1="388" x2="160" y2="410" class="cn" stroke-width="1.5" marker-end="url(#a)"/>
+  <text x="171" y="404" class="edge">yes</text>
+  <rect class="greenb" x="60" y="410" width="200" height="42" rx="4"/>
+  <text x="160" y="435" class="okt" text-anchor="middle">execute on device</text>
+
+  <!-- side panel -->
+  <rect class="band" x="582" y="120" width="248" height="300" rx="8"/>
+  <text x="600" y="144" class="lab">DESTRUCTIVE_OPS · safety.py</text>
+  <text x="600" y="167" class="mono">power.on · power.off</text>
+  <text x="600" y="186" class="mono">power.off_hard · power.reset</text>
+  <text x="600" y="205" class="mono">media.connect · media.disconnect</text>
+  <text x="600" y="224" class="mono">gpio.switch · redfish.reset</text>
+  <line x1="600" y1="242" x2="812" y2="242" class="div" stroke-width="1"/>
+  <text x="600" y="265" class="lab">Default confirm behavior</text>
+  <text x="600" y="288" class="ts">dry_run=True → always log-only</text>
+  <text x="600" y="310" class="ts">library default → allow (scripts run)</text>
+  <text x="600" y="332" class="ts">CLI → interactive y/N unless --yes</text>
+  <text x="600" y="354" class="ts">MCP power tool → needs confirm=true</text>
+  <line x1="600" y1="372" x2="812" y2="372" class="div" stroke-width="1"/>
+  <text x="600" y="394" class="lab">green = runs · red = blocked</text>
+  <text x="600" y="410" class="ts">The set is explicit and auditable.</text>
+</svg>

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -19,6 +19,8 @@ SDK.
 | `classify_screen` | read-only | boot/run phase via the vision backend (needs `ANTHROPIC_API_KEY`) |
 | `power` | **destructive** | `on`/`off`/`off-hard`/`reset`; **refuses unless `confirm=true`** |
 
+![The kvm-pilot MCP server exposes four read-only tools — info, power_state, snapshot, classify_screen — built with a deny-all confirm callback, plus one gated power tool that refuses unless the agent passes confirm=true and then runs through the same safety gate.](../docs/mcp-tools.svg)
+
 The read-only tools build the client with a deny-all confirm callback; the
 `power` tool refuses unless an agent explicitly passes `confirm=true`. A model
 can never power-cycle a machine implicitly.


### PR DESCRIPTION
## What

Adds five SVG diagrams in the Claude design language and wires them into the docs. The README previously had no visuals, and the MCP tool surface plus the boot-phase / safety concepts were text-only.

## Diagrams

| Diagram | Location | Shows |
|---|---|---|
| `docs/how-it-works.svg` | README → How it works | the vision control loop — screenshot → classify → act, no agent on target |
| `docs/boot-phases.svg` | README → Boot-phase detection | `wait_for_state` timeline via the unattended-install example |
| `docs/safety.svg` | README → Safety model | how a destructive call flows through the gate |
| `docs/mcp-tools.svg` | mcp_server/README → Tools | read-only vs. gated `power` tool surface |
| `docs/architecture.svg` | docs/architecture.md | restyled to match; header unified with the set |

## Design

- Warm Claude palette, sentence case throughout, two font weights (400/500), no text under 11px, and ≤2–3 colors per diagram, each with a one-line legend.
- Light **and** dark via `@media (prefers-color-scheme: dark)` inside each file (GitHub honors in-SVG media queries, not external CSS variables), using the ramp's dark stops — 800 fill / 200 stroke / 100 text.
- Surfaces and text are class-based so a single media block flips the whole palette.

## Verification

- All five validate as XML.
- Rendered both light and dark (force-toggled) for every diagram — contrast holds, nothing drops out.
- Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
