### PR TITLE
feat(vision): gate the model call behind cheap signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   reports the `Logs` capability (`/api/log`); the rest are the seam for the
   Redfish and IPMI drivers, where boot phase is a structured enum and the
   console is a serial text stream.
+- `KVMClient.has_video_signal()` — a cheap "is there a screen?" probe over
+  `/api/streamer`, parsed defensively (only `False` on a positive offline
+  report).
+- `ScreenAnalyzer` gates: `gate_on_power_signal`, `skip_unchanged_frames` (both
+  default on) and opt-in `ocr_rules` (with `DEFAULT_OCR_RULES`), plus
+  `vlm_calls` / `cheap_resolves` counters.
+
+### Changed
+- `ScreenAnalyzer.classify()` now resolves from cheap signals before calling the
+  vision backend: a `power_off` / `no_signal` short-circuit (no snapshot, no
+  model), an unchanged-frame skip (reuse the last result), and optional
+  OCR-assist for text screens. In a typical boot-watch this avoids most model
+  calls; set the flags to `False` to restore unconditional classification.
 
 ## [0.1.0a1] — 2026-06-26
 

--- a/src/kvm_pilot/client.py
+++ b/src/kvm_pilot/client.py
@@ -145,6 +145,25 @@ class KVMClient(CapabilityMixin):
     def get_streamer_state(self) -> dict:
         return self._http.get("/api/streamer")
 
+    def has_video_signal(self) -> bool:
+        """True if the capture pipeline reports a live video source.
+
+        Parses ``/api/streamer`` defensively: it returns ``False`` only when the
+        device *positively* reports the source offline, so a missing or unknown
+        field never suppresses a real frame. Lets the vision layer skip a model
+        call when there is simply nothing on screen (powered off, between mode
+        sets, sleeping).
+        """
+        try:
+            state = self.get_streamer_state()
+        except Exception:  # noqa: BLE001 - a liveness probe must never raise
+            return True
+        source = state.get("source") or {}
+        if not source and isinstance(state.get("streamer"), dict):
+            source = state["streamer"].get("source") or {}
+        online = source.get("online") if isinstance(source, dict) else None
+        return True if online is None else bool(online)
+
     # -- HID: keyboard ---------------------------------------------------
 
     def get_hid_state(self) -> dict:

--- a/src/kvm_pilot/vision/__init__.py
+++ b/src/kvm_pilot/vision/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .analyzer import ScreenAnalyzer
+from .analyzer import DEFAULT_OCR_RULES, ScreenAnalyzer
 from .anthropic import AnthropicBackend
 from .base import (
     ALL_PHASES,
@@ -41,6 +41,7 @@ def make_backend(
 
 __all__ = [
     "ScreenAnalyzer",
+    "DEFAULT_OCR_RULES",
     "VisionBackend",
     "AnthropicBackend",
     "OpenAICompatBackend",

--- a/src/kvm_pilot/vision/analyzer.py
+++ b/src/kvm_pilot/vision/analyzer.py
@@ -4,6 +4,21 @@ ScreenAnalyzer — snapshot + classify loop over any VisionBackend.
 Takes a KVMClient (for snapshots) and a VisionBackend (for classification) and
 provides single-shot classify plus blocking wait-for-state loops with bounded
 backoff. Backend-agnostic: Claude or a local VLM, identical call sites.
+
+A model call is the most expensive way to read the screen, so ``classify`` is
+*gated* by cheap signals first (see ``docs/sensing-hierarchy.svg``):
+
+  1. power / no-signal short-circuit — if the device reports the host powered
+     off or no video source, return ``power_off`` / ``no_signal`` with no model
+     call (and no snapshot);
+  2. optional OCR-assist — if ``ocr_rules`` are set and the device has on-board
+     OCR, resolve text screens (GRUB, a kernel panic) without a model;
+  3. unchanged-frame skip — if the captured frame is identical to the last
+     classified one, reuse that result instead of re-classifying.
+
+Only when none of these resolve does the vision backend run. The gates are
+duck-typed and defensive: a backend or device that lacks a probe simply skips
+it, so this never breaks a driver that only does snapshots.
 """
 
 from __future__ import annotations
@@ -13,9 +28,25 @@ import time
 from collections.abc import Callable
 
 from ..errors import TimeoutError, VisionError
-from .base import ScreenState, VisionBackend
+from .base import (
+    PHASE_CRASH_SCREEN,
+    PHASE_GRUB_MENU,
+    PHASE_NO_SIGNAL,
+    PHASE_POWER_OFF,
+    PHASE_UEFI_SHELL,
+    ScreenState,
+    VisionBackend,
+)
 
 logger = logging.getLogger("kvm_pilot.vision")
+
+# Opt-in OCR rules: (case-insensitive substring, phase). Kept deliberately
+# high-precision so a match is unambiguous; pass your own list to extend.
+DEFAULT_OCR_RULES: list[tuple[str, str]] = [
+    ("gnu grub", PHASE_GRUB_MENU),
+    ("kernel panic", PHASE_CRASH_SCREEN),
+    ("uefi interactive shell", PHASE_UEFI_SHELL),
+]
 
 
 class ScreenAnalyzer:
@@ -27,13 +58,22 @@ class ScreenAnalyzer:
         default_poll_interval: float = 3.0,
         min_confidence: float = 0.70,
         on_state_change: Callable | None = None,
+        gate_on_power_signal: bool = True,
+        skip_unchanged_frames: bool = True,
+        ocr_rules: list[tuple[str, str]] | None = None,
     ):
         self._kvm = kvm
         self._backend = backend
         self._poll_interval = default_poll_interval
         self._min_confidence = min_confidence
         self._on_state_change = on_state_change
+        self._gate_on_power_signal = gate_on_power_signal
+        self._skip_unchanged_frames = skip_unchanged_frames
+        self._ocr_rules = ocr_rules
         self._last_state: ScreenState | None = None
+        # Observability: how often the cheap gates avoided a model call.
+        self.vlm_calls = 0
+        self.cheap_resolves = 0
 
     @property
     def backend(self) -> VisionBackend:
@@ -48,14 +88,48 @@ class ScreenAnalyzer:
     # -- single shot -----------------------------------------------------
 
     def classify(self, hint: str = "", image_b64: str | None = None) -> ScreenState:
+        # The cheap gates apply only to the auto-snapshot path; when the caller
+        # hands us a specific image they want that image classified verbatim.
+        gates_on = image_b64 is None
+
+        if gates_on and self._gate_on_power_signal:
+            cheap = self._probe_power_signal()
+            if cheap is not None:
+                self.cheap_resolves += 1
+                return self._finalize(cheap)
+
+        if gates_on and self._ocr_rules:
+            ocr_state = self._probe_ocr()
+            if ocr_state is not None:
+                self.cheap_resolves += 1
+                return self._finalize(ocr_state)
+
         if image_b64 is None:
             try:
                 image_b64 = self._kvm.snapshot_base64()
             except Exception as exc:  # noqa: BLE001
                 raise VisionError(f"KVM snapshot failed: {exc}") from exc
 
-        state = self._backend.classify(image_b64, hint=hint)
+        # Identical frame ⇒ identical phase: reuse the last result, no model call.
+        if (
+            gates_on
+            and self._skip_unchanged_frames
+            and self._last_state is not None
+            and self._last_state.image_b64
+            and image_b64 == self._last_state.image_b64
+        ):
+            self.cheap_resolves += 1
+            return self._last_state
 
+        state = self._backend.classify(image_b64, hint=hint)
+        self.vlm_calls += 1
+        return self._finalize(state)
+
+    detect_state = classify  # ergonomic alias
+
+    # -- gates -----------------------------------------------------------
+
+    def _finalize(self, state: ScreenState) -> ScreenState:
         if self._on_state_change and (
             self._last_state is None or self._last_state.phase != state.phase
         ):
@@ -66,7 +140,32 @@ class ScreenAnalyzer:
         self._last_state = state
         return state
 
-    detect_state = classify  # ergonomic alias
+    def _probe_power_signal(self) -> ScreenState | None:
+        """Resolve power_off / no_signal from cheap device state, or None."""
+        kvm = self._kvm
+        try:
+            if hasattr(kvm, "is_powered_on") and not kvm.is_powered_on():
+                return ScreenState(PHASE_POWER_OFF, "ATX power LED reports off.", 0.99, "")
+            if hasattr(kvm, "has_video_signal") and not kvm.has_video_signal():
+                return ScreenState(PHASE_NO_SIGNAL, "Capture reports no video source.", 0.99, "")
+        except Exception:  # noqa: BLE001 - a probe must never break classification
+            return None
+        return None
+
+    def _probe_ocr(self) -> ScreenState | None:
+        """Resolve a phase from on-device OCR text via ocr_rules, or None."""
+        kvm = self._kvm
+        if not self._ocr_rules or not hasattr(kvm, "snapshot_ocr"):
+            return None
+        try:
+            text = kvm.snapshot_ocr()
+        except Exception:  # noqa: BLE001 - OCR is best-effort; fall through to the model
+            return None
+        low = (text or "").lower()
+        for needle, phase in self._ocr_rules:
+            if needle in low:
+                return ScreenState(phase, f"OCR matched {needle!r}.", 0.95, text)
+        return None
 
     # -- wait loops ------------------------------------------------------
 
@@ -125,4 +224,4 @@ class ScreenAnalyzer:
         return self._last_state
 
 
-__all__ = ["ScreenAnalyzer"]
+__all__ = ["ScreenAnalyzer", "DEFAULT_OCR_RULES"]

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3,7 +3,7 @@
 import pytest
 
 from kvm_pilot.errors import TimeoutError
-from kvm_pilot.vision import ScreenAnalyzer
+from kvm_pilot.vision import DEFAULT_OCR_RULES, ScreenAnalyzer
 from kvm_pilot.vision.base import ScreenState, VisionBackend
 
 
@@ -28,8 +28,22 @@ class FakeBackend(VisionBackend):
 
 
 class FakeKVM:
+    """A live capture: every snapshot differs, so the unchanged-frame gate never
+    fires and the backend is consulted on every poll."""
+
+    def __init__(self):
+        self._n = 0
+
     def snapshot_base64(self, quality: int = 85) -> str:
-        return "ZmFrZQ=="  # "fake"
+        self._n += 1
+        return f"frame-{self._n}"
+
+
+class StaticKVM:
+    """A genuinely static screen: the same frame every time."""
+
+    def snapshot_base64(self, quality: int = 85) -> str:
+        return "ZmFrZQ=="
 
 
 def test_classify_returns_phase():
@@ -75,3 +89,102 @@ def test_on_state_change_fires_once_per_change():
     )
     analyzer.wait_for_any_state(["desktop"], timeout=5.0)
     assert changes == ["booting", "desktop"]  # not three entries
+
+
+# -- cheap gates (avoid a model call) --------------------------------------
+
+
+def test_unchanged_frame_reuses_classification_without_model_call():
+    backend = FakeBackend(["booting", "grub_menu"])  # would advance if re-called
+    analyzer = ScreenAnalyzer(StaticKVM(), backend, default_poll_interval=0.0)
+    first = analyzer.classify()
+    second = analyzer.classify()
+    assert first.phase == "booting"
+    assert second.phase == "booting"  # reused, not re-classified
+    assert backend.calls == 1
+    assert analyzer.cheap_resolves == 1
+
+
+def test_skip_unchanged_frames_can_be_disabled():
+    backend = FakeBackend(["booting", "grub_menu"])
+    analyzer = ScreenAnalyzer(
+        StaticKVM(), backend, default_poll_interval=0.0, skip_unchanged_frames=False
+    )
+    analyzer.classify()
+    analyzer.classify()
+    assert backend.calls == 2  # no reuse
+
+
+class PoweredOffKVM:
+    def snapshot_base64(self, quality: int = 85) -> str:
+        raise AssertionError("must not snapshot when powered off")
+
+    def is_powered_on(self) -> bool:
+        return False
+
+
+def test_power_off_short_circuits_without_snapshot_or_model():
+    backend = FakeBackend(["desktop"])
+    analyzer = ScreenAnalyzer(PoweredOffKVM(), backend)
+    state = analyzer.classify()
+    assert state.phase == "power_off"
+    assert backend.calls == 0
+    assert analyzer.vlm_calls == 0
+    assert analyzer.cheap_resolves == 1
+
+
+class NoSignalKVM:
+    def snapshot_base64(self, quality: int = 85) -> str:
+        raise AssertionError("must not snapshot when there is no video signal")
+
+    def is_powered_on(self) -> bool:
+        return True
+
+    def has_video_signal(self) -> bool:
+        return False
+
+
+def test_no_signal_short_circuits_without_model():
+    backend = FakeBackend(["desktop"])
+    analyzer = ScreenAnalyzer(NoSignalKVM(), backend)
+    assert analyzer.classify().phase == "no_signal"
+    assert backend.calls == 0
+
+
+class OCRKVM:
+    def __init__(self, text):
+        self._text = text
+        self._n = 0
+
+    def snapshot_base64(self, quality: int = 85) -> str:
+        self._n += 1
+        return f"frame-{self._n}"
+
+    def snapshot_ocr(self, *args, **kwargs) -> str:
+        return self._text
+
+
+def test_ocr_assist_resolves_text_screen_without_model():
+    backend = FakeBackend(["desktop"])
+    analyzer = ScreenAnalyzer(
+        OCRKVM("GNU GRUB version 2.06"), backend, ocr_rules=DEFAULT_OCR_RULES
+    )
+    assert analyzer.classify().phase == "grub_menu"
+    assert backend.calls == 0
+
+
+def test_ocr_assist_falls_through_to_model_on_no_match():
+    backend = FakeBackend(["desktop"])
+    analyzer = ScreenAnalyzer(
+        OCRKVM("some unrelated terminal text"), backend, ocr_rules=DEFAULT_OCR_RULES
+    )
+    assert analyzer.classify().phase == "desktop"  # OCR didn't match → model ran
+    assert backend.calls == 1
+
+
+def test_gates_default_on_but_inert_without_device_probes():
+    # FakeKVM exposes only snapshot_base64; the power/signal probe must no-op.
+    backend = FakeBackend(["bios_menu"])
+    analyzer = ScreenAnalyzer(FakeKVM(), backend)
+    assert analyzer.classify().phase == "bios_menu"
+    assert analyzer.vlm_calls == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -63,6 +63,22 @@ def test_msd_set_params_gated_by_confirm(fake_http):
     assert fake_http.calls == []  # boot-media selection must not fire when denied
 
 
+def test_has_video_signal_reads_online_flag(client, fake_http):
+    fake_http.results["/api/streamer"] = {"source": {"online": True}}
+    assert client.has_video_signal() is True
+    fake_http.results["/api/streamer"] = {"source": {"online": False}}
+    assert client.has_video_signal() is False
+
+
+def test_has_video_signal_handles_nested_and_unknown_shapes(client, fake_http):
+    # Nested under "streamer" still resolves.
+    fake_http.results["/api/streamer"] = {"streamer": {"source": {"online": False}}}
+    assert client.has_video_signal() is False
+    # Unknown shape must default to True so a real frame is never suppressed.
+    fake_http.results["/api/streamer"] = {}
+    assert client.has_video_signal() is True
+
+
 def test_pikvmclient_alias():
     from kvm_pilot import PiKVMClient
 


### PR DESCRIPTION
The **first efficiency win** from the sensing-hierarchy thread: stop spending a vision-model call to learn things the device reports for free.

> Stacked on #10 — review/merge that first; this PR's base is `feat/sensing-foundation` and will retarget to `main` automatically once #10 lands.

## What

`ScreenAnalyzer.classify()` now resolves from cheap signals **before** the vision backend:

1. **power / no-signal short-circuit** — if the device reports the host powered off or no video source, return `power_off` / `no_signal` with **no snapshot and no model call**. (`KVMClient.has_video_signal()` is a new, defensively-parsed `/api/streamer` probe.)
2. **unchanged-frame skip** — an identical captured frame reuses the last classification instead of re-classifying.
3. **OCR-assist (opt-in)** — high-precision `ocr_rules` (`DEFAULT_OCR_RULES`) resolve text screens (GRUB, a kernel panic) via on-device OCR, no model.

`vlm_calls` / `cheap_resolves` counters expose the savings. In a typical boot-watch — long stretches where the screen is static, powered off, or knowable from a LED — this avoids most model calls.

## Defaults & compatibility

- `gate_on_power_signal` and `skip_unchanged_frames` default **on**, but are **inert on a driver that only does snapshots** (the probes are duck-typed: no `is_powered_on` / `has_video_signal` → no-op), so they never break a minimal `Video` driver.
- `ocr_rules` is **opt-in** (default `None`).
- Set the flags to `False` to restore unconditional classification.
- One test-only change: `FakeKVM` now returns a **distinct frame per snapshot** (a realistic live capture, so the unchanged-frame gate doesn't fire); all original assertions are unchanged. New `StaticKVM` / `PoweredOffKVM` / `NoSignalKVM` / `OCRKVM` fakes cover each gate.

## Checks

`ruff`, `mypy src/kvm_pilot`, `pytest` (60 tests), and `bandit` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
