### PR TITLE
refactor(redfish): drop no-op guards in hard_cycle settle delays

### DIFF
--- a/src/kvm_pilot/drivers/redfish/driver.py
+++ b/src/kvm_pilot/drivers/redfish/driver.py
@@ -459,11 +459,9 @@ class RedfishDriver(CapabilityMixin):
         """
         logger.info("Hard power cycling %s via Redfish", self.host)
         self.power_off_hard()
-        if off_delay:
-            time.sleep(off_delay)
+        time.sleep(off_delay)
         self.power_on()
-        if on_delay:
-            time.sleep(on_delay)
+        time.sleep(on_delay)
 
     # -- BootProgress ----------------------------------------------------
 


### PR DESCRIPTION
time.sleep(0.0) is already a no-op, so the `if off_delay:` / `if on_delay:` guards added nothing. Calling time.sleep() unconditionally also aligns RedfishDriver.hard_cycle with the real-hardware sibling KVMClient.hard_cycle, removing a third distinct style in the power family.