### PR TITLE
feat(glkvm): document observed ATX-power-always-off quirk (GL-RM1PE)

### DIFF
--- a/src/kvm_pilot/drivers/pikvm.py
+++ b/src/kvm_pilot/drivers/pikvm.py
@@ -67,6 +67,23 @@ GLKVM_QUIRKS: list[Quirk] = [
         firmware="all",
         source="documented",
     ),
+    Quirk(
+        id="atx-power-state-always-off",
+        summary=(
+            "GL-RM1PE ATX sensing is not wired like a stock PiKVM: /api/atx "
+            "reports power='off', enabled=false, and both power/hdd LEDs false "
+            "even while the host is fully powered on and booted. ATX power state "
+            "and LEDs are therefore unreliable on this hardware."
+        ),
+        workaround=(
+            "Do not trust ATX power/LED readings on GLKVM; infer host state from "
+            "the video stream (a screenshot / vision classification) instead. "
+            "This also means power on/off/cycle cannot be confirmed via ATX — "
+            "verify the result visually."
+        ),
+        firmware="4.82",
+        source="observed",
+    ),
 ]
 
 

--- a/tests/test_pikvm_family.py
+++ b/tests/test_pikvm_family.py
@@ -88,3 +88,14 @@ def test_known_quirks_offline_with_explicit_firmware():
     # No network: pass a firmware string directly.
     quirks = GLKVMDriver("h").known_quirks(firmware="anything")
     assert any(q.id == "api-disabled-by-default" for q in quirks)
+
+
+def test_observed_atx_power_quirk_matches_its_firmware():
+    # Observed on a GL-RM1PE running kvmd 4.82: ATX reports power='off' while the
+    # host is booted. It is firmware-scoped, so it matches 4.82 but not others.
+    on_482 = GLKVMDriver("h").known_quirks(firmware="4.82")
+    by_id = {q.id: q for q in on_482}
+    assert "atx-power-state-always-off" in by_id
+    assert by_id["atx-power-state-always-off"].source == "observed"
+    other = {q.id for q in GLKVMDriver("h").known_quirks(firmware="9.99")}
+    assert "atx-power-state-always-off" not in other


### PR DESCRIPTION
Adds an `observed`-source GLKVM quirk (firmware `4.82`): on the GL-RM1PE, `/api/atx` reports power off, `enabled=false`, and both LEDs false **even while the host is fully booted** — ATX sensing is not wired like a stock PiKVM. Workaround: infer host state from the video stream, and verify power actions visually. Includes a firmware-scoped test.

Observed on real hardware during a live GL-RM1PE to Dell T7610 session (which also surfaced that ATX power *control* returns HTTP 500 — no out-of-band reset).

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
