### PR TITLE
feat(drivers): PiKVM driver family + GL-RM1PE first-contact support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ KVM_PILOT_PASSWD=changeme
 # KVM_PILOT_PORT=443
 # KVM_PILOT_SCHEME=https
 # KVM_PILOT_TIMEOUT=30
+# KVM_PILOT_DRIVER=glkvm          # pikvm (default) | glkvm | blikvm | fake | redfish
 # KVM_PILOT_VERIFY_SSL=false
 # KVM_PILOT_TOTP_SECRET=BASE32SECRET
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - New phase token **`os_running`** (`vision.base`) for an OS that has handed off
   but whose specific on-screen state isn't distinguishable — emitted by the
   vision backend and mapped to from a BMC's `BootProgress=OSRunning`.
+- **PiKVM driver family.** `KVMClient` was split into a canonical **`PiKVMDriver`**
+  base with thin **`GLKVMDriver`** / **`BliKVMDriver`** subclasses (the
+  API-compatible forks); `KVMClient` and `PiKVMClient` remain aliases of
+  `PiKVMDriver`. The registry maps `glkvm`/`blikvm` to the subclasses.
+- **GLKVM (GL-RM1PE) first-contact support.** `GLKVMDriver` detects the GL "API
+  disabled by default" condition — a 404 across `/api/*` now raises an actionable
+  `ApiDisabledError` pointing at `/etc/kvmd/nginx-kvmd.conf` instead of a bare
+  HTTP 404 — plus a `check_api_enabled()` preflight, `get_firmware_info()`, and a
+  `known_quirks()` registry (seeded honestly with the one documented quirk; grows
+  as real hardware testing reveals release-specific behavior). New
+  `errors.ApiDisabledError`.
+- **`HostConfig.driver`** field (+ `KVM_PILOT_DRIVER` env / config-file key) so a
+  profile can pin its driver; the CLI `--driver` flag overrides it.
 
 ### Changed
 - `ScreenAnalyzer.classify()` now resolves from cheap signals before calling the

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ revert this**, so you may need to redo it after updates. This is a GL firmware
 behavior, not a `kvm-pilot` setting. Stock PiKVM devices expose the API by
 default and need no change.
 
+`kvm-pilot` now **detects this condition**: select the GL driver and a 404 across
+`/api/*` is surfaced as a clear, actionable `ApiDisabledError` (pointing you at
+`nginx-kvmd.conf`) instead of a bare HTTP 404 — and you can preflight with
+`check_api_enabled()`.
+
+```python
+from kvm_pilot import make_driver           # or: from kvm_pilot import GLKVMDriver
+
+gl = make_driver("glkvm", host="192.168.8.1", passwd="…")   # GL-RM1 / GL-RM1PE
+gl.check_api_enabled()        # raises ApiDisabledError with the fix if it's off
+gl.get_firmware_info()        # {'version': …, 'model': 'GL-RM1PE', …}
+gl.known_quirks()             # firmware-specific quirks we track
+```
+
+Pin it for the CLI / a profile with `--driver glkvm`, `KVM_PILOT_DRIVER=glkvm`, or
+`driver = "glkvm"` in a config profile. (`PiKVMDriver` is the canonical base;
+`GLKVMDriver` / `BliKVMDriver` are the fork subclasses. `KVMClient` remains an
+alias of `PiKVMDriver`.)
+
 ---
 
 ## How it works

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,6 +10,7 @@ port = 443
 scheme = "https"
 verify_ssl = false          # GL/PiKVM ship self-signed certs
 timeout = 30.0
+driver = "glkvm"            # pikvm (default) | glkvm | blikvm | fake | redfish
 # totp_secret = "BASE32SECRET"   # only if 2FA is enabled (needs the 'totp' extra)
 
 [hosts.rack2]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,11 +105,14 @@ second device family lands.)
 - [x] **Step 1 — capability protocols** ([`drivers/base.py`](../src/kvm_pilot/drivers/base.py)).
       `KVMClient` implements them via `CapabilityMixin`; no behaviour change.
 - [ ] **Step 2** — split `http.py` into `HttpTransport` + `AuthStrategy`.
-- [~] **Step 3 — driver registry.** `make_driver(kind, **conf)` + `register_driver()`
-      ([`drivers/__init__.py`](../src/kvm_pilot/drivers/__init__.py)) and a `--driver`
-      CLI flag have landed; `KVMClient` doubles as the PiKVM driver for now (kinds
-      `pikvm`/`glkvm`/`blikvm`). Still to come: a dedicated `PiKVMDriver` split and
-      `HostConfig.driver`.
+- [x] **Step 3 — driver registry + PiKVM family.** `make_driver(kind, **conf)` +
+      `register_driver()` ([`drivers/__init__.py`](../src/kvm_pilot/drivers/__init__.py)),
+      a `--driver` CLI flag, and `HostConfig.driver` (+ `KVM_PILOT_DRIVER`). `KVMClient`
+      was split into a canonical `PiKVMDriver` base with thin `GLKVMDriver` /
+      `BliKVMDriver` subclasses ([`drivers/pikvm.py`](../src/kvm_pilot/drivers/pikvm.py));
+      `KVMClient`/`PiKVMClient` stay as aliases. `GLKVMDriver` detects the GL
+      "API disabled" 404 (→ `ApiDisabledError`) and tracks per-firmware quirks.
+      (Moving `PiKVMDriver` out of `client.py` into `drivers/pikvm/` is deferred.)
 - [x] **Step 4 — drivers.** Two concrete non-PiKVM drivers have landed:
       `FakeDriver` ([`drivers/fake.py`](../src/kvm_pilot/drivers/fake.py)) — in-process,
       no hardware (#2) — and `RedfishDriver`

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -21,7 +21,8 @@ import os
 
 from mcp.server.fastmcp import FastMCP
 
-from kvm_pilot import KVMClient, resolve_host
+from kvm_pilot import resolve_host
+from kvm_pilot.drivers import make_driver_from_config
 from kvm_pilot.safety import allow_all, deny_all
 from kvm_pilot.vision import ScreenAnalyzer, make_backend
 
@@ -37,7 +38,8 @@ _POWER_ACTIONS = {
 
 def _make_client(profile: str | None, *, confirm):
     cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
-    return KVMClient.from_config(cfg, confirm=confirm)
+    # Honor cfg.driver (e.g. a profile pinned to 'glkvm') the same way the CLI does.
+    return make_driver_from_config(cfg, confirm=confirm)
 
 
 @mcp.tool()

--- a/src/kvm_pilot/__init__.py
+++ b/src/kvm_pilot/__init__.py
@@ -19,11 +19,12 @@ Quickstart:
 from __future__ import annotations
 
 from .__about__ import __version__
-from .client import KVMClient, PiKVMClient
+from .client import KVMClient, PiKVMClient, PiKVMDriver
 from .config import HostConfig, resolve_host
-from .drivers import make_driver
+from .drivers import BliKVMDriver, GLKVMDriver, make_driver
 from .drivers.base import Capability, KVMDriver
 from .errors import (
+    ApiDisabledError,
     AuthError,
     BusyError,
     CapabilityError,
@@ -38,8 +39,11 @@ from .safety import SafetyPolicy, deny_all, interactive_confirm
 
 __all__ = [
     "__version__",
+    "PiKVMDriver",
     "KVMClient",
     "PiKVMClient",
+    "GLKVMDriver",
+    "BliKVMDriver",
     "HostConfig",
     "resolve_host",
     "SafetyPolicy",
@@ -54,6 +58,7 @@ __all__ = [
     "SafetyError",
     "VisionError",
     "CapabilityError",
+    "ApiDisabledError",
     "Capability",
     "KVMDriver",
     "make_driver",

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 from .__about__ import __version__
 from .client import KVMClient
 from .config import resolve_host
+from .drivers import make_driver_from_config
 from .errors import KVMPilotError, SafetyError
 from .safety import allow_all, interactive_confirm
 
@@ -42,18 +43,6 @@ if TYPE_CHECKING:
 def _build_client(args) -> KVMClient | FakeDriver:
     confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
     dry_run = getattr(args, "dry_run", False)
-
-    if getattr(args, "driver", "pikvm") == "fake":
-        # Hardware-free: no host/credential resolution needed. (Library callers
-        # selecting a driver by string use drivers.make_driver(); the CLI knows
-        # the concrete type it wants here.)
-        from .drivers.fake import FakeDriver
-
-        return FakeDriver(
-            host=getattr(args, "host", None) or "fake",
-            confirm=confirm, dry_run=dry_run,
-        )
-
     cfg = resolve_host(
         getattr(args, "profile", None),
         host=getattr(args, "host", None),
@@ -64,8 +53,10 @@ def _build_client(args) -> KVMClient | FakeDriver:
         timeout=getattr(args, "http_timeout", None),
         totp_secret=getattr(args, "totp_secret", None),
         verify_ssl=getattr(args, "verify_ssl", None),
+        driver=getattr(args, "driver", None),
     )
-    return KVMClient.from_config(cfg, confirm=confirm, dry_run=dry_run)
+    # Shared with the MCP server so cfg.driver is honored the same way everywhere.
+    return make_driver_from_config(cfg, confirm=confirm, dry_run=dry_run)
 
 
 def _make_analyzer(kvm: KVMClient | FakeDriver, args):
@@ -199,8 +190,9 @@ def cmd_events(args) -> int:
 # -- parser ----------------------------------------------------------------
 
 def _add_common(p: argparse.ArgumentParser) -> None:
-    p.add_argument("--driver", choices=["pikvm", "glkvm", "blikvm", "fake"], default="pikvm",
-                   help="Device driver (default pikvm; 'fake' = in-process, no hardware)")
+    p.add_argument("--driver", choices=["pikvm", "glkvm", "blikvm", "fake"],
+                   help="Device driver (overrides KVM_PILOT_DRIVER / config profile; "
+                        "default pikvm; 'glkvm' = GL.iNet GLKVM fork, 'fake' = no hardware)")
     p.add_argument("--host")
     p.add_argument("--user")
     p.add_argument("--passwd")
@@ -313,6 +305,11 @@ def main(argv: list | None = None) -> int:
         print(f"blocked: {exc}", file=sys.stderr)
         return 3
     except KVMPilotError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except (ValueError, KeyError) as exc:
+        # Config/host resolution errors (missing host, unknown profile) — present
+        # cleanly instead of a traceback.
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/src/kvm_pilot/client.py
+++ b/src/kvm_pilot/client.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .drivers.base import CapabilityMixin
-from .errors import AuthError, TimeoutError
+from .errors import ApiDisabledError, AuthError, KVMPilotError, TimeoutError
 from .http import HTTP
 from .safety import SafetyPolicy
 
@@ -37,8 +37,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger("kvm_pilot.client")
 
 
-class KVMClient(CapabilityMixin):
-    """Full PiKVM / GLKVM API client.
+class PiKVMDriver(CapabilityMixin):
+    """Full PiKVM-family REST driver (canonical base of the PiKVM/GLKVM/BliKVM family).
+
+    This is the concrete client for stock PiKVM and any API-compatible device.
+    ``GLKVMDriver`` / ``BliKVMDriver`` (in ``kvm_pilot.drivers.pikvm``) subclass it
+    and override only the deltas. ``KVMClient`` and ``PiKVMClient`` are kept as
+    back-compatible aliases of this class.
 
     Args:
         host: IP or hostname of the KVM device.
@@ -54,6 +59,10 @@ class KVMClient(CapabilityMixin):
         confirm: Optional callback (op, description) -> bool gating destructive ops.
         max_retries: Bounded retries on transient errors (busy/unavailable/network).
     """
+
+    # Subclasses (GLKVMDriver) set this to make a 404 across /api/* surface as a
+    # clear ApiDisabledError with device-specific guidance. None for stock PiKVM.
+    _NOT_FOUND_HINT: str | None = None
 
     def __init__(
         self,
@@ -81,6 +90,7 @@ class KVMClient(CapabilityMixin):
             scheme=scheme,
             totp_secret=totp_secret,
             max_retries=max_retries,
+            not_found_hint=self._NOT_FOUND_HINT,
         )
         self.safety = SafetyPolicy(dry_run=dry_run, confirm=confirm)
 
@@ -92,12 +102,13 @@ class KVMClient(CapabilityMixin):
         confirm=None,
         dry_run: bool = False,
         max_retries: int = 3,
-    ) -> KVMClient:
-        """Build a client from a resolved :class:`~kvm_pilot.config.HostConfig`.
+    ) -> PiKVMDriver:
+        """Build a driver from a resolved :class:`~kvm_pilot.config.HostConfig`.
 
         Centralizes the field-by-field construction the CLI, MCP server, and
         examples would otherwise each repeat (and keeps ``scheme``/``timeout``
-        from silently drifting between call sites).
+        from silently drifting between call sites). Subclasses build their own
+        type (``cls``), so ``GLKVMDriver.from_config(cfg)`` returns a GLKVMDriver.
         """
         return cls(
             cfg.host,
@@ -112,6 +123,54 @@ class KVMClient(CapabilityMixin):
             confirm=confirm,
             max_retries=max_retries,
         )
+
+    # -- firmware / preflight -------------------------------------------
+
+    def get_firmware_info(self) -> dict:
+        """Best-effort firmware/version snapshot from ``/api/info``.
+
+        Normalizes the kvmd version, platform, and model so callers (and the
+        per-firmware quirk registry) can reason about the running release. Shapes
+        vary across PiKVM/GLKVM firmware, so every field is read defensively.
+        """
+        info = self.get_info()
+
+        def _sub(d: object, key: str) -> dict:
+            val = d.get(key) if isinstance(d, dict) else None
+            return val if isinstance(val, dict) else {}
+
+        system = _sub(info, "system")
+        kvmd = _sub(system, "kvmd")
+        platform = _sub(_sub(info, "hw"), "platform")
+        version = kvmd.get("version")
+        return {
+            "version": version,
+            "kvmd_version": version,
+            "platform": platform.get("base") or platform.get("type"),
+            "model": platform.get("model"),
+        }
+
+    def check_api_enabled(self) -> dict:
+        """Preflight: confirm the PiKVM REST API is reachable, else raise clearly.
+
+        On GL.iNet (GLKVM) firmware the API is disabled by default and every
+        ``/api/*`` returns 404; this turns that bare 404 into an actionable
+        :class:`~kvm_pilot.errors.ApiDisabledError`. Returns ``/api/info`` on success.
+        """
+        try:
+            return self.get_info()
+        except ApiDisabledError:
+            raise
+        except KVMPilotError as exc:
+            if exc.status_code == 404:
+                raise ApiDisabledError(
+                    "The PiKVM REST API returned 404. On GL.iNet (GLKVM) firmware "
+                    "the API is disabled by default — enable it in "
+                    "/etc/kvmd/nginx-kvmd.conf and restart kvmd (it can revert on "
+                    "a firmware upgrade).",
+                    404,
+                ) from exc
+            raise
 
     # -- auth ------------------------------------------------------------
 
@@ -503,7 +562,10 @@ class KVMClient(CapabilityMixin):
             time.sleep(0.2)
 
 
-# Backwards-compatible alias for anyone porting from the old skill module.
-PiKVMClient = KVMClient
+# ``KVMClient`` is the long-standing public name and stays as the canonical alias
+# of ``PiKVMDriver``; ``PiKVMClient`` is the older skill-module alias. All three
+# are the same class.
+KVMClient = PiKVMDriver
+PiKVMClient = PiKVMDriver
 
-__all__ = ["KVMClient", "PiKVMClient"]
+__all__ = ["PiKVMDriver", "KVMClient", "PiKVMClient"]

--- a/src/kvm_pilot/config.py
+++ b/src/kvm_pilot/config.py
@@ -35,6 +35,7 @@ class HostConfig:
     verify_ssl: bool = False
     timeout: float = 30.0
     totp_secret: str | None = None
+    driver: str = "pikvm"
 
 
 def _load_file(path: Path) -> dict[str, Any]:
@@ -55,6 +56,7 @@ def resolve_host(
     timeout: float | None = None,
     totp_secret: str | None = None,
     verify_ssl: bool | None = None,
+    driver: str | None = None,
     config_path: Path | None = None,
 ) -> HostConfig:
     """Resolve a HostConfig from args > env > file (in that priority)."""
@@ -75,12 +77,16 @@ def resolve_host(
             return base[key]
         return default
 
+    resolved_driver = pick("driver", driver, "KVM_PILOT_DRIVER", "pikvm")
     resolved_host = pick("host", host, "KVM_PILOT_HOST")
     if not resolved_host:
-        raise ValueError(
-            "No host specified. Provide --host, set KVM_PILOT_HOST, or name a "
-            "profile defined in the config file."
-        )
+        if resolved_driver == "fake":
+            resolved_host = "fake"  # the in-process fake driver needs no real host
+        else:
+            raise ValueError(
+                "No host specified. Provide --host, set KVM_PILOT_HOST, or name a "
+                "profile defined in the config file."
+            )
 
     port_val = pick("port", port, "KVM_PILOT_PORT", 443)
     verify_val = pick("verify_ssl", verify_ssl, "KVM_PILOT_VERIFY_SSL", False)
@@ -96,6 +102,7 @@ def resolve_host(
         verify_ssl=bool(verify_val),
         timeout=float(pick("timeout", timeout, "KVM_PILOT_TIMEOUT", 30.0)),
         totp_secret=pick("totp_secret", totp_secret, "KVM_PILOT_TOTP_SECRET"),
+        driver=resolved_driver,
     )
 
 

--- a/src/kvm_pilot/drivers/__init__.py
+++ b/src/kvm_pilot/drivers/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from ..errors import KVMPilotError
 from .base import (
     CAPABILITY_PROTOCOLS,
     GPIO,
@@ -33,7 +34,10 @@ from .base import (
 )
 
 if TYPE_CHECKING:
+    from ..client import KVMClient
+    from ..config import HostConfig
     from .fake import FakeDriver
+    from .pikvm import BliKVMDriver, GLKVMDriver
     from .redfish import RedfishDriver
 
 
@@ -45,9 +49,21 @@ if TYPE_CHECKING:
 
 
 def _make_pikvm(**conf: object) -> KVMDriver:
-    from ..client import KVMClient
+    from ..client import PiKVMDriver
 
-    return KVMClient(**conf)  # type: ignore[arg-type]
+    return PiKVMDriver(**conf)  # type: ignore[arg-type]
+
+
+def _make_glkvm(**conf: object) -> KVMDriver:
+    from .pikvm import GLKVMDriver
+
+    return GLKVMDriver(**conf)  # type: ignore[arg-type]
+
+
+def _make_blikvm(**conf: object) -> KVMDriver:
+    from .pikvm import BliKVMDriver
+
+    return BliKVMDriver(**conf)  # type: ignore[arg-type]
 
 
 def _make_fake(**conf: object) -> KVMDriver:
@@ -63,10 +79,11 @@ def _make_redfish(**conf: object) -> KVMDriver:
 
 
 _DRIVER_FACTORIES: dict[str, Callable[..., KVMDriver]] = {
-    # PiKVM, the GL.iNet GLKVM fork, and BliKVM share one API-compatible client.
+    # PiKVM-family: one base (PiKVMDriver) with thin GLKVM/BliKVM subclasses for
+    # the API-compatible forks.
     "pikvm": _make_pikvm,
-    "glkvm": _make_pikvm,
-    "blikvm": _make_pikvm,
+    "glkvm": _make_glkvm,
+    "blikvm": _make_blikvm,
     # One Redfish driver covers Dell iDRAC, HPE iLO, Supermicro, Lenovo XCC, OpenBMC.
     "redfish": _make_redfish,
     "fake": _make_fake,
@@ -99,6 +116,34 @@ def make_driver(kind: str = "pikvm", **conf: object) -> KVMDriver:
     return factory(**conf)
 
 
+def make_driver_from_config(
+    cfg: HostConfig, *, confirm: Callable[[str, str], bool] | None = None, dry_run: bool = False
+) -> KVMClient | FakeDriver:
+    """Build the driver named by ``cfg.driver`` from a resolved ``HostConfig``.
+
+    Shared by the CLI and the MCP server so a profile/env that pins
+    ``driver = "glkvm"`` is honored everywhere — not just via ``--driver``. It is
+    shape-aware (the fake driver takes no credentials; the PiKVM family builds via
+    ``from_config``), unlike a raw ``make_driver(**all_fields)`` call.
+    """
+    kind = cfg.driver
+    if kind == "fake":
+        from .fake import FakeDriver
+
+        return FakeDriver(host=cfg.host, confirm=confirm, dry_run=dry_run)
+    if kind in ("pikvm", "glkvm", "blikvm"):
+        from ..client import PiKVMDriver
+        from .pikvm import BliKVMDriver, GLKVMDriver
+
+        cls = {"pikvm": PiKVMDriver, "glkvm": GLKVMDriver, "blikvm": BliKVMDriver}[kind]
+        return cls.from_config(cfg, confirm=confirm, dry_run=dry_run)
+    raise KVMPilotError(
+        f"Driver {kind!r} does not support from-config construction here "
+        "(supported: pikvm, glkvm, blikvm, fake). Build it directly with "
+        f"make_driver({kind!r}, ...) from the library."
+    )
+
+
 def __getattr__(name: str) -> object:
     # Lazily expose the concrete drivers without importing them at package load
     # (keeps the import graph acyclic). ``from kvm_pilot.drivers import FakeDriver``
@@ -111,6 +156,10 @@ def __getattr__(name: str) -> object:
         from .redfish import RedfishDriver
 
         return RedfishDriver
+    if name in ("GLKVMDriver", "BliKVMDriver"):
+        from . import pikvm
+
+        return getattr(pikvm, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -133,7 +182,10 @@ __all__ = [
     "CAPABILITY_PROTOCOLS",
     "detect_capabilities",
     "make_driver",
+    "make_driver_from_config",
     "register_driver",
     "FakeDriver",
     "RedfishDriver",
+    "GLKVMDriver",
+    "BliKVMDriver",
 ]

--- a/src/kvm_pilot/drivers/pikvm.py
+++ b/src/kvm_pilot/drivers/pikvm.py
@@ -1,0 +1,100 @@
+"""
+PiKVM-family driver variants: GL.iNet GLKVM and BliKVM.
+
+``PiKVMDriver`` (in :mod:`kvm_pilot.client`) is the canonical base — the full
+PiKVM REST client. The two devices here are *API-compatible forks*, so each
+subclass overrides only its deltas:
+
+  * ``GLKVMDriver`` — the GL.iNet GLKVM fork (GL-RM1 / GL-RM1PE). Its firmware
+    ships the PiKVM REST API **disabled** by default, so this driver turns the
+    resulting 404s into a clear, actionable error and tracks known per-firmware
+    quirks.
+  * ``BliKVMDriver`` — BliKVM hardware. No deltas are known yet; the subclass
+    exists so device-specific behavior has a home.
+
+Quirk data is seeded **only** with what is actually documented/known — there is
+no fabricated per-firmware data. The registry is the place to record real
+findings as the GL-RM1PE (the first hardware target) and others get tested.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..client import PiKVMDriver
+from ..errors import KVMPilotError
+
+_GL_API_DISABLED_HINT = (
+    "On GL.iNet (GLKVM) firmware the PiKVM REST API is disabled by default; all "
+    "/api/* return 404 until you enable it in /etc/kvmd/nginx-kvmd.conf and "
+    "restart kvmd (it can revert on a firmware upgrade)."
+)
+
+
+@dataclass(frozen=True)
+class Quirk:
+    """A known device/firmware quirk and how to work around it.
+
+    ``firmware`` is ``"all"`` or a substring matched against the device's reported
+    version; ``source`` records provenance — ``"documented"`` (from vendor docs)
+    vs ``"observed"`` (confirmed on real hardware). Keep these honest.
+    """
+
+    id: str
+    summary: str
+    workaround: str
+    firmware: str = "all"
+    source: str = "documented"
+
+    def applies_to(self, firmware: str | None) -> bool:
+        return self.firmware == "all" or (firmware is not None and self.firmware in firmware)
+
+
+# The ONLY quirk we currently know for sure. Add entries here as real GL-RM1PE /
+# GLKVM testing reveals release-specific behavior — with source="observed" and a
+# concrete `firmware` match. Do not invent version-specific quirks.
+GLKVM_QUIRKS: list[Quirk] = [
+    Quirk(
+        id="api-disabled-by-default",
+        summary=(
+            "GL firmware ships the PiKVM REST API disabled; every /api/* returns "
+            "404 until it is enabled."
+        ),
+        workaround=(
+            "Enable the API block in /etc/kvmd/nginx-kvmd.conf and restart kvmd. "
+            "It can revert on a firmware upgrade, so re-check after updates."
+        ),
+        firmware="all",
+        source="documented",
+    ),
+]
+
+
+class GLKVMDriver(PiKVMDriver):
+    """GL.iNet GLKVM fork (GL-RM1 / GL-RM1PE) — first hardware target.
+
+    API-compatible with PiKVM, but surfaces the 'API disabled' 404 as an
+    ``ApiDisabledError`` and exposes the known per-firmware quirks.
+    """
+
+    _NOT_FOUND_HINT = _GL_API_DISABLED_HINT
+
+    def known_quirks(self, firmware: str | None = None) -> list[Quirk]:
+        """Quirks that apply to ``firmware`` (auto-detected from the device if omitted)."""
+        if firmware is None:
+            try:
+                firmware = self.get_firmware_info().get("version")
+            except KVMPilotError:
+                firmware = None
+        return [q for q in GLKVM_QUIRKS if q.applies_to(firmware)]
+
+
+class BliKVMDriver(PiKVMDriver):
+    """BliKVM — PiKVM-API-compatible hardware.
+
+    No deltas from the base client are known yet; this subclass exists so any
+    BliKVM-specific behavior or quirks have a home.
+    """
+
+
+__all__ = ["GLKVMDriver", "BliKVMDriver", "Quirk", "GLKVM_QUIRKS"]

--- a/src/kvm_pilot/errors.py
+++ b/src/kvm_pilot/errors.py
@@ -43,6 +43,15 @@ class CapabilityError(KVMPilotError):
     """The driver does not support the requested capability."""
 
 
+class ApiDisabledError(KVMPilotError):
+    """The device's REST API appears disabled.
+
+    The hallmark case is GL.iNet (GLKVM) firmware, which ships the PiKVM REST API
+    off by default — every ``/api/*`` returns 404 until it is enabled in
+    ``/etc/kvmd/nginx-kvmd.conf`` (and it can revert on a firmware upgrade).
+    """
+
+
 __all__ = [
     "KVMPilotError",
     "AuthError",
@@ -53,4 +62,5 @@ __all__ = [
     "SafetyError",
     "VisionError",
     "CapabilityError",
+    "ApiDisabledError",
 ]

--- a/src/kvm_pilot/http.py
+++ b/src/kvm_pilot/http.py
@@ -23,6 +23,7 @@ import urllib.request
 from typing import Any
 
 from .errors import (
+    ApiDisabledError,
     AuthError,
     BusyError,
     ConnectionError,
@@ -64,6 +65,7 @@ class HTTP:
         totp_secret: str | None = None,
         max_retries: int = 3,
         backoff_base: float = 0.5,
+        not_found_hint: str | None = None,
     ):
         self._base = f"{scheme}://{host}:{port}"
         self._user = user
@@ -72,6 +74,9 @@ class HTTP:
         self._totp_secret = totp_secret
         self._max_retries = max(0, max_retries)
         self._backoff_base = backoff_base
+        # Appended to a 404's error (and promotes it to ApiDisabledError) — set by
+        # the GLKVM driver, whose firmware 404s every /api/* until the API is enabled.
+        self._not_found_hint = not_found_hint
         self._verify_ssl = verify_ssl
         self._ssl_ctx = ssl.create_default_context()
         if not verify_ssl:
@@ -130,6 +135,8 @@ class HTTP:
             raise BusyError(f"Device busy (HTTP {status}): {text}", status)
         if status == 503:
             raise UnavailableError(f"Subsystem unavailable (HTTP {status}): {text}", status)
+        if status == 404 and self._not_found_hint:
+            raise ApiDisabledError(f"HTTP 404: {text}\n{self._not_found_hint}", status)
         raise KVMPilotError(f"HTTP {status}: {text}", status)
 
     @staticmethod

--- a/tests/emulator.py
+++ b/tests/emulator.py
@@ -26,6 +26,7 @@ class FakeKVMState:
         self.fail_status: int | None = None
         self.fail_times = 0
         self.echo_password = False
+        self.api_disabled = False  # GL firmware: every /api/* returns 404
         self.last_headers: dict[str, str] = {}
         self.calls: list[tuple[str, str]] = []
 
@@ -75,6 +76,10 @@ class _Handler(BaseHTTPRequestHandler):
             st.fail_times -= 1
             self._send(b"transient", status=st.fail_status, ctype="text/plain")
             return True
+        if st.api_disabled and path.startswith("/api/"):
+            # GL.iNet firmware blocks the API at nginx -> 404 (HTML in reality).
+            self._send(b"<html>404</html>", status=404, ctype="text/html")
+            return True
         return False
 
     def do_GET(self) -> None:
@@ -84,7 +89,10 @@ class _Handler(BaseHTTPRequestHandler):
         if path == "/api/auth/check":
             self._json({})
         elif path == "/api/info":
-            self._json({"hw": {"platform": "fake"}})
+            self._json({
+                "hw": {"platform": {"base": "fake", "model": "GL-RM1PE"}},
+                "system": {"kvmd": {"version": "4.2-gl-test"}},
+            })
         elif path == "/api/atx":
             self._json({"leds": {"power": self._state.powered_on}})
         elif path == "/api/streamer/snapshot":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,48 @@ def test_driver_fake_power_action_is_dispatched():
     assert rc == 0
 
 
+def test_driver_glkvm_builds_the_glkvm_subclass():
+    from kvm_pilot.cli import _build_client, build_parser
+    from kvm_pilot.drivers.pikvm import GLKVMDriver
+
+    args = build_parser().parse_args(["info", "--driver", "glkvm", "--host", "h"])
+    kvm = _build_client(args)  # construction only; no network
+    assert isinstance(kvm, GLKVMDriver)
+
+
+def test_driver_defaults_to_pikvm_when_unset(monkeypatch):
+    from kvm_pilot.cli import _build_client, build_parser
+    from kvm_pilot.client import PiKVMDriver
+
+    monkeypatch.delenv("KVM_PILOT_DRIVER", raising=False)
+    args = build_parser().parse_args(["info", "--host", "h"])  # no --driver
+    kvm = _build_client(args)
+    assert isinstance(kvm, PiKVMDriver) and not type(kvm).__name__.startswith(("GL", "Bli"))
+
+
+def test_unsupported_driver_via_env_is_a_clean_error(monkeypatch, capsys):
+    # The CLI can't dispatch redfish generically yet; a config/env selection must
+    # produce a clean error (exit 1), not a crash.
+    monkeypatch.setenv("KVM_PILOT_DRIVER", "redfish")
+    rc = main(["info", "--host", "h"])
+    assert rc == 1
+    assert "does not support" in capsys.readouterr().err
+
+
+def test_fake_via_env_needs_no_host(monkeypatch):
+    # Parity with --driver fake: KVM_PILOT_DRIVER=fake must not require a host.
+    monkeypatch.setenv("KVM_PILOT_DRIVER", "fake")
+    assert main(["capabilities"]) == 0
+
+
+def test_missing_host_is_a_clean_error(monkeypatch, capsys):
+    monkeypatch.delenv("KVM_PILOT_HOST", raising=False)
+    monkeypatch.delenv("KVM_PILOT_DRIVER", raising=False)
+    rc = main(["info"])  # no host, pikvm driver -> resolve_host ValueError, caught cleanly
+    assert rc == 1
+    assert "host" in capsys.readouterr().err.lower()
+
+
 def test_classify_driver_fake_is_offline_without_api_key(monkeypatch, capsys):
     # With the lazy API-key check, the analyzer resolves power_off from the fake's
     # cheap power gate with no model call — so no ANTHROPIC_API_KEY is required.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,21 @@ def test_timeout_precedence(monkeypatch, tmp_path):
     assert resolve_host(host="h", timeout=99.0, config_path=none).timeout == 99.0  # arg wins
 
 
+def test_driver_precedence(monkeypatch, tmp_path):
+    monkeypatch.delenv("KVM_PILOT_DRIVER", raising=False)
+    none = tmp_path / "none.toml"
+    assert resolve_host(host="h", config_path=none).driver == "pikvm"  # default
+    monkeypatch.setenv("KVM_PILOT_DRIVER", "glkvm")
+    assert resolve_host(host="h", config_path=none).driver == "glkvm"  # env
+    assert resolve_host(host="h", driver="blikvm", config_path=none).driver == "blikvm"  # arg wins
+
+
+def test_driver_from_profile(tmp_path):
+    f = tmp_path / "config.toml"
+    f.write_text('[hosts.gl]\nhost = "10.0.0.9"\ndriver = "glkvm"\n')
+    assert resolve_host("gl", config_path=f).driver == "glkvm"
+
+
 def test_profile_from_file(tmp_path):
     f = tmp_path / "config.toml"
     f.write_text(

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -105,6 +105,18 @@ def test_make_driver_fake() -> None:
     assert d.host == "lab"
 
 
+def test_make_driver_glkvm_blikvm_return_the_subclasses() -> None:
+    from kvm_pilot.client import PiKVMDriver
+    from kvm_pilot.drivers import BliKVMDriver, GLKVMDriver, make_driver
+
+    g = make_driver("glkvm", host="h")
+    b = make_driver("blikvm", host="h")
+    assert isinstance(g, GLKVMDriver) and isinstance(g, PiKVMDriver)
+    assert isinstance(b, BliKVMDriver) and isinstance(b, PiKVMDriver)
+    # And they still satisfy the original public name.
+    assert isinstance(g, KVMClient)
+
+
 def test_make_driver_unknown_kind_lists_known() -> None:
     import pytest
 
@@ -120,3 +132,18 @@ def test_register_driver_adds_a_kind() -> None:
     sentinel = object()
     register_driver("sentinel", lambda **conf: sentinel)
     assert make_driver("sentinel") is sentinel
+
+
+def test_make_driver_from_config_dispatches_on_cfg_driver() -> None:
+    # The CLI and MCP server share this so cfg.driver is honored identically.
+    import pytest
+
+    from kvm_pilot.config import HostConfig
+    from kvm_pilot.drivers import FakeDriver, make_driver_from_config
+    from kvm_pilot.drivers.pikvm import GLKVMDriver
+    from kvm_pilot.errors import KVMPilotError
+
+    assert isinstance(make_driver_from_config(HostConfig(host="h", driver="glkvm")), GLKVMDriver)
+    assert isinstance(make_driver_from_config(HostConfig(host="h", driver="fake")), FakeDriver)
+    with pytest.raises(KVMPilotError, match="does not support"):
+        make_driver_from_config(HostConfig(host="h", driver="redfish"))

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -33,7 +33,7 @@ def test_login_sets_auth_token(emu):
 
 def test_get_info_roundtrip(emu):
     info = _client(emu).get_info()
-    assert info["hw"]["platform"] == "fake"
+    assert info["hw"]["platform"]["base"] == "fake"
     assert ("GET", "/api/info") in emu.state.calls
 
 
@@ -63,7 +63,7 @@ def test_retry_on_503_then_succeeds(emu):
     emu.state.fail_status = 503
     emu.state.fail_times = 1
     info = _client(emu).get_info()
-    assert info["hw"]["platform"] == "fake"
+    assert info["hw"]["platform"]["base"] == "fake"
 
 
 def test_password_redacted_over_real_transport(emu):

--- a/tests/test_pikvm_family.py
+++ b/tests/test_pikvm_family.py
@@ -1,0 +1,90 @@
+"""GLKVM / BliKVM driver family — the PiKVMDriver split, GL API-disabled
+detection, firmware info, and the quirk registry, over the real transport."""
+
+from __future__ import annotations
+
+import pytest
+
+from emulator import EmulatorServer
+from kvm_pilot import ApiDisabledError, BliKVMDriver, GLKVMDriver, KVMClient, PiKVMDriver
+from kvm_pilot.errors import KVMPilotError
+
+
+@pytest.fixture
+def emu():
+    with EmulatorServer() as server:
+        yield server
+
+
+def gl(emu, **kw) -> GLKVMDriver:
+    return GLKVMDriver("127.0.0.1", "admin", "s3cr3t", port=emu.port, scheme="http", **kw)
+
+
+# -- the family split ------------------------------------------------------
+
+def test_family_are_pikvmdriver_subclasses():
+    assert issubclass(GLKVMDriver, PiKVMDriver)
+    assert issubclass(BliKVMDriver, PiKVMDriver)
+    # KVMClient / PiKVMClient remain aliases of the canonical base.
+    assert KVMClient is PiKVMDriver
+
+
+def test_glkvm_capabilities_match_the_base(emu):
+    # A fork advertises the same capabilities — it's the same kvmd API.
+    assert gl(emu).capabilities() == PiKVMDriver("placeholder-host").capabilities()
+
+
+# -- firmware tracking -----------------------------------------------------
+
+def test_get_firmware_info_normalizes_version_and_model(emu):
+    fw = gl(emu).get_firmware_info()
+    assert fw["version"] == "4.2-gl-test"
+    assert fw["kvmd_version"] == "4.2-gl-test"
+    assert fw["model"] == "GL-RM1PE"
+
+
+# -- GL API-disabled detection (the first-contact gotcha) ------------------
+
+def test_check_api_enabled_passes_when_api_is_up(emu):
+    info = gl(emu).check_api_enabled()
+    assert info["hw"]["platform"]["model"] == "GL-RM1PE"
+
+
+def test_api_disabled_surfaces_actionable_error(emu):
+    emu.state.api_disabled = True  # GL firmware blocks /api/* -> 404
+    with pytest.raises(ApiDisabledError) as ei:
+        gl(emu).get_info()
+    assert "nginx-kvmd.conf" in str(ei.value)
+
+
+def test_check_api_enabled_detects_disabled(emu):
+    emu.state.api_disabled = True
+    with pytest.raises(ApiDisabledError):
+        gl(emu).check_api_enabled()
+
+
+def test_stock_pikvm_404_is_a_plain_error_not_apidisabled(emu):
+    # The base driver has no GL hint, so a bare 404 from get_info stays generic
+    # (only the explicit check_api_enabled() preflight upgrades it).
+    emu.state.api_disabled = True
+    base = PiKVMDriver("127.0.0.1", "admin", "s3cr3t", port=emu.port, scheme="http")
+    with pytest.raises(KVMPilotError) as ei:
+        base.get_info()
+    assert not isinstance(ei.value, ApiDisabledError)
+    assert ei.value.status_code == 404
+
+
+# -- quirk registry --------------------------------------------------------
+
+def test_known_quirks_includes_documented_api_disabled(emu):
+    quirks = gl(emu).known_quirks()  # auto-detects firmware from the device
+    by_id = {q.id: q for q in quirks}
+    assert "api-disabled-by-default" in by_id
+    assert by_id["api-disabled-by-default"].source == "documented"
+    assert "nginx-kvmd.conf" in by_id["api-disabled-by-default"].workaround
+
+
+def test_known_quirks_offline_with_explicit_firmware():
+    # No network: pass a firmware string directly.
+    quirks = GLKVMDriver("h").known_quirks(firmware="anything")
+    assert any(q.id == "api-disabled-by-default" for q in quirks)


### PR DESCRIPTION
Completes **Step 3** of the driver-plugin epic (#5) and the re-scoped **#30**, with the **GL-RM1PE** (first hardware target) in mind.

### PiKVMDriver family split
`KVMClient` → canonical **`PiKVMDriver`** base + thin **`GLKVMDriver`** / **`BliKVMDriver`** subclasses (API-compatible forks). `KVMClient` / `PiKVMClient` remain aliases — no public break. Registry maps `glkvm`/`blikvm` to the subclasses.

### GL first-contact support (the GL-RM1PE gotcha)
GL firmware ships the PiKVM REST API **disabled** (every `/api/*` 404s until enabled in `/etc/kvmd/nginx-kvmd.conf`). Previously only documented; now **detected**: `GLKVMDriver` raises an actionable **`ApiDisabledError`** instead of a bare 404, plus a `check_api_enabled()` preflight. New `errors.ApiDisabledError` + an `HTTP.not_found_hint` hook (GL-only).

### Firmware + quirk tracking
`get_firmware_info()` normalizes kvmd version/platform/model; `known_quirks()` reads an **honest** registry seeded with the one documented quirk (no fabricated per-firmware data) — it grows as real GL-RM1PE testing reveals specifics.

### Driver selection
`HostConfig.driver` (+ `KVM_PILOT_DRIVER`), wired through `resolve_host`; `--driver` overrides.

### Review-driven fixes (3 reviewers, 2 confirmed)
- A shared `drivers.make_driver_from_config()` backs **both** the CLI and the MCP server, so `cfg.driver` is honored everywhere (the MCP path previously dropped GL detection for a pinned `glkvm` profile).
- `resolve_host` makes the fake driver host-free; the CLI presents config errors (missing host, unknown profile, env-selected unsupported driver) cleanly instead of a traceback.

**150 tests** (was 132); ruff / mypy / bandit clean; examples + MCP compile. Capability-aware `--driver redfish` CLI dispatch remains follow-up #27.
