### PR TITLE
docs: Redfish reference, design decisions, engineering principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,32 @@ any docs or messaging; do not claim features are "tested" or "beta".
   `HID`, `Video`, `VirtualMedia`, `GPIO`, `Events`, `SystemInfo`). See
   `docs/architecture.md`.
 
+## Engineering principles (how to make changes)
+Optimize for the next person reading this, not for cleverness.
+- Prefer the boring, standard solution; use existing utilities instead of new ones.
+- Smallest change that works. No speculative generality.
+- No new abstraction/layer/dependency unless it's used in ≥2 places.
+- Prefer composition and early returns over inheritance and nesting.
+- Delete more than you add where you can.
+- Add tests that read as documentation of intent.
+- Write the simplest thing that could work; ask for more if needed rather than
+  building it speculatively.
+- After a change, run `/simplify` and report what you cut.
+- Record non-obvious "looks wrong but is intentional" choices in
+  `docs/decisions.md` so they aren't re-litigated.
+
 ## Layout
-- `src/kvm_pilot/client.py` — `KVMClient`, the PiKVM/GLKVM REST client.
+- `src/kvm_pilot/client.py` — `PiKVMDriver`, the PiKVM-family REST client (`KVMClient`/`PiKVMClient` are aliases).
 - `src/kvm_pilot/http.py` — stdlib HTTP transport (retry/backoff, secret redaction).
 - `src/kvm_pilot/safety.py` — `SafetyPolicy`, `DESTRUCTIVE_OPS`.
-- `src/kvm_pilot/drivers/base.py` — capability protocols (driver-plugin model).
+- `src/kvm_pilot/drivers/` — capability protocols (`base.py`), the `make_driver()` registry
+  (`__init__.py`), and drivers: `pikvm.py` (`GLKVMDriver`/`BliKVMDriver`), `fake.py`, `redfish/`.
 - `src/kvm_pilot/vision/` — pluggable vision backends + `ScreenAnalyzer`.
 - `src/kvm_pilot/{config,errors,cli}.py` — config resolution, exceptions, CLI.
-- `tests/` — unit tests; HTTP + vision are mocked (`tests/conftest.py`).
-- `docs/architecture.md` — driver-plugin design + diagram. `skill/SKILL.md` — the bundled Claude skill.
+- `tests/` — unit tests (HTTP + vision mocked, `tests/conftest.py`) plus pure-stdlib
+  fake servers `emulator.py` (kvmd) and `redfish_emulator.py` exercised over the real transport.
+- `docs/` — `architecture.md` (driver-plugin design + diagrams), `redfish.md` (Redfish
+  reference), `decisions.md` (design-decision records). `skill/SKILL.md` — the bundled Claude skill.
 
 ## Dev workflow (Python ≥ 3.11)
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,10 @@ implements only the capability protocols its hardware supports.
 
 ![kvm-pilot driver-plugin architecture](architecture.svg)
 
+**Further reading:** [`redfish.md`](redfish.md) (Redfish driver reference — spec
+grounding, portability rules, open questions) and [`decisions.md`](decisions.md)
+(records of non-obvious design choices).
+
 ## Layers
 
 - **Consumers** — the CLI, the `KVMClient` facade, and `ScreenAnalyzer`. None of

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,71 @@
+# Design decisions
+
+Short records of non-obvious choices — especially the ones that **look wrong but
+are intentional**, so they don't get re-litigated. Newest first.
+
+## Drivers
+
+### Kept the 4 unimplemented sensing protocols (`BootProgress`, `Sensors`, `SerialConsole`, `Watchdog`)
+They landed with zero implementers, which reads like dead code. Kept on purpose:
+they are the documented seam for BMC drivers, and they're no longer speculative —
+`FakeDriver` and `RedfishDriver` implement `BootProgress`, `RedfishDriver` implements
+`Sensors`. `SerialConsole`/`Watchdog` are the IPMI/SOL seam. Don't delete them as
+"dead code."
+
+### `PiKVMDriver` is a base class with `GLKVMDriver`/`BliKVMDriver` subclasses (inheritance, not composition)
+The GL/Bli devices are *API-compatible forks* — a subclass that overrides only the
+deltas is the natural shape, and there are ≥2 real subclasses. (General guidance
+still favors composition; this is the case where inheritance genuinely fits.)
+`KVMClient`/`PiKVMClient` stay as aliases of `PiKVMDriver` so no public API breaks.
+
+### `GLKVMDriver` maps **every** `/api/*` 404 → `ApiDisabledError`
+Looks over-broad. It's intentional: GL firmware disables the **whole** `/api/*`
+surface by default, so a 404 on any endpoint is overwhelmingly "API disabled," and
+that's the dominant first-contact failure on a GL-RM1PE. The stock `PiKVMDriver`
+sets no hint, so its 404s stay generic (see `test_stock_pikvm_404_is_a_plain_error`).
+
+### Quirk registry holds only documented/observed facts
+`GLKVM_QUIRKS` is seeded with the single documented quirk and grows from real
+testing (`source="observed"`). Never invent firmware-version-specific data — the
+project's honesty rule (alpha, untested on hardware) applies to the quirk DB too.
+
+### `RedfishDriver` is library/registry-only, not on the CLI `--driver` list
+A BMC is capability-partial (no HID/Video; no `hard_cycle`/`watch_events`), so CLI
+subcommands like `type`/`snapshot`/`events` would `AttributeError`. It's exposed via
+`make_driver("redfish")`; the CLI entry waits on capability-aware dispatch
+([#27](https://github.com/DustinTrap/kvm-pilot/issues/27)).
+
+### Redfish action POSTs keep the default retry (on transient errors)
+Reviewers flagged retrying non-idempotent POSTs (reset/insert). Kept: those ops are
+effectively idempotent (resetting twice is still reset; inserting twice is still
+inserted), retry only fires on transient `409`/`503`/network, and it matches the
+existing `KVMClient` behavior.
+
+### One `make_driver_from_config()` shared by the CLI and MCP server
+The driver-from-`HostConfig` dispatch is shape-aware (fake takes no credentials;
+the PiKVM family builds via `from_config`). It lives in one place so `cfg.driver`
+is honored identically by both consumers (used in ≥2 places → justified helper).
+
+### A dedicated `RedfishHTTP` transport instead of reusing `http.py`
+`http.py` is PiKVM-specific (`X-KVMD-*` auth, the `ok`/`result` envelope) and
+discards status/headers, which Redfish needs (`202`, `X-Auth-Token`, `Location`,
+`ETag`). Generalizing `http.py` is the separate Step 2 ([#6](https://github.com/DustinTrap/kvm-pilot/issues/6)).
+
+## Vision
+
+### Added an `os_running` phase token
+For `BootProgress=OSRunning`, which means "OS handed off, running" — no existing
+token fit, and the alternative (returning `None`) wrongly signals "can't report."
+Cheap to add now that `SYSTEM_PROMPT` interpolates `ALL_PHASES`.
+
+### `AnthropicBackend` validates its API key lazily (at first network use)
+So analyzer paths resolved by a cheap gate (e.g. `power_off`) run offline with no
+key — `classify --driver fake` needs no credentials. Mirrors the lazy model
+resolution.
+
+## Process
+
+Most structural choices came from adversarial review passes (find → verify →
+fix). The *fixes* are in the code; this file preserves the *rejected* findings and
+tradeoff rationale. The Redfish driver's spec grounding lives in
+[`redfish.md`](redfish.md).

--- a/docs/redfish.md
+++ b/docs/redfish.md
@@ -1,0 +1,128 @@
+# RedfishDriver — reference
+
+Implementation notes for [`drivers/redfish/`](../src/kvm_pilot/drivers/redfish/),
+grounded in the DMTF Redfish spec and Dell/HPE/Supermicro/Lenovo/OpenBMC docs.
+
+> **Status:** alpha, **mock-tested only — never run against a real BMC.** Behaviors
+> that can only be confirmed on hardware are tracked in [#29](https://github.com/DustinTrap/kvm-pilot/issues/29).
+> Sources are listed at the bottom.
+
+## What it is
+
+One stdlib (`urllib`) client for server BMCs. It advertises a BMC's
+*complementary* capability set — strong on structured state, no pixels:
+
+| Capability | Redfish source |
+|---|---|
+| `SystemInfo` | `ComputerSystem` (`Manufacturer`/`Model`/`UUID`/`BiosVersion`/`PowerState`/`Status`) + `ServiceRoot.RedfishVersion` |
+| `Power` | read `ComputerSystem.PowerState`; write `Actions/#ComputerSystem.Reset` |
+| `BootProgress` | `ComputerSystem.BootProgress.LastState` → the project's phase vocabulary |
+| `Sensors` | `Chassis/{id}/Sensors` (unified) **or** legacy `Chassis/{id}/Thermal` + `/Power` |
+| `Logs` | a discovered `LogService` `Entries` collection (SEL / Lclog / IML) |
+| `VirtualMedia` | a `VirtualMedia` slot + `InsertMedia`/`EjectMedia` actions |
+
+**Not implemented** (a BMC has none): `HID`, `Video`, `GPIO`. **Deferred** ([#28](https://github.com/DustinTrap/kvm-pilot/issues/28)):
+`SerialConsole` (SOL is an SSH/IPMI descriptor, not an HTTP byte stream),
+`Events` (push/SSE), `Watchdog` (an IPMI primitive).
+
+## The cardinal rule: navigate hypermedia, don't hard-code
+
+Member ids are **not** portable — Dell `System.Embedded.1` / `iDRAC.Embedded.1`,
+HPE / Supermicro / Lenovo `1`, OpenBMC `system` / `bmc`. So:
+
+- **Discover by following `@odata.id`**, never assume an id. From `ServiceRoot`
+  (`/redfish/v1/`) → `Systems`/`Chassis`/`Managers` collections → `Members[0].@odata.id`.
+- **Read `Actions[...].target`** for action URIs; learn allowed parameters from
+  `@Redfish.ActionInfo` (preferred) → inline `ResetType@Redfish.AllowableValues`
+  → fall back to the DMTF enum and let the POST 4xx tell you. iDRAC10 drops the
+  inline annotation; HPE keeps it.
+- **Feature-detect on payload shape, not version strings.** Decide a feature
+  exists because the property/link/action is present, not from `RedfishVersion`
+  or `@odata.type` (vendors ship different minor versions per resource).
+- **Page** every collection via `Members@odata.nextLink` (bounded — a cyclic
+  nextLink must not loop forever).
+
+## Power: map intent → the target's actual `ResetType`
+
+`ResetType` support varies per target (and power state), so map each intent to
+the first advertised value:
+
+| method | preference order |
+|---|---|
+| `power_on` | `On` → `ForceOn` |
+| `power_off` | `GracefulShutdown` → `PushPowerButton` → `ForceOff` |
+| `power_off_hard` | `ForceOff` → `PushPowerButton` |
+| `reset_hard` | `ForceRestart` → `PowerCycle` → `GracefulRestart` |
+
+`reset_hard` prefers `ForceRestart` because **`GracefulRestart` is not reliably
+graceful** (Dell iDRAC9 v3.36 bug; HPE iLO5 advisory). If none match, raise
+`CapabilityError` with the advertised set.
+
+## BootProgress → phase vocabulary
+
+`BootProgressTypes` maps to `vision.base` phases: the `*Started`/`*Complete`
+init states → `post_screen`; `SetupEntered` → `bios_menu`; `OSBootStarted` →
+`booting`; `OSRunning` → `os_running` (a token added for exactly this). A literal
+`None` + powered off → `power_off`; absent `BootProgress` → `None` ("can't
+report"); unknown enum → `unknown` (never raise).
+
+## Auth (session-first) and security
+
+1. `GET /redfish/v1/` → `Links.Sessions.@odata.id` (else `/redfish/v1/SessionService/Sessions`).
+2. `POST` it with **no auth header**, `{"UserName","Password"}` → capture
+   `X-Auth-Token` (sent on every later request) + `Location` (the session URI).
+3. `DELETE` the session on logout — BMCs cap sessions (Lenovo XCC ~16; iLO
+   limited), so leaks lock you out. Fall back to the body `@odata.id` if
+   `Location` is absent.
+
+- **HTTP Basic** is optional (`auth="basic"`); vendors increasingly disable it
+  (Dell flipped the default to *Unadvertised* in iDRAC9 7.30) — session-first is
+  the right default.
+- **`PasswordChangeRequired`**: a login can return 201 yet carry that MessageId
+  with every op then 403 — surface a distinct `AuthError`, never auto-PATCH.
+- **Pin credentials to the configured origin.** A BMC-supplied absolute URL
+  (`Location`/`@odata.id`/Task monitor) pointing off-host must not receive the
+  token / Basic auth.
+
+## Async, errors, sensors, media, logs
+
+- **Async:** an action may return `204` (sync) or `202` + a `Location` Task
+  monitor — poll `TaskState` to a terminal state; treat **404/410 on the monitor
+  as success** (iDRAC/iLO GC finished tasks) and `TaskStatus=Critical` as failure.
+- **Errors:** parse `error.@Message.ExtendedInfo[*].MessageId` (read whichever of
+  `Severity`/`MessageSeverity` is present). Map `401/403`→`AuthError`,
+  `409`→`BusyError`, `503`→`UnavailableError`.
+- **Sensors:** prefer the unified `Sensors` collection if the `Chassis` advertises
+  the link; else legacy `Thermal` + `Power`.
+- **VirtualMedia:** collect slots from **both** System- and Manager-level
+  collections, pick by `MediaTypes` (`cdrom` flag), read `InsertMedia`/`EjectMedia`
+  targets from the slot. Redfish has no separate "connect" step — Insert attaches.
+- **Logs:** scan `LogServices` under both the System and the Manager (Dell SEL/Lclog
+  under Manager; HPE IML under System); follow the `@odata.id` link, never build
+  `/LogServices` by hand.
+
+## Safety
+
+Reset and virtual-media insert/eject route through `SafetyPolicy.guard()` with the
+`redfish.*` ids in [`safety.py`](../src/kvm_pilot/safety.py). Reads are never gated.
+
+## Open questions (need real hardware — [#29](https://github.com/DustinTrap/kvm-pilot/issues/29))
+
+Sync-vs-async per vendor/action; current iDRAC9/10 & iLO5/6 `ResetType` sets;
+ETag/If-Match enforcement (and empty-`""`-ETag handling) once boot-override lands
+([#28](https://github.com/DustinTrap/kvm-pilot/issues/28)); `LogService` selection
+on unseen vendors; whether HPE can disable Basic auth.
+
+## Sources
+
+- DMTF Redfish Specification **DSP0266** (1.15.x) and Data Model **DSP0268**; the
+  schema bundle at <https://redfish.dmtf.org/schemas/> (`ComputerSystem`,
+  `ComputerSystem.Reset`/`ActionInfo`, `BootProgress`, `Sensor`, `Thermal`/`Power`,
+  `VirtualMedia`, `LogService`/`LogEntry`, `Task`, `SessionService`).
+- Redfish error model: <https://redfish.redoc.ly/docs/concepts/errorresponses/>.
+- Dell iDRAC Redfish API guide (dell.com/support manuals); HPE iLO RESTful/Redfish
+  (developer.hpe.com); Supermicro Redfish; Lenovo XCC REST API
+  (<https://pubs.lenovo.com/xcc-restapi/>); OpenBMC
+  (<https://github.com/openbmc/docs/blob/master/REDFISH-cheatsheet.md>).
+- `ResetType` AllowableValues drift: <https://redfishforum.com/thread/354>.
+  Empty-ETag handling lesson: OpenStack Sushy release notes.


### PR DESCRIPTION
Captures session knowledge that otherwise lived only in workflow transcripts, so it survives in the repo.

- **`docs/redfish.md`** — `RedfishDriver` reference: spec grounding (DMTF + Dell/HPE/Supermicro/Lenovo/OpenBMC), the hypermedia-portability rules, capability mapping, session auth + security, async/error handling, and the open questions (→ #29), with sources.
- **`docs/decisions.md`** — records of non-obvious *"looks wrong but is intentional"* choices: kept the speculative sensing protocols, the GL blanket `404→ApiDisabledError`, the `os_running` token, the quirk-registry honesty rule, retry-on-POST, the dedicated Redfish transport, etc.
- **`CLAUDE.md`** — a new **Engineering principles** section (simplest-thing-that-works, ≥2-uses-before-abstraction, composition over inheritance, delete > add, tests as intent, run `/simplify` after changes) and a refreshed Layout.
- **`docs/architecture.md`** — pointer to the two new docs.

**Documentation only — no code changed.**
