### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.xml
@@ -46,8 +46,8 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build sdist and wheel
         run: |
           python -m pip install --upgrade pip build
           python -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -28,7 +28,7 @@ jobs:
     permissions:
       id-token: write   # trusted publishing (OIDC) — no API token in secrets
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## What
CI is warning on every run that `actions/checkout@v4` and `actions/setup-python@v5` are being force-migrated off the deprecated Node 20 runtime. Bump all first-party actions to their current Node-24 majors across both workflows.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-python` | v5 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/download-artifact` | v4 | **v8** |

All four target majors are confirmed `using: node24` (verified against each action's `action.yml`). Usage is vanilla — no changed inputs — so this is a runtime-only bump.

## Notes
- `release.yml`'s `upload`/`download-artifact` pair stays on the post-v4 artifact backend, so the build to publish round-trip is preserved (PyPI Trusted Publishing untouched). `release.yml` only runs on a published Release, so it isn't exercised by this PR's CI — the change is vanilla name/path inputs.
- Overlap with #34: that PR adds a `redfish-integration` job; I've bumped its action refs there too so neither PR reintroduces a Node-20 reference. Whichever merges second may need a trivial `ci.yml` rebase (both sides set the same versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
