### PR TITLE
feat(cli): capability-aware --driver dispatch + unlock --driver redfish (#27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
     # the tests/integration conftest starts `sushy-emulator` itself.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install project + external Redfish emulator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,25 @@ jobs:
           path: coverage.xml
           if-no-files-found: ignore
 
+  redfish-integration:
+    # Validates `--driver redfish` end-to-end against an external, DMTF-conformant
+    # reference emulator (sushy-tools, --fake driver). The fake backend needs no
+    # libvirt/QEMU and no nested KVM, so it runs on a stock GitHub-hosted runner;
+    # the tests/integration conftest starts `sushy-emulator` itself.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install project + external Redfish emulator
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install "sushy-tools==2.2.0"   # pinned so an upstream change can't redden unrelated PRs
+      - name: Integration tests vs sushy-emulator (--fake)
+        run: pytest tests/integration -m integration -v
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ bmc.read_sensors()["temperatures"]
 bmc.power_off(wait=True)       # mapped to the target's actual ResetType, gated
 ```
 
+It's on the CLI too — `kvm-pilot info --driver redfish --host idrac.lan …`.
+Capability-specific subcommands a BMC can't serve (`type`, `snapshot`, `events`)
+fail cleanly rather than crashing. Add `--redfish-auth basic` for an endpoint
+without a SessionService (emulators, or a BMC with session auth disabled).
+
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE). `kvm-pilot` is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,9 +126,11 @@ second device family lands.)
       (`SystemInfo`, `Power`, `BootProgress`, `Sensors`, `Logs`, `VirtualMedia`) and
       none of `HID`/`Video`/`GPIO`, so structured-state sensing (`BootProgress`,
       `Sensors`) finally has real implementers alongside the PiKVM pixels.
-      `RedfishDriver` is currently a library/`make_driver("redfish")` driver; wiring
-      it into the CLI awaits **capability-aware `--driver` dispatch** (so commands
-      that need a capability a device lacks fail cleanly instead of `AttributeError`).
+      `RedfishDriver` is on the CLI (`--driver redfish`) via **capability-aware
+      `--driver` dispatch** ([#27](https://github.com/DustinTrap/kvm-pilot/issues/27)):
+      a subcommand needing a capability the device lacks fails cleanly (exit 1)
+      instead of `AttributeError`, and the `redfish` path is validated end-to-end
+      against an external DMTF-conformant emulator (sushy-tools) in CI.
 - [ ] **Step 5** — entry-point plugins + a "writing a driver" guide; per-driver deps as extras.
 
 The zero-dependency stdlib core is preserved: the HTTP transport stays on

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,57 @@ are intentional**, so they don't get re-litigated. Newest first.
 
 ## Drivers
 
+### Capability-aware CLI dispatch: gate on `supports()`, then cast to the rich driver union ([#27](https://github.com/DustinTrap/kvm-pilot/issues/27))
+Each subcommand declares the capability it needs; `_client(args, cap)` builds the
+driver and rejects it with a clean message + exit 1 (not an `AttributeError`) when it
+lacks the capability, deriving the command name from `args.command`. `_rich_client`
+wraps it and `cast`s to `KVMClient | FakeDriver` (the `RichDriver` alias) — which looks
+like a type lie. It's sound: `RedfishDriver` is the only capability-partial driver and
+it lacks exactly HID/Video/Events, so gating on one of those excludes it, leaving the
+PiKVM-family/Fake surface that carries the convenience kwargs (`slow=`, `quality=`,
+`stream=`) the minimal capability protocols don't declare. A future rich-but-partial
+driver would need its own Protocol rather than this cast.
+
+### `RedfishDriver.hard_cycle` exists even though `hard_cycle` is not a capability
+`power-cycle` gates on `POWER`, but `hard_cycle` isn't part of the `Power` protocol —
+`KVMClient`/`FakeDriver` carried it as a convenience, `RedfishDriver` didn't, so
+`power-cycle --driver redfish` would `AttributeError` despite a BMC plainly having
+power. Added `hard_cycle` (force-off → on) so the invariant "advertises `POWER` ⇒ the
+CLI `power-cycle` works" holds for every power driver. Its `off_delay`/`on_delay`
+default to `0.0` (unlike `KVMClient`'s ATX settle delays) because the two gated power
+ops already block on the real `PowerState` transition.
+
+It is now the *third* copy of the same `power_off_hard → power_on` composition
+(`KVMClient`, `FakeDriver`, `RedfishDriver`). A shared `PowerMixin.hard_cycle`
+(composed from the protocol methods, with the settle delays as an overridable class
+attribute) is the better home and would make the invariant structural — **deferred on
+purpose**: the clean version changes `KVMClient.hard_cycle`'s public `off_delay`/
+`on_delay` signature and touches the primary (real-hardware) PiKVM path, which is out
+of scope for the CLI-dispatch change. Tracked as follow-up, not churned into #27.
+
+### `--redfish-auth` selector, defaulting to `session`
+Session auth is the BMC norm (and what real iDRAC/iLO recommend), so it stays the
+default. But sushy-tools' `--fake` emulator exposes no `SessionService`, and a BMC can
+administratively disable session or basic auth (cf.
+[#29](https://github.com/DustinTrap/kvm-pilot/issues/29)) — an "unlocked" `--driver
+redfish` that could *only* do session auth couldn't authenticate to either. The
+`basic` opt-in keeps the unlock honest. It's redfish-only and ignored by the PiKVM
+family.
+
+### Two-layer Redfish testing: in-process mock for the CLI path, external sushy-tools for independence
+The pure-stdlib `tests/redfish_emulator.py` validates the full CLI → driver → HTTP
+path in the default hermetic suite (`test_cli_redfish.py`). The opt-in `integration`
+job (`tests/integration/`) runs the same surface against DMTF-conformant **sushy-tools**
+`sushy-emulator --fake` — an *independently authored* implementation, so a spec
+assumption shared by our driver and our own mock can't hide. sushy's fake driver has
+no `SessionService`, hence the basic-auth path; it applies power transitions with a
+short simulated delay that the driver's wait loop absorbs. The `--fake` backend needs
+no libvirt/QEMU and no nested KVM, so it runs on a stock GitHub runner (pip-install +
+self-started subprocess — no Docker, no `services:` container). The fixture also honors
+`KVM_PILOT_REDFISH_URL` so the same tests can run against an already-running emulator —
+the local-Docker fallback (`quay.io/metal3-io/sushy-tools`) when sushy-tools isn't on
+PATH.
+
 ### Kept the 4 unimplemented sensing protocols (`BootProgress`, `Sensors`, `SerialConsole`, `Watchdog`)
 They landed with zero implementers, which reads like dead code. Kept on purpose:
 they are the documented seam for BMC drivers, and they're no longer speculative —
@@ -28,12 +79,6 @@ sets no hint, so its 404s stay generic (see `test_stock_pikvm_404_is_a_plain_err
 `GLKVM_QUIRKS` is seeded with the single documented quirk and grows from real
 testing (`source="observed"`). Never invent firmware-version-specific data — the
 project's honesty rule (alpha, untested on hardware) applies to the quirk DB too.
-
-### `RedfishDriver` is library/registry-only, not on the CLI `--driver` list
-A BMC is capability-partial (no HID/Video; no `hard_cycle`/`watch_events`), so CLI
-subcommands like `type`/`snapshot`/`events` would `AttributeError`. It's exposed via
-`make_driver("redfish")`; the CLI entry waits on capability-aware dispatch
-([#27](https://github.com/DustinTrap/kvm-pilot/issues/27)).
 
 ### Redfish action POSTs keep the default retry (on transient errors)
 Reviewers flagged retrying non-idempotent POSTs (reset/insert). Kept: those ops are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ packages = ["src/kvm_pilot"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+markers = [
+    "integration: opt-in end-to-end tests against an external Redfish emulator (sushy-tools); skipped unless sushy-emulator is installed or KVM_PILOT_REDFISH_URL is set",
+]
 
 [tool.coverage.run]
 source = ["kvm_pilot"]

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -25,22 +25,30 @@ import argparse
 import json
 import logging
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .__about__ import __version__
 from .client import KVMClient
 from .config import resolve_host
 from .drivers import make_driver_from_config
-from .errors import KVMPilotError, SafetyError
+from .drivers.base import Capability
+from .errors import CapabilityError, KVMPilotError, SafetyError
 from .safety import allow_all, interactive_confirm
 
 if TYPE_CHECKING:
-    # Either built-in driver the CLI can drive — both implement the surface the
-    # subcommands use (power, HID, snapshot, events, capabilities, ...).
+    # Drivers the CLI can construct. KVMClient (PiKVM family) and FakeDriver expose
+    # the full HID/Video/Events surface the subcommands call; RedfishDriver is
+    # capability-partial (a BMC — strong on structured state, but no keyboard or
+    # screen), so capability-specific subcommands gate on supports() before
+    # dispatch instead of AttributeError-ing deep in a handler.
     from .drivers.fake import FakeDriver
+    from .drivers.redfish import RedfishDriver
+
+    AnyDriver = KVMClient | FakeDriver | RedfishDriver
+    RichDriver = KVMClient | FakeDriver
 
 
-def _build_client(args) -> KVMClient | FakeDriver:
+def _build_client(args) -> AnyDriver:
     confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
     dry_run = getattr(args, "dry_run", False)
     cfg = resolve_host(
@@ -54,6 +62,7 @@ def _build_client(args) -> KVMClient | FakeDriver:
         totp_secret=getattr(args, "totp_secret", None),
         verify_ssl=getattr(args, "verify_ssl", None),
         driver=getattr(args, "driver", None),
+        redfish_auth=getattr(args, "redfish_auth", None),
     )
     # Shared with the MCP server so cfg.driver is honored the same way everywhere.
     return make_driver_from_config(cfg, confirm=confirm, dry_run=dry_run)
@@ -71,23 +80,67 @@ def _make_analyzer(kvm: KVMClient | FakeDriver, args):
     return ScreenAnalyzer(kvm, backend)
 
 
+# -- capability dispatch ---------------------------------------------------
+#
+# Drivers advertise capabilities structurally (drivers.base), so each subcommand
+# declares the one it needs and the dispatcher fails cleanly when the active
+# driver lacks it — the seam that lets a capability-partial driver (e.g.
+# --driver redfish, a BMC with no HID/Video) coexist with the full-featured
+# PiKVM family.
+
+
+def _driver_label(kvm) -> str:
+    # "RedfishDriver" -> "redfish": the registry kind, derived from the class so
+    # the kind names aren't copied into a second map to keep in sync.
+    return type(kvm).__name__.removesuffix("Driver").lower()
+
+
+def _client(args, capability: Capability) -> AnyDriver:
+    """Build the driver and fail cleanly if it can't serve this subcommand.
+
+    The required capability is checked up front — a structural, network-free probe
+    (``supports()``) — so a command a device lacks exits 1 with a clear message
+    instead of ``AttributeError``-ing deep in the handler. The subcommand name for
+    the message comes from ``args.command`` (the argparse ``dest``).
+    """
+    kvm = _build_client(args)
+    if not kvm.supports(capability):
+        raise CapabilityError(
+            f"'{args.command}' needs the {capability.value} capability, which the "
+            f"{_driver_label(kvm)} driver does not provide"
+        )
+    return kvm
+
+
+def _rich_client(args, capability: Capability) -> RichDriver:
+    """``_client`` for subcommands that use the full HID/Video/Events surface.
+
+    Gating on HID/Video/Events excludes RedfishDriver — the only capability-partial
+    driver, and the only one lacking those — leaving the PiKVM-family/Fake surface
+    that carries the convenience kwargs (``slow=``, ``quality=``, ``stream=``) the
+    minimal capability protocols don't declare. The cast records that narrowing for
+    the type checker (see docs/decisions.md).
+    """
+    return cast("RichDriver", _client(args, capability))
+
+
 # -- subcommand handlers ---------------------------------------------------
 
 def cmd_info(args) -> int:
-    kvm = _build_client(args)
+    kvm = _client(args, Capability.SYSTEM_INFO)
     print(json.dumps(kvm.get_info(), indent=2, default=str))
     return 0
 
 
 def cmd_snapshot(args) -> int:
-    kvm = _build_client(args)
+    kvm = _rich_client(args, Capability.VIDEO)
     out = kvm.snapshot_save(args.output)
     print(f"Saved {out}")
     return 0
 
 
 def cmd_power(args) -> int:
-    kvm = _build_client(args)
+    kvm = _client(args, Capability.POWER)
     action = {
         "on": kvm.power_on,
         "off": kvm.power_off,
@@ -100,33 +153,33 @@ def cmd_power(args) -> int:
 
 
 def cmd_power_cycle(args) -> int:
-    kvm = _build_client(args)
+    kvm = _client(args, Capability.POWER)
     kvm.hard_cycle()
     print("hard power cycle: requested")
     return 0
 
 
 def cmd_type(args) -> int:
-    kvm = _build_client(args)
+    kvm = _rich_client(args, Capability.HID)
     kvm.type_text(args.text, slow=args.slow)
     return 0
 
 
 def cmd_key(args) -> int:
-    kvm = _build_client(args)
+    kvm = _rich_client(args, Capability.HID)
     kvm.press_key(args.key)
     return 0
 
 
 def cmd_mount(args) -> int:
-    kvm = _build_client(args)
+    kvm = _client(args, Capability.VIRTUAL_MEDIA)
     name = kvm.mount_iso(args.source, image_name=args.name, cdrom=not args.usb)
     print(f"mounted: {name}")
     return 0
 
 
 def cmd_classify(args) -> int:
-    kvm = _build_client(args)
+    kvm = _rich_client(args, Capability.VIDEO)
     analyzer = _make_analyzer(kvm, args)
     state = analyzer.classify(hint=args.hint or "")
     print(json.dumps(state.to_dict(), indent=2, default=str))
@@ -134,7 +187,7 @@ def cmd_classify(args) -> int:
 
 
 def cmd_watch(args) -> int:
-    kvm = _build_client(args)
+    kvm = _rich_client(args, Capability.VIDEO)
     analyzer = _make_analyzer(kvm, args)
 
     def _progress(state, elapsed):
@@ -153,8 +206,6 @@ def cmd_watch(args) -> int:
 
 
 def cmd_capabilities(args) -> int:
-    from .drivers.base import Capability
-
     kvm = _build_client(args)
     caps = kvm.capabilities()  # structural; makes no network call
     # Print in the capability enum's declaration order for stable output.
@@ -167,7 +218,7 @@ def cmd_capabilities(args) -> int:
 
 
 def cmd_events(args) -> int:
-    kvm = _build_client(args)
+    kvm = _rich_client(args, Capability.EVENTS)
     try:
         seen = 0
         for evt in kvm.watch_events(stream=not args.no_stream, timeout=args.duration):
@@ -190,9 +241,10 @@ def cmd_events(args) -> int:
 # -- parser ----------------------------------------------------------------
 
 def _add_common(p: argparse.ArgumentParser) -> None:
-    p.add_argument("--driver", choices=["pikvm", "glkvm", "blikvm", "fake"],
+    p.add_argument("--driver", choices=["pikvm", "glkvm", "blikvm", "redfish", "fake"],
                    help="Device driver (overrides KVM_PILOT_DRIVER / config profile; "
-                        "default pikvm; 'glkvm' = GL.iNet GLKVM fork, 'fake' = no hardware)")
+                        "default pikvm; 'glkvm' = GL.iNet GLKVM fork, 'redfish' = a DMTF "
+                        "Redfish BMC (no HID/Video — capability-partial), 'fake' = no hardware)")
     p.add_argument("--host")
     p.add_argument("--user")
     p.add_argument("--passwd")
@@ -200,6 +252,9 @@ def _add_common(p: argparse.ArgumentParser) -> None:
     p.add_argument("--scheme", choices=["http", "https"])
     p.add_argument("--profile", help="Named host profile from the config file")
     p.add_argument("--totp-secret", dest="totp_secret")
+    p.add_argument("--redfish-auth", dest="redfish_auth", choices=["session", "basic"],
+                   help="Redfish HTTP auth mode (default session; use 'basic' for a BMC or "
+                        "emulator without a SessionService). Ignored by non-redfish drivers.")
     p.add_argument("--verify-ssl", dest="verify_ssl", action="store_true", default=None)
     p.add_argument("--dry-run", dest="dry_run", action="store_true",
                    help="Log destructive actions without sending them")

--- a/src/kvm_pilot/config.py
+++ b/src/kvm_pilot/config.py
@@ -36,6 +36,10 @@ class HostConfig:
     timeout: float = 30.0
     totp_secret: str | None = None
     driver: str = "pikvm"
+    # Redfish-only: HTTP auth mode ("session" — the BMC default — or "basic", for
+    # endpoints without a SessionService, e.g. emulators or BMCs with session
+    # auth disabled). Ignored by the PiKVM family.
+    redfish_auth: str = "session"
 
 
 def _load_file(path: Path) -> dict[str, Any]:
@@ -57,6 +61,7 @@ def resolve_host(
     totp_secret: str | None = None,
     verify_ssl: bool | None = None,
     driver: str | None = None,
+    redfish_auth: str | None = None,
     config_path: Path | None = None,
 ) -> HostConfig:
     """Resolve a HostConfig from args > env > file (in that priority)."""
@@ -103,6 +108,7 @@ def resolve_host(
         timeout=float(pick("timeout", timeout, "KVM_PILOT_TIMEOUT", 30.0)),
         totp_secret=pick("totp_secret", totp_secret, "KVM_PILOT_TOTP_SECRET"),
         driver=resolved_driver,
+        redfish_auth=pick("redfish_auth", redfish_auth, "KVM_PILOT_REDFISH_AUTH", "session"),
     )
 
 

--- a/src/kvm_pilot/drivers/__init__.py
+++ b/src/kvm_pilot/drivers/__init__.py
@@ -118,13 +118,14 @@ def make_driver(kind: str = "pikvm", **conf: object) -> KVMDriver:
 
 def make_driver_from_config(
     cfg: HostConfig, *, confirm: Callable[[str, str], bool] | None = None, dry_run: bool = False
-) -> KVMClient | FakeDriver:
+) -> KVMClient | FakeDriver | RedfishDriver:
     """Build the driver named by ``cfg.driver`` from a resolved ``HostConfig``.
 
     Shared by the CLI and the MCP server so a profile/env that pins
     ``driver = "glkvm"`` is honored everywhere — not just via ``--driver``. It is
-    shape-aware (the fake driver takes no credentials; the PiKVM family builds via
-    ``from_config``), unlike a raw ``make_driver(**all_fields)`` call.
+    shape-aware (the fake driver takes no credentials; the PiKVM family and the
+    Redfish BMC build via ``from_config``), unlike a raw ``make_driver(**all_fields)``
+    call.
     """
     kind = cfg.driver
     if kind == "fake":
@@ -137,9 +138,13 @@ def make_driver_from_config(
 
         cls = {"pikvm": PiKVMDriver, "glkvm": GLKVMDriver, "blikvm": BliKVMDriver}[kind]
         return cls.from_config(cfg, confirm=confirm, dry_run=dry_run)
+    if kind == "redfish":
+        from .redfish import RedfishDriver
+
+        return RedfishDriver.from_config(cfg, confirm=confirm, dry_run=dry_run)
     raise KVMPilotError(
         f"Driver {kind!r} does not support from-config construction here "
-        "(supported: pikvm, glkvm, blikvm, fake). Build it directly with "
+        "(supported: pikvm, glkvm, blikvm, redfish, fake). Build it directly with "
         f"make_driver({kind!r}, ...) from the library."
     )
 

--- a/src/kvm_pilot/drivers/redfish/driver.py
+++ b/src/kvm_pilot/drivers/redfish/driver.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...errors import CapabilityError, KVMPilotError, TimeoutError
 from ...safety import SafetyPolicy
@@ -42,6 +42,9 @@ from ...vision.base import (
 )
 from ..base import CapabilityMixin
 from .transport import RedfishHTTP
+
+if TYPE_CHECKING:
+    from ...config import HostConfig
 
 logger = logging.getLogger("kvm_pilot.redfish")
 
@@ -133,6 +136,36 @@ class RedfishDriver(CapabilityMixin):
         # (insert, eject, slot) keyed by cdrom flag — CD vs removable media differ.
         self._vm: dict[bool, tuple[str, str, str]] = {}
         self._log_entries_uri: str | None = None
+
+    @classmethod
+    def from_config(
+        cls,
+        cfg: HostConfig,
+        *,
+        confirm: Callable[[str, str], bool] | None = None,
+        dry_run: bool = False,
+        max_retries: int = 3,
+    ) -> RedfishDriver:
+        """Build a driver from a resolved :class:`~kvm_pilot.config.HostConfig`.
+
+        Mirrors ``PiKVMDriver.from_config`` so the CLI and MCP server construct a
+        BMC the same way they build a PiKVM. ``totp_secret`` has no Redfish
+        analogue (a BMC authenticates with HTTP Basic or a Redfish session), so it
+        is ignored here.
+        """
+        return cls(
+            cfg.host,
+            cfg.user,
+            cfg.passwd,
+            port=cfg.port,
+            scheme=cfg.scheme,
+            verify_ssl=cfg.verify_ssl,
+            timeout=cfg.timeout,
+            auth=cfg.redfish_auth,
+            dry_run=dry_run,
+            confirm=confirm,
+            max_retries=max_retries,
+        )
 
     # -- discovery -------------------------------------------------------
 
@@ -413,6 +446,24 @@ class RedfishDriver(CapabilityMixin):
             "reset_hard", "redfish.reset_hard",
             f"HARD reset {self.host} (data loss risk)", wait, None,
         )
+
+    def hard_cycle(self, off_delay: float = 0.0, on_delay: float = 0.0) -> None:
+        """Force off then power on — a full off→on cycle.
+
+        A BMC has no ATX double-tap, so this composes the two gated power ops.
+        Both already block on the real PowerState transition (``power_off_hard``
+        waits for Off, ``power_on`` waits for On), so no fixed settle delay is
+        needed; ``off_delay``/``on_delay`` are optional caller-tunable pauses,
+        defaulting to none. Lets every POWER driver answer ``power-cycle``
+        uniformly (signature mirrors ``FakeDriver.hard_cycle``).
+        """
+        logger.info("Hard power cycling %s via Redfish", self.host)
+        self.power_off_hard()
+        if off_delay:
+            time.sleep(off_delay)
+        self.power_on()
+        if on_delay:
+            time.sleep(on_delay)
 
     # -- BootProgress ----------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,3 +54,15 @@ def client(fake_http):
     c = KVMClient("fake", "admin", "secret")
     c._http = fake_http
     return c
+
+
+@pytest.fixture
+def emu():
+    """A running pure-stdlib fake DMTF Redfish service (see redfish_emulator.py).
+
+    Shared by the RedfishDriver tests and the CLI ``--driver redfish`` tests.
+    """
+    from redfish_emulator import RedfishEmulator
+
+    with RedfishEmulator() as e:
+        yield e

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,86 @@
+"""Fixtures for the opt-in external-emulator integration tests.
+
+These validate ``--driver redfish`` against an *independent* reference Redfish
+implementation — DMTF-conformant sushy-tools (``sushy-emulator --fake``) — rather
+than the project's own in-process emulator, so spec assumptions shared by our
+driver and our mock can't hide a bug.
+
+The fixture sources an emulator three ways, in priority order:
+  1. ``KVM_PILOT_REDFISH_URL`` — an already-running emulator (e.g. a local
+     ``docker run … quay.io/metal3-io/sushy-tools``).
+  2. ``sushy-emulator`` on ``PATH`` — started here as a ``--fake`` subprocess on
+     an ephemeral port (this is the CI path: ``pip install sushy-tools``).
+  3. neither — the tests ``skip`` (so the default suite stays hermetic).
+
+The ``--fake`` driver needs no libvirt/QEMU and no nested KVM, so it runs on a
+stock GitHub-hosted runner.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+import urllib.request
+
+import pytest
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_healthy(url: str, proc: subprocess.Popen | None, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc is not None and proc.poll() is not None:
+            out = proc.stdout.read() if proc.stdout else ""
+            raise RuntimeError(f"sushy-emulator exited early (rc={proc.returncode}):\n{out}")
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310 - localhost http
+                if resp.status == 200:
+                    return
+        except OSError:
+            pass
+        time.sleep(0.5)  # back off on both a non-200 and a connection error
+    raise RuntimeError(f"emulator at {url} did not become healthy within {timeout}s")
+
+
+@pytest.fixture(scope="session")
+def redfish_emulator_url() -> str:
+    url = os.environ.get("KVM_PILOT_REDFISH_URL")
+    if url:
+        _wait_healthy(url.rstrip("/") + "/redfish/v1/", None)
+        yield url.rstrip("/")
+        return
+
+    exe = shutil.which("sushy-emulator")
+    if not exe:
+        pytest.skip(
+            "external Redfish emulator unavailable: set KVM_PILOT_REDFISH_URL or "
+            "`pip install sushy-tools` so sushy-emulator is on PATH"
+        )
+
+    port = _free_port()
+    proc = subprocess.Popen(  # noqa: S603 - fixed argv, trusted binary from PATH
+        [exe, "--fake", "-i", "127.0.0.1", "-p", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        _wait_healthy(base + "/redfish/v1/", proc)
+        yield base
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/integration/test_redfish_external.py
+++ b/tests/integration/test_redfish_external.py
@@ -1,0 +1,83 @@
+"""End-to-end ``--driver redfish`` against an external reference emulator.
+
+Marked ``integration`` and skipped unless an emulator is available (see
+``conftest.py``). The point of running against sushy-tools rather than the
+in-process ``redfish_emulator`` is *independence*: an externally-authored,
+DMTF-conformant implementation can expose assumptions our driver and our own mock
+happen to share (``@odata`` shapes, UUID member ids, action target URLs, the
+async ``TaskService``/``202`` flow).
+
+sushy-tools' ``--fake`` driver has no SessionService, so we authenticate with
+HTTP Basic (``--redfish-auth basic``) — the same path a BMC with session auth
+disabled would need. It applies power transitions with a short simulated delay,
+which the driver's wait loop absorbs; that delay is exactly why state assertions
+go through ``power_on()``/``power_off_hard()`` (which block on the real GET) and
+not a fire-and-forget call.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+
+import pytest
+
+from kvm_pilot.cli import main
+from kvm_pilot.drivers.redfish import RedfishDriver
+from kvm_pilot.safety import allow_all
+
+pytestmark = pytest.mark.integration
+
+
+def _parts(url: str) -> tuple[str, int, str]:
+    u = urllib.parse.urlparse(url)
+    return u.hostname or "127.0.0.1", u.port or (443 if u.scheme == "https" else 80), u.scheme
+
+
+def _cli(url: str, *rest: str) -> list[str]:
+    host, port, scheme = _parts(url)
+    return [*rest, "--driver", "redfish", "--redfish-auth", "basic",
+            "--host", host, "--port", str(port), "--scheme", scheme]
+
+
+def _driver(url: str) -> RedfishDriver:
+    host, port, scheme = _parts(url)
+    return RedfishDriver(host, "admin", "password", port=port, scheme=scheme,
+                         auth="basic", confirm=allow_all)
+
+
+def test_cli_info_talks_to_external_reference(redfish_emulator_url, capsys):
+    rc = main(_cli(redfish_emulator_url, "info"))
+    assert rc == 0
+    info = json.loads(capsys.readouterr().out)
+    # An independent Redfish service answered through the whole CLI -> driver ->
+    # HTTP -> hypermedia-discovery chain.
+    assert info["manufacturer"]
+    assert info["redfish_version"]
+
+
+def test_cli_capabilities_match_the_bmc_set(redfish_emulator_url, capsys):
+    rc = main(_cli(redfish_emulator_url, "capabilities"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "power" in out and "system_info" in out
+    assert "hid" not in out and "video" not in out  # a BMC has neither
+
+
+def test_cli_capability_gate_fires_against_external_reference(redfish_emulator_url, capsys):
+    # #27's core guarantee, proven against an independent BMC: a HID command on a
+    # capability-partial driver exits 1 cleanly (the gate runs before any network).
+    rc = main(_cli(redfish_emulator_url, "type", "hello"))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "hid" in err and "redfish" in err
+
+
+def test_power_transitions_are_reflected_on_get(redfish_emulator_url):
+    # The independent corroboration our own mock can't give: a real reset POST
+    # drives PowerState, observed back via a fresh GET.
+    driver = _driver(redfish_emulator_url)
+    driver.power_on()
+    assert driver.is_powered_on() is True
+    driver.power_off_hard()
+    assert driver.is_powered_on() is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,12 +121,60 @@ def test_driver_defaults_to_pikvm_when_unset(monkeypatch):
 
 
 def test_unsupported_driver_via_env_is_a_clean_error(monkeypatch, capsys):
-    # The CLI can't dispatch redfish generically yet; a config/env selection must
-    # produce a clean error (exit 1), not a crash.
-    monkeypatch.setenv("KVM_PILOT_DRIVER", "redfish")
+    # An unknown driver kind (no from-config support) must produce a clean error
+    # (exit 1), not a crash.
+    monkeypatch.setenv("KVM_PILOT_DRIVER", "ipmi")
     rc = main(["info", "--host", "h"])
     assert rc == 1
     assert "does not support" in capsys.readouterr().err
+
+
+def test_driver_redfish_builds_redfish_driver():
+    # --driver redfish is now a CLI choice and constructs a RedfishDriver
+    # (construction only; login is lazy so no network call here).
+    from kvm_pilot.cli import _build_client, build_parser
+    from kvm_pilot.drivers.redfish import RedfishDriver
+
+    args = build_parser().parse_args(["info", "--driver", "redfish", "--host", "h"])
+    kvm = _build_client(args)
+    assert isinstance(kvm, RedfishDriver)
+
+
+def test_redfish_capabilities_are_offline(capsys):
+    # capabilities() is structural — a BMC's set, no network, no key.
+    rc = main(["capabilities", "--driver", "redfish", "--host", "h"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "power" in out and "virtual_media" in out and "system_info" in out
+    assert "hid" not in out and "video" not in out  # a BMC has neither
+
+
+@pytest.mark.parametrize(
+    "argv, capability",
+    [
+        (["type", "hello", "--driver", "redfish", "--host", "h"], "hid"),
+        (["key", "Return", "--driver", "redfish", "--host", "h"], "hid"),
+        (["snapshot", "out.jpg", "--driver", "redfish", "--host", "h"], "video"),
+        (["classify", "--driver", "redfish", "--host", "h"], "video"),
+        (["watch", "grub_menu", "--driver", "redfish", "--host", "h"], "video"),
+        (["events", "--driver", "redfish", "--host", "h"], "events"),
+    ],
+)
+def test_capability_partial_driver_fails_cleanly(argv, capability, capsys, monkeypatch):
+    # The gate fires before any network call (and before the vision backend is
+    # built): a BMC lacks HID/Video/Events, so these subcommands exit 1 with a
+    # clear message instead of an AttributeError.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    rc = main(argv)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert capability in err and "redfish" in err
+
+
+def test_capability_gate_leaves_full_drivers_working(capsys):
+    # The fake driver has HID, so `type` still dispatches through the gate.
+    rc = main(["type", "hello world", "--driver", "fake"])
+    assert rc == 0
 
 
 def test_fake_via_env_needs_no_host(monkeypatch):

--- a/tests/test_cli_redfish.py
+++ b/tests/test_cli_redfish.py
@@ -1,0 +1,69 @@
+"""CLI ``--driver redfish`` end-to-end over the real transport against a fake BMC.
+
+Complements the offline dispatch tests in ``test_cli.py``: these drive the actual
+``main()`` entry point against the pure-stdlib Redfish emulator, so the whole
+chain — argparse → ``make_driver_from_config`` → ``RedfishDriver`` → ``RedfishHTTP``
+→ HTTP — is exercised for the subcommands a BMC *does* support (info, power,
+power-cycle, mount). No Docker, no hardware.
+
+The external best-in-class equivalent (sushy-tools) lives in
+``tests/integration/test_redfish_external.py``.
+"""
+
+from __future__ import annotations
+
+from kvm_pilot.cli import main
+from redfish_emulator import RESET
+
+# The `emu` fixture (a running RedfishEmulator) is shared from tests/conftest.py.
+
+
+def _argv(emu, *rest: str) -> list[str]:
+    return [*rest, "--driver", "redfish", "--host", emu.host,
+            "--port", str(emu.port), "--scheme", "http"]
+
+
+def _reset_types(emu) -> list[str]:
+    return [body.get("ResetType") for path, body in emu.state.posts if path == RESET]
+
+
+def test_cli_info_reports_bmc_identity(emu, capsys):
+    emu.state.power_state = "On"
+    rc = main(_argv(emu, "info"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ACME" in out and "Server 9000" in out  # from the emulator's ComputerSystem
+
+
+def test_cli_power_on_drives_real_state(emu):
+    emu.state.power_state = "Off"
+    rc = main(_argv(emu, "power", "on", "--yes"))
+    assert rc == 0
+    assert emu.state.power_state == "On"
+    assert _reset_types(emu) == ["On"]
+
+
+def test_cli_power_cycle_forces_off_then_on(emu):
+    # power-cycle works on a BMC via RedfishDriver.hard_cycle (force off -> on),
+    # the method added so every POWER driver answers the command uniformly.
+    emu.state.power_state = "On"
+    rc = main(_argv(emu, "power-cycle", "--yes"))
+    assert rc == 0
+    assert emu.state.power_state == "On"
+    assert _reset_types(emu) == ["ForceOff", "On"]
+
+
+def test_cli_mount_inserts_virtual_media(emu):
+    iso = "http://srv/imgs/ubuntu-24.04.iso"
+    rc = main(_argv(emu, "mount", iso, "--yes"))
+    assert rc == 0
+    assert emu.state.inserted is True
+    assert emu.state.last_image == iso
+
+
+def test_cli_mount_is_gated_under_dry_run(emu):
+    # The insert is destructive; --dry-run logs without sending it (--yes so the
+    # confirm step, which runs before the dry-run skip, is non-interactive).
+    rc = main(_argv(emu, "mount", "http://srv/x.iso", "--yes", "--dry-run"))
+    assert rc == 0
+    assert emu.state.inserted is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,27 @@ def test_driver_from_profile(tmp_path):
     assert resolve_host("gl", config_path=f).driver == "glkvm"
 
 
+def test_redfish_auth_precedence(monkeypatch, tmp_path):
+    monkeypatch.delenv("KVM_PILOT_REDFISH_AUTH", raising=False)
+    none = tmp_path / "none.toml"
+    assert resolve_host(host="h", config_path=none).redfish_auth == "session"  # BMC default
+    monkeypatch.setenv("KVM_PILOT_REDFISH_AUTH", "basic")
+    assert resolve_host(host="h", config_path=none).redfish_auth == "basic"  # env
+    assert resolve_host(  # arg wins
+        host="h", redfish_auth="session", config_path=none
+    ).redfish_auth == "session"
+
+
+def test_redfish_auth_threads_into_driver():
+    # from_config must hand the resolved auth mode to the RedfishHTTP transport,
+    # so `--redfish-auth basic` actually selects HTTP Basic.
+    from kvm_pilot.config import HostConfig
+    from kvm_pilot.drivers.redfish import RedfishDriver
+
+    d = RedfishDriver.from_config(HostConfig(host="h", driver="redfish", redfish_auth="basic"))
+    assert d._http._auth == "basic"
+
+
 def test_profile_from_file(tmp_path):
     f = tmp_path / "config.toml"
     f.write_text(

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -139,11 +139,16 @@ def test_make_driver_from_config_dispatches_on_cfg_driver() -> None:
     import pytest
 
     from kvm_pilot.config import HostConfig
-    from kvm_pilot.drivers import FakeDriver, make_driver_from_config
+    from kvm_pilot.drivers import FakeDriver, RedfishDriver, make_driver_from_config
     from kvm_pilot.drivers.pikvm import GLKVMDriver
     from kvm_pilot.errors import KVMPilotError
 
     assert isinstance(make_driver_from_config(HostConfig(host="h", driver="glkvm")), GLKVMDriver)
     assert isinstance(make_driver_from_config(HostConfig(host="h", driver="fake")), FakeDriver)
+    # redfish now builds via RedfishDriver.from_config (construction only, lazy login).
+    assert isinstance(
+        make_driver_from_config(HostConfig(host="h", driver="redfish")), RedfishDriver
+    )
+    # A genuinely unknown kind still raises a clean, actionable error.
     with pytest.raises(KVMPilotError, match="does not support"):
-        make_driver_from_config(HostConfig(host="h", driver="redfish"))
+        make_driver_from_config(HostConfig(host="h", driver="ipmi"))

--- a/tests/test_redfish_driver.py
+++ b/tests/test_redfish_driver.py
@@ -14,13 +14,9 @@ from kvm_pilot.drivers.base import Capability
 from kvm_pilot.drivers.redfish.transport import RedfishHTTP
 from kvm_pilot.errors import AuthError, CapabilityError, KVMPilotError, SafetyError
 from kvm_pilot.safety import deny_all
-from redfish_emulator import RESET, VM_EJECT, VM_INSERT, RedfishEmulator
+from redfish_emulator import RESET, VM_EJECT, VM_INSERT
 
-
-@pytest.fixture
-def emu():
-    with RedfishEmulator() as e:
-        yield e
+# The `emu` fixture (a running RedfishEmulator) is shared from tests/conftest.py.
 
 
 def make(emu, **kw) -> RedfishDriver:


### PR DESCRIPTION
Closes #27.

## What
Make every capability-specific subcommand check `kvm.supports(<capability>)` before dispatch and fail cleanly, then add `redfish` to the `--driver` choices. This hardens dispatch for any capability-partial driver and unlocks `--driver redfish` end-to-end.

## Why this is the right shape
A BMC has no HID/Video/Events, and `RedfishDriver` doesn't implement `hard_cycle`/`watch_events`, so `type`/`snapshot`/`events`/`power-cycle` would `AttributeError`. Now:

- **`_client(args, cap)` / `_rich_client(args, cap)`** — build the driver and reject it with a clear message + exit 1 when it lacks the capability (e.g. `'type' needs the hid capability, which the redfish driver does not provide`). The command name comes from `args.command`; `_rich_client` narrows to the PiKVM-family/Fake surface for the subcommands that use rich kwargs (`slow=`, `quality=`, `stream=`).
- **`RedfishDriver.hard_cycle`** (force-off → on) so the invariant *advertises `POWER` ⇒ `power-cycle` works* holds for every power driver. Settle delays default to `0.0` (the gated power ops already block on the real `PowerState`).
- **`RedfishDriver.from_config`** + a `redfish` branch in the shared `make_driver_from_config`, so `cfg.driver = "redfish"` is honored by both the CLI and the MCP server.
- **`--redfish-auth {session,basic}`** (default `session`, the BMC norm). `basic` is required for endpoints without a `SessionService` — emulators, and BMCs with session auth disabled (cf. #29).

## Tested with best-in-class emulators (no hardware)
Two layers:

1. **Default hermetic suite** — `test_cli_redfish.py` drives `main()` over real HTTP against the project's in-process Redfish emulator (info / power / power-cycle / mount / dry-run), plus offline gating tests for `type`/`key`/`snapshot`/`classify`/`watch`/`events`.
2. **Opt-in `integration` job** — validates `--driver redfish` against the **external, DMTF-conformant** [`sushy-tools`](https://opendev.org/openstack/sushy-tools) reference emulator (`sushy-emulator --fake`), an independently-authored implementation. The `--fake` backend needs **no QEMU/libvirt and no nested KVM**, so it runs on a stock `ubuntu-latest` runner (pip-install + self-started subprocess; the fixture also honors `KVM_PILOT_REDFISH_URL` for a local-Docker fallback).

Validated locally against a live `sushy-emulator --fake`: `info`, `capabilities`, the capability gate (`type` → exit 1), and the power state machine (reset POSTs reflected on a fresh GET).

## Checks
`ruff` · `mypy` · `pytest` (162 pass, 4 integration skipped without the emulator) · `bandit` · `pip-audit` — all green. Non-obvious choices (the rich-driver cast, per-driver `hard_cycle` vs a future `PowerMixin`, the auth selector, the two-layer test strategy) are recorded in `docs/decisions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)