### PR TITLE
feat(health): device preflight healthcheck with severity gate (#80)

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -136,6 +136,21 @@ def info(profile: str | None = None) -> dict:
 
 
 @mcp.tool(annotations=_READ_ONLY)
+def healthcheck(profile: str | None = None) -> dict:
+    """Audit the device's readiness/recovery, security posture, and firmware (#80).
+
+    Read-only. Returns per-check findings with a tiered severity; a ``CRITICAL``
+    (e.g. no out-of-band reset path) is what should gate a subsequent destructive
+    op. The most valuable finding is ``recovery-path`` — whether a hung guest can
+    be reset at all when the KVM is remote.
+    """
+    with _driver(profile, confirm=deny_all, capability=Capability.SYSTEM_INFO) as (cfg, kvm):
+        from kvm_pilot.health import run_healthcheck
+
+        return {**_provenance(cfg), **run_healthcheck(kvm).to_dict()}
+
+
+@mcp.tool(annotations=_READ_ONLY)
 def power_state(profile: str | None = None) -> dict:
     """Return whether the host is powered on, plus ATX detail where the driver has it
     (read-only)."""

--- a/src/kvm_pilot/__init__.py
+++ b/src/kvm_pilot/__init__.py
@@ -35,6 +35,13 @@ from .errors import (
     UnavailableError,
     VisionError,
 )
+from .health import (
+    HealthGateError,
+    HealthReport,
+    Severity,
+    preflight,
+    run_healthcheck,
+)
 from .safety import SafetyPolicy, deny_all, interactive_confirm
 
 __all__ = [
@@ -62,4 +69,9 @@ __all__ = [
     "Capability",
     "KVMDriver",
     "make_driver",
+    "run_healthcheck",
+    "preflight",
+    "HealthReport",
+    "HealthGateError",
+    "Severity",
 ]

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -112,6 +113,18 @@ def _build_client(args) -> AnyDriver:
     return kvm
 
 
+def _skip_healthcheck(args) -> bool:
+    if getattr(args, "skip_healthcheck", False):
+        return True
+    return os.environ.get("KVM_PILOT_SKIP_HEALTHCHECK", "").lower() in ("1", "true", "yes")
+
+
+def _preflight_gate(kvm, confirm, *, skip: bool) -> None:
+    from .health import HealthCache, preflight
+
+    preflight(kvm, confirm=confirm, cache=HealthCache(), skip=skip)
+
+
 def _make_analyzer(kvm: KVMClient | FakeDriver, args):
     from .vision import ScreenAnalyzer, make_backend
 
@@ -153,6 +166,14 @@ def _client(args, capability: Capability) -> AnyDriver:
             f"'{args.command}' needs the {capability.value} capability, which the "
             f"{_driver_label(kvm)} driver does not provide"
         )
+    # Destructive subcommands set _preflight=True: gate them on the device
+    # healthcheck (#80), but only AFTER the capability check so a command the
+    # driver cannot serve still fails cleanly without any network probe. Dry-run
+    # and --skip-healthcheck bypass; --yes means the operator pre-approved, so a
+    # critical informs-and-proceeds rather than blocking.
+    if getattr(args, "_preflight", False) and not getattr(args, "dry_run", False):
+        confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
+        _preflight_gate(kvm, confirm, skip=_skip_healthcheck(args))
     return kvm
 
 
@@ -288,6 +309,40 @@ def cmd_watch(args) -> int:
     return 0
 
 
+def cmd_healthcheck(args) -> int:
+    from .health import Severity, run_healthcheck
+
+    kvm = _build_client(args)
+    report = run_healthcheck(kvm)
+    if getattr(args, "fix", False):
+        _apply_auto_fixes(kvm, report, args)
+        report = run_healthcheck(kvm)  # re-audit after fixes
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2, default=str))
+    else:
+        print(f"Healthcheck: {report.driver_kind}@{report.host} "
+              f"(firmware={report.firmware or '?'}) — worst: {report.worst}")
+        for r in report.results:
+            line = f"  [{str(r.severity):<8}] {r.pillar}: {r.title} — {r.detail}"
+            print(line)
+            if r.severity >= Severity.WARNING and r.remediation:
+                print(f"             ↳ {r.remediation}")
+    # Exit code reflects the worst finding: CRITICAL=2, WARNING=1, else 0.
+    if report.worst is Severity.CRITICAL:
+        return 2
+    if report.worst is Severity.WARNING:
+        return 1
+    return 0
+
+
+def _apply_auto_fixes(kvm, report, args) -> None:
+    confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
+    for r in report.results:
+        if r.auto_fix and r.auto_fix.safe_reversible:
+            if confirm("health.fix", f"Apply fix for {r.id}: {r.auto_fix.description}"):
+                r.auto_fix.apply(kvm)
+
+
 def cmd_capabilities(args) -> int:
     kvm = _build_client(args)
     caps = kvm.capabilities()  # structural; makes no network call
@@ -356,6 +411,9 @@ def _add_common(p: argparse.ArgumentParser) -> None:
                    help="Log destructive actions without sending them")
     p.add_argument("--yes", "-y", action="store_true",
                    help="Skip interactive confirmation on destructive actions")
+    p.add_argument("--skip-healthcheck", dest="skip_healthcheck", action="store_true",
+                   help="Skip the device preflight healthcheck gate before a "
+                        "destructive action (KVM_PILOT_SKIP_HEALTHCHECK=1 also works)")
 
 
 def _add_vision(p: argparse.ArgumentParser) -> None:
@@ -386,6 +444,14 @@ def build_parser() -> argparse.ArgumentParser:
     _add_common(p)
     p.set_defaults(func=cmd_capabilities)
 
+    p = sub.add_parser("healthcheck",
+                       help="Audit device readiness/security/firmware (#80)")
+    p.add_argument("--json", action="store_true", help="Emit the report as JSON")
+    p.add_argument("--fix", action="store_true",
+                   help="Offer to apply safe, reversible auto-fixes (with confirmation)")
+    _add_common(p)
+    p.set_defaults(func=cmd_healthcheck)
+
     p = sub.add_parser("snapshot", help="Save a screenshot")
     p.add_argument("output")
     _add_common(p)
@@ -408,33 +474,33 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("power", help="Power action")
     p.add_argument("action", choices=["on", "off", "off-hard", "reset"])
     _add_common(p)
-    p.set_defaults(func=cmd_power)
+    p.set_defaults(func=cmd_power, _preflight=True)
 
     p = sub.add_parser("power-cycle", help="Hard power cycle (off-hard -> on)")
     _add_common(p)
-    p.set_defaults(func=cmd_power_cycle)
+    p.set_defaults(func=cmd_power_cycle, _preflight=True)
 
     p = sub.add_parser("type", help="Type text on the host")
     p.add_argument("text")
     p.add_argument("--slow", action="store_true")
     _add_common(p)
-    p.set_defaults(func=cmd_type)
+    p.set_defaults(func=cmd_type, _preflight=True)
 
     p = sub.add_parser("key", help="Press a single key")
     p.add_argument("key")
     _add_common(p)
-    p.set_defaults(func=cmd_key)
+    p.set_defaults(func=cmd_key, _preflight=True)
 
     p = sub.add_parser("mount", help="Mount an ISO (local path or URL)")
     p.add_argument("source")
     p.add_argument("--name")
     p.add_argument("--usb", action="store_true")
     _add_common(p)
-    p.set_defaults(func=cmd_mount)
+    p.set_defaults(func=cmd_mount, _preflight=True)
 
     p = sub.add_parser("eject", help="Detach virtual media (the inverse of mount)")
     _add_common(p)
-    p.set_defaults(func=cmd_eject)
+    p.set_defaults(func=cmd_eject, _preflight=True)
 
     p = sub.add_parser("classify", help="Classify the current screen once")
     _add_common(p)

--- a/src/kvm_pilot/health.py
+++ b/src/kvm_pilot/health.py
@@ -1,0 +1,737 @@
+"""
+Device preflight healthcheck (issue #80).
+
+Audits a KVM device's **readiness/recovery**, **security posture**, and
+**firmware currency** before it is trusted for real work, then gates
+destructive/multi-step operations on the result.
+
+Design (see issue #80):
+
+* Every check returns a :class:`CheckResult` with a :class:`Severity`. A check
+  that does not apply to the active driver returns ``None`` and is skipped — a
+  driver never has to hand-maintain a check list, exactly like
+  ``known_quirks()``.
+* Severity is tiered: ``CRITICAL`` blocks a destructive op until it is
+  explicitly overridden; ``WARNING``/``INFO`` inform and proceed. In an
+  interactive run the operator is prompted (continue/abort); unattended, a
+  critical **fails closed** unless a stored acknowledgement exists.
+* Results are split into **stable posture** (``cacheable=True`` — firmware,
+  TLS, wiring/recovery-path; changes only via config/firmware) and **volatile
+  readiness** (``cacheable=False`` — media online, video/HID liveness; flips at
+  runtime). The cache accelerates the stable audit; volatile checks are always
+  re-probed live at point-of-use so a stale "OK" can never mask a runtime
+  change (the failure mode this whole feature exists to prevent).
+
+The module is stdlib-only and imports nothing from the drivers — it probes a
+driver purely through its public, **read-only** methods (never a
+``DESTRUCTIVE_OPS`` call), so it is safe to run on a live host.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import os
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .errors import KVMPilotError
+from .safety import ConfirmCallback
+
+__all__ = [
+    "Severity",
+    "Pillar",
+    "AutoFix",
+    "CheckResult",
+    "HealthReport",
+    "HealthGateError",
+    "run_healthcheck",
+    "enforce_gate",
+    "preflight",
+    "HealthCache",
+    "CHECKS",
+]
+
+
+class Severity(enum.IntEnum):
+    """Ordered so ``max(...)`` yields the worst result."""
+
+    OK = 0
+    INFO = 1
+    WARNING = 2
+    CRITICAL = 3
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.name
+
+
+class Pillar(enum.StrEnum):
+    READINESS = "readiness"
+    SECURITY = "security"
+    FIRMWARE = "firmware"
+
+
+class HealthGateError(KVMPilotError):
+    """Raised when a destructive op is blocked by an unacknowledged CRITICAL."""
+
+
+@dataclass(frozen=True)
+class AutoFix:
+    """An opt-in remediation the operator can choose to apply.
+
+    ``apply(driver)`` performs the fix. Only ``safe_reversible`` fixes are ever
+    applied automatically (with per-item consent); anything else is
+    report-only. A fix must never perturb a running guest.
+    """
+
+    description: str
+    safe_reversible: bool
+    apply: Callable[[Any], None]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    id: str
+    pillar: Pillar
+    severity: Severity
+    title: str
+    detail: str
+    remediation: str = ""
+    # Stable posture is cacheable; volatile readiness must be re-probed live.
+    cacheable: bool = True
+    auto_fix: AutoFix | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "pillar": str(self.pillar),
+            "severity": str(self.severity),
+            "title": self.title,
+            "detail": self.detail,
+            "remediation": self.remediation,
+            "cacheable": self.cacheable,
+            "auto_fix": self.auto_fix.description if self.auto_fix else None,
+        }
+
+
+@dataclass
+class HealthReport:
+    host: str
+    driver_kind: str
+    firmware: str | None
+    results: list[CheckResult] = field(default_factory=list)
+    ran_at: float = 0.0
+
+    @property
+    def worst(self) -> Severity:
+        return max((r.severity for r in self.results), default=Severity.OK)
+
+    @property
+    def criticals(self) -> list[CheckResult]:
+        return [r for r in self.results if r.severity is Severity.CRITICAL]
+
+    @property
+    def cache_key(self) -> str:
+        return f"{self.driver_kind}@{self.host}#{self.firmware or '?'}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "host": self.host,
+            "driver": self.driver_kind,
+            "firmware": self.firmware,
+            "ran_at": self.ran_at,
+            "worst": str(self.worst),
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Check helpers                                                               #
+# --------------------------------------------------------------------------- #
+
+# A check probes a driver and returns a result, or None if it does not apply.
+Check = Callable[[Any], "CheckResult | None"]
+
+_KNOWN_DEFAULT_CREDS = {("admin", "admin"), ("admin", "password"), ("root", "root")}
+
+
+def _driver_kind(driver: Any) -> str:
+    name = type(driver).__name__.lower()
+    for kind in ("glkvm", "blikvm", "redfish", "fake"):
+        if kind in name:
+            return kind
+    return "pikvm"
+
+
+def _firmware_of(driver: Any) -> str | None:
+    fn = getattr(driver, "get_firmware_info", None)
+    if fn is None:
+        return None
+    try:
+        return fn().get("version")
+    except KVMPilotError:
+        return None
+
+
+def _result(result: Any) -> dict[str, Any]:
+    """Unwrap a kvmd ``{"ok": ..., "result": {...}}`` envelope if present."""
+    if isinstance(result, dict) and "result" in result and isinstance(result["result"], dict):
+        return result["result"]
+    return result if isinstance(result, dict) else {}
+
+
+# --------------------------------------------------------------------------- #
+# Readiness / recovery checks (mostly volatile)                              #
+# --------------------------------------------------------------------------- #
+
+
+def check_api_reachable(driver: Any) -> CheckResult | None:
+    """The device answers and authenticates. Volatile: re-probe live."""
+    get_info = getattr(driver, "get_info", None)
+    if get_info is None:
+        return None
+    try:
+        get_info()
+    except KVMPilotError as exc:
+        return CheckResult(
+            id="api-reachable",
+            pillar=Pillar.READINESS,
+            severity=Severity.CRITICAL,
+            title="Device API reachable",
+            detail=f"{type(exc).__name__}: {exc}",
+            remediation="Check host/credentials/network; for GLKVM enable the REST API "
+            "in /etc/kvmd/nginx-kvmd.conf.",
+            cacheable=False,
+        )
+    return CheckResult(
+        id="api-reachable",
+        pillar=Pillar.READINESS,
+        severity=Severity.OK,
+        title="Device API reachable",
+        detail="Authenticated and responding.",
+        cacheable=False,
+    )
+
+
+def check_recovery_path(driver: Any) -> CheckResult | None:
+    """Is there ANY out-of-band reset if the guest hangs? (Stable posture.)
+
+    The highest-value check: a hung guest with no OOB reset can be bricked/
+    stranded when the KVM is remote. ATX being *enabled in kvmd* is not enough —
+    it must be wired to the host (GL rigs frequently are not).
+    """
+    supports = getattr(driver, "supports", None)
+    get_atx = getattr(driver, "get_atx_state", None)
+
+    if get_atx is None:
+        # No ATX surface (e.g. Redfish BMC or the fake driver). If the driver
+        # advertises POWER, its reset is genuine out-of-band (BMC/emulator).
+        try:
+            from .drivers.base import Capability
+
+            has_power = bool(supports and supports(Capability.POWER))
+        except Exception:  # pragma: no cover - defensive
+            has_power = False
+        if has_power:
+            return CheckResult(
+                id="recovery-path",
+                pillar=Pillar.READINESS,
+                severity=Severity.OK,
+                title="Out-of-band recovery path",
+                detail="Driver exposes out-of-band power/reset.",
+            )
+        return None
+
+    # PiKVM family: ATX must actually be wired to the host header.
+    atx_wired = False
+    try:
+        atx = _result(get_atx())
+        atx_wired = bool(atx.get("enabled"))
+    except KVMPilotError:
+        atx_wired = False
+
+    gpio_power = False
+    get_gpio = getattr(driver, "get_gpio_state", None)
+    if get_gpio is not None:
+        try:
+            outputs = _result(get_gpio()).get("state", {}).get("outputs", {})
+            gpio_power = bool(outputs)
+        except KVMPilotError:
+            gpio_power = False
+
+    if atx_wired or gpio_power:
+        how = "ATX" if atx_wired else "GPIO"
+        return CheckResult(
+            id="recovery-path",
+            pillar=Pillar.READINESS,
+            severity=Severity.OK,
+            title="Out-of-band recovery path",
+            detail=f"{how} power/reset control is wired.",
+        )
+    return CheckResult(
+        id="recovery-path",
+        pillar=Pillar.READINESS,
+        severity=Severity.CRITICAL,
+        title="Out-of-band recovery path",
+        detail="No out-of-band reset: ATX reports enabled=false and no GPIO power "
+        "channels are defined. A hung guest cannot be recovered remotely.",
+        remediation="Wire the ATX cable to the host front-panel power/reset header, "
+        "or provision a GPIO/Redfish/IPMI reset path.",
+    )
+
+
+def check_video_signal(driver: Any) -> CheckResult | None:
+    """Live video from the host. Volatile."""
+    fn = getattr(driver, "has_video_signal", None)
+    if fn is None:
+        return None
+    try:
+        alive = bool(fn())
+    except KVMPilotError:
+        alive = False
+    if alive:
+        return CheckResult(
+            id="video-signal",
+            pillar=Pillar.READINESS,
+            severity=Severity.OK,
+            title="Video signal",
+            detail="Capture stream is live.",
+            cacheable=False,
+        )
+    return CheckResult(
+        id="video-signal",
+        pillar=Pillar.READINESS,
+        severity=Severity.WARNING,
+        title="Video signal",
+        detail="No video signal from the host.",
+        remediation="Host may be powered off or the HDMI capture is disconnected.",
+        cacheable=False,
+    )
+
+
+def _reconnect_media(driver: Any) -> None:  # pragma: no cover - exercised via AutoFix test
+    driver.msd_disconnect()
+    time.sleep(0.5)
+    driver.msd_connect()
+
+
+def check_msd_online(driver: Any) -> CheckResult | None:
+    """Virtual media attached but not actually presented to the host. Volatile."""
+    fn = getattr(driver, "get_msd_state", None)
+    if fn is None:
+        return None
+    try:
+        msd = _result(fn())
+    except KVMPilotError:
+        return None
+    drive = msd.get("drive") or {}
+    image = drive.get("image")
+    online = msd.get("online")
+    if not image:
+        return CheckResult(
+            id="msd-online",
+            pillar=Pillar.READINESS,
+            severity=Severity.OK,
+            title="Virtual media",
+            detail="No image attached.",
+            cacheable=False,
+        )
+    if online:
+        return CheckResult(
+            id="msd-online",
+            pillar=Pillar.READINESS,
+            severity=Severity.OK,
+            title="Virtual media",
+            detail="Image attached and online (presented to host).",
+            cacheable=False,
+        )
+    fix = None
+    if hasattr(driver, "msd_disconnect") and hasattr(driver, "msd_connect"):
+        fix = AutoFix(
+            description="Re-select and reconnect the virtual media gadget.",
+            safe_reversible=True,
+            apply=_reconnect_media,
+        )
+    return CheckResult(
+        id="msd-online",
+        pillar=Pillar.READINESS,
+        severity=Severity.WARNING,
+        title="Virtual media",
+        detail="An image is attached but online=false — it is not presented to the "
+        "host, so a boot-from-media will fail.",
+        remediation="Enable virtual media on the device (GL firmware disables the "
+        "USB gadget separately), then reconnect.",
+        cacheable=False,
+        auto_fix=fix,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Security-posture checks (stable)                                           #
+# --------------------------------------------------------------------------- #
+
+
+def check_tls_posture(driver: Any) -> CheckResult | None:
+    http = getattr(driver, "_http", None)
+    if http is None:
+        return None
+    verify = getattr(http, "_verify_ssl", False)
+    ca = getattr(http, "_ssl_ca_file", None)
+    if verify or ca:
+        return CheckResult(
+            id="tls-posture",
+            pillar=Pillar.SECURITY,
+            severity=Severity.OK,
+            title="TLS verification",
+            detail="Certificate verification is enabled/pinned.",
+        )
+    return CheckResult(
+        id="tls-posture",
+        pillar=Pillar.SECURITY,
+        severity=Severity.WARNING,
+        title="TLS verification",
+        detail="TLS verification is disabled — credentials travel over an "
+        "unauthenticated channel (MITM-able).",
+        remediation="Pin the device certificate with ssl_ca_file / --ssl-ca-file, "
+        "or enable verify_ssl.",
+    )
+
+
+def check_default_creds(driver: Any) -> CheckResult | None:
+    http = getattr(driver, "_http", None)
+    if http is None:
+        return None
+    user = getattr(http, "_user", None)
+    passwd = getattr(http, "_passwd", None)
+    if (user, passwd) in _KNOWN_DEFAULT_CREDS:
+        return CheckResult(
+            id="default-creds",
+            pillar=Pillar.SECURITY,
+            severity=Severity.WARNING,
+            title="Default credentials",
+            detail=f"Authenticating as {user!r} with a well-known default password.",
+            remediation="Change the device password from its factory default.",
+        )
+    return CheckResult(
+        id="default-creds",
+        pillar=Pillar.SECURITY,
+        severity=Severity.OK,
+        title="Default credentials",
+        detail="Not using a known default password.",
+    )
+
+
+def check_exposed_services(driver: Any) -> CheckResult | None:
+    get_info = getattr(driver, "get_info", None)
+    if get_info is None:
+        return None
+    try:
+        info = _result(get_info())
+    except KVMPilotError:
+        return None
+    extras = info.get("extras")
+    if not isinstance(extras, dict):
+        return None
+    remote = {"vnc", "ipmi"}
+    enabled = sorted(
+        name
+        for name, meta in extras.items()
+        if isinstance(meta, dict) and meta.get("enabled")
+    )
+    exposed = [name for name in enabled if name in remote]
+    if exposed:
+        return CheckResult(
+            id="exposed-services",
+            pillar=Pillar.SECURITY,
+            severity=Severity.WARNING,
+            title="Exposed services",
+            detail=f"Broad-access services enabled: {', '.join(exposed)}.",
+            remediation="Disable unused remote-access services (VNC/IPMI) or "
+            "restrict them to the management network.",
+        )
+    return CheckResult(
+        id="exposed-services",
+        pillar=Pillar.SECURITY,
+        severity=Severity.INFO,
+        title="Exposed services",
+        detail=f"Enabled extras: {', '.join(enabled) or 'none'}.",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Firmware checks (stable)                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def check_firmware_report(driver: Any) -> CheckResult | None:
+    fn = getattr(driver, "get_firmware_info", None)
+    if fn is None:
+        return None
+    try:
+        fw = fn()
+    except KVMPilotError:
+        return None
+    version = fw.get("version")
+    model = fw.get("model")
+    return CheckResult(
+        id="firmware-report",
+        pillar=Pillar.FIRMWARE,
+        severity=Severity.INFO,
+        title="Firmware",
+        detail=f"model={model or '?'} kvmd/firmware={version or '?'}.",
+    )
+
+
+def check_firmware_quirks(driver: Any) -> CheckResult | None:
+    fn = getattr(driver, "known_quirks", None)
+    if fn is None:
+        return None
+    try:
+        quirks = fn()
+    except KVMPilotError:
+        return None
+    if not quirks:
+        return None
+    lines = "; ".join(f"{q.id} ({q.source})" for q in quirks)
+    remediation = " | ".join(q.workaround for q in quirks)
+    return CheckResult(
+        id="firmware-quirks",
+        pillar=Pillar.FIRMWARE,
+        severity=Severity.WARNING,
+        title="Known firmware quirks",
+        detail=f"{len(quirks)} quirk(s) apply to this firmware: {lines}.",
+        remediation=remediation,
+    )
+
+
+# The registry — each check self-guards, so the same list serves every driver.
+CHECKS: list[Check] = [
+    check_api_reachable,
+    check_recovery_path,
+    check_video_signal,
+    check_msd_online,
+    check_tls_posture,
+    check_default_creds,
+    check_exposed_services,
+    check_firmware_report,
+    check_firmware_quirks,
+]
+
+
+def run_healthcheck(driver: Any, *, checks: Iterable[Check] | None = None) -> HealthReport:
+    """Run every applicable check against ``driver`` and return a report."""
+    results: list[CheckResult] = []
+    for check in checks if checks is not None else CHECKS:
+        try:
+            res = check(driver)
+        except Exception as exc:  # a broken check must never crash the audit
+            res = CheckResult(
+                id=getattr(check, "__name__", "check"),
+                pillar=Pillar.READINESS,
+                severity=Severity.INFO,
+                title="Check error",
+                detail=f"{type(exc).__name__}: {exc}",
+                cacheable=False,
+            )
+        if res is not None:
+            results.append(res)
+    return HealthReport(
+        host=getattr(driver, "host", "?"),
+        driver_kind=_driver_kind(driver),
+        firmware=_firmware_of(driver),
+        results=results,
+        ran_at=_now(),
+    )
+
+
+def _now() -> float:
+    # Wrapped so tests can monkeypatch a deterministic clock.
+    return time.time()
+
+
+# --------------------------------------------------------------------------- #
+# Severity gate                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def enforce_gate(
+    report: HealthReport,
+    *,
+    confirm: ConfirmCallback | None = None,
+    skip: bool = False,
+    acknowledged: frozenset[str] = frozenset(),
+) -> None:
+    """Block a destructive op on unacknowledged CRITICAL findings.
+
+    ``skip`` bypasses the gate. Findings whose id is in ``acknowledged`` (a
+    stored override) are treated as accepted. With remaining criticals:
+
+    * ``confirm`` given (interactive) → prompt continue/abort.
+    * ``confirm`` None (automation) → **fail closed** (raise).
+    """
+    if skip:
+        return
+    pending = [c for c in report.criticals if c.id not in acknowledged]
+    if not pending:
+        return
+    summary = "; ".join(f"{c.title}: {c.detail}" for c in pending)
+    message = (
+        f"{len(pending)} CRITICAL health finding(s) on {report.cache_key}: {summary}"
+    )
+    if confirm is None:
+        raise HealthGateError(message)
+    if not confirm("health.gate", message):
+        raise HealthGateError(f"Operation aborted by operator. {message}")
+
+
+# --------------------------------------------------------------------------- #
+# Cache (stable posture only) + acknowledgements                            #
+# --------------------------------------------------------------------------- #
+
+
+def _cache_base_dir(name: str = os.name) -> str:
+    if name == "nt":  # pragma: no cover - platform specific
+        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
+        if base:
+            return base
+        return str(Path.home() / "AppData" / "Local")
+    return os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+
+
+def _default_cache_path() -> Path:
+    override = os.environ.get("KVM_PILOT_HEALTH_CACHE")
+    if override:
+        return Path(override).expanduser()
+    return Path(_cache_base_dir()) / "kvm-pilot" / "health-cache.json"
+
+
+class HealthCache:
+    """Persist the **stable** posture + operator acknowledgements per device.
+
+    Keyed by ``driver@host#firmware`` so a firmware change invalidates the entry
+    automatically — that is what catches the GL "an upgrade silently reverted my
+    settings" trap. Volatile results are never stored here.
+    """
+
+    def __init__(self, path: Path | None = None, *, max_age: float = 86400.0) -> None:
+        self.path = path or _default_cache_path()
+        self.max_age = max_age
+        self._data: dict[str, Any] = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            return json.loads(self.path.read_text())
+        except (OSError, ValueError):
+            return {}
+
+    def _save(self) -> None:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text(json.dumps(self._data, indent=2))
+        except OSError:  # pragma: no cover - best effort
+            pass
+
+    def stable_results(self, key: str, *, now: float | None = None) -> list[CheckResult] | None:
+        entry = self._data.get(key)
+        if not entry:
+            return None
+        clock = now if now is not None else _now()
+        if clock - entry.get("ran_at", 0.0) > self.max_age:
+            return None
+        out: list[CheckResult] = []
+        for r in entry.get("results", []):
+            out.append(
+                CheckResult(
+                    id=r["id"],
+                    pillar=Pillar(r["pillar"]),
+                    severity=Severity[r["severity"]],
+                    title=r["title"],
+                    detail=r["detail"],
+                    remediation=r.get("remediation", ""),
+                    cacheable=True,
+                )
+            )
+        return out
+
+    def store_stable(self, report: HealthReport) -> None:
+        self._data.setdefault(report.cache_key, {})
+        self._data[report.cache_key].update(
+            {
+                "ran_at": report.ran_at,
+                "results": [
+                    r.to_dict() for r in report.results if r.cacheable
+                ],
+            }
+        )
+        self._save()
+
+    def acknowledged(self, key: str) -> frozenset[str]:
+        entry = self._data.get(key) or {}
+        return frozenset(entry.get("acknowledged", []))
+
+    def acknowledge(self, key: str, ids: Iterable[str]) -> None:
+        entry = self._data.setdefault(key, {})
+        acks = set(entry.get("acknowledged", []))
+        acks.update(ids)
+        entry["acknowledged"] = sorted(acks)
+        self._save()
+
+
+def preflight(
+    driver: Any,
+    *,
+    confirm: ConfirmCallback | None = None,
+    skip: bool = False,
+    cache: HealthCache | None = None,
+    enforce: bool = True,
+) -> HealthReport:
+    """Run the audit (stable-from-cache + volatile-live) and enforce the gate.
+
+    Volatile checks always run live; stable checks are served from ``cache`` when
+    fresh, else run and re-cached. Returns the merged report; raises
+    :class:`HealthGateError` when a critical is unacknowledged (unless ``skip``).
+    """
+    if skip:
+        report = HealthReport(host=getattr(driver, "host", "?"), driver_kind=_driver_kind(driver), firmware=None)
+        return report
+
+    volatile_checks = [c for c in CHECKS if _is_volatile(c)]
+    stable_checks = [c for c in CHECKS if not _is_volatile(c)]
+
+    firmware = _firmware_of(driver)
+    key = f"{_driver_kind(driver)}@{getattr(driver, 'host', '?')}#{firmware or '?'}"
+
+    cached_stable = cache.stable_results(key) if cache is not None else None
+    if cached_stable is None:
+        stable = run_healthcheck(driver, checks=stable_checks).results
+    else:
+        stable = cached_stable
+
+    volatile = run_healthcheck(driver, checks=volatile_checks).results
+
+    report = HealthReport(
+        host=getattr(driver, "host", "?"),
+        driver_kind=_driver_kind(driver),
+        firmware=firmware,
+        results=stable + volatile,
+        ran_at=_now(),
+    )
+    if cache is not None and cached_stable is None:
+        cache.store_stable(report)
+
+    acknowledged = cache.acknowledged(key) if cache is not None else frozenset()
+    if enforce:
+        enforce_gate(report, confirm=confirm, acknowledged=acknowledged)
+    return report
+
+
+# Volatile checks are re-probed live every time; stable ones may come from cache.
+def _is_volatile(check: Check) -> bool:
+    return getattr(check, "__name__", "") in {
+        "check_api_reachable",
+        "check_video_signal",
+        "check_msd_online",
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,12 @@ def _no_external_network(monkeypatch):
     monkeypatch.setattr(socket.socket, "connect", guarded_connect)
 
 
+@pytest.fixture(autouse=True)
+def _isolated_health_cache(tmp_path, monkeypatch):
+    """Redirect the healthcheck cache to a per-test tmp file (never touch ~/.cache)."""
+    monkeypatch.setenv("KVM_PILOT_HEALTH_CACHE", str(tmp_path / "health-cache.json"))
+
+
 class FakeHTTP:
     """Records requests and returns canned results instead of hitting a network."""
 

--- a/tests/emulator.py
+++ b/tests/emulator.py
@@ -41,6 +41,10 @@ class FakeKVMState:
         self.fail_times = 0
         self.echo_password = False
         self.api_disabled = False  # GL firmware: every /api/* returns 404
+        # Healthcheck knobs: ATX wiring, GPIO outputs, MSD state.
+        self.atx_enabled = True
+        self.gpio_outputs: dict[str, object] = {}
+        self.msd: dict[str, object] = {"online": False, "drive": {"image": None}}
         # Real kvmd 401s /api/* without valid X-KVMD-User/Passwd (or auth_token
         # cookie). Enforced by default so a dropped-credential regression fails.
         self.expected_user = "admin"
@@ -129,7 +133,16 @@ class _Handler(BaseHTTPRequestHandler):
                 "system": {"kvmd": {"version": "4.2-gl-test"}},
             })
         elif path == "/api/atx":
-            self._json({"leds": {"power": self._state.powered_on}})
+            self._json({
+                "enabled": self._state.atx_enabled,
+                "leds": {"power": self._state.powered_on},
+            })
+        elif path == "/api/gpio":
+            self._json({"state": {"outputs": self._state.gpio_outputs}})
+        elif path == "/api/msd":
+            self._json(self._state.msd)
+        elif path == "/api/streamer":
+            self._json({"source": {"online": True, "resolution": {"width": 1920, "height": 1080}}})
         elif path == "/api/streamer/snapshot":
             self._send(_FAKE_JPEG, ctype="image/jpeg")
         elif path == "/api/log":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -285,3 +285,69 @@ def test_cli_sensors_unsupported_on_pikvm_fails_cleanly(capsys):
     rc = main(["sensors", "--host", "h"])
     assert rc == 1
     assert "sensors" in capsys.readouterr().err
+
+
+# -- healthcheck command + destructive gate (#80) -------------------------- #
+
+
+def test_healthcheck_command_on_fake_driver(capsys):
+    from kvm_pilot.cli import main
+
+    rc = main(["healthcheck", "--driver", "fake"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Healthcheck: fake@" in out
+    assert "recovery-path" in out or "Out-of-band" in out
+
+
+def test_healthcheck_command_json(capsys):
+    import json as _json
+
+    from kvm_pilot.cli import main
+
+    rc = main(["healthcheck", "--driver", "fake", "--json"])
+    assert rc == 0
+    report = _json.loads(capsys.readouterr().out)
+    assert report["driver"] == "fake"
+    assert report["worst"] in {"OK", "INFO", "WARNING", "CRITICAL"}
+
+
+def test_destructive_gate_blocks_on_critical(monkeypatch, capsys):
+    # A driver whose recovery-path is CRITICAL must block a power action when
+    # unattended (no --yes -> interactive confirm, which fails closed with no TTY).
+    from kvm_pilot import cli
+
+    def fake_gate(kvm, confirm, *, skip):
+        from kvm_pilot.health import HealthGateError
+
+        if not skip:
+            raise HealthGateError("no out-of-band recovery path")
+
+    monkeypatch.setattr(cli, "_preflight_gate", fake_gate)
+    rc = cli.main(["power", "off-hard", "--driver", "fake"])
+    assert rc == 1  # HealthGateError is a KVMPilotError -> exit 1
+
+
+def test_destructive_gate_skipped_with_flag(monkeypatch):
+    from kvm_pilot import cli
+
+    calls = {"n": 0}
+
+    def fake_gate(kvm, confirm, *, skip):
+        calls["n"] += 1
+        assert skip is True  # --skip-healthcheck propagates
+
+    monkeypatch.setattr(cli, "_preflight_gate", fake_gate)
+    rc = cli.main(["power", "on", "--driver", "fake", "--yes", "--skip-healthcheck"])
+    assert rc == 0 and calls["n"] == 1
+
+
+def test_destructive_gate_not_run_in_dry_run(monkeypatch):
+    from kvm_pilot import cli
+
+    def boom(*a, **k):
+        raise AssertionError("preflight must not run under --dry-run")
+
+    monkeypatch.setattr(cli, "_preflight_gate", boom)
+    rc = cli.main(["power", "off-hard", "--driver", "fake", "--dry-run"])
+    assert rc == 0

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,313 @@
+"""Tests for the device preflight healthcheck (issue #80)."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from emulator import EmulatorServer
+from kvm_pilot.drivers.fake import FakeDriver
+from kvm_pilot.drivers.pikvm import GLKVMDriver
+from kvm_pilot.health import (
+    CheckResult,
+    HealthCache,
+    HealthGateError,
+    HealthReport,
+    Pillar,
+    Severity,
+    check_default_creds,
+    check_exposed_services,
+    check_msd_online,
+    check_recovery_path,
+    check_tls_posture,
+    enforce_gate,
+    preflight,
+    run_healthcheck,
+)
+
+
+def stub(**attrs):
+    """A minimal driver-shaped object; callables are set as bound-free lambdas."""
+    ns = types.SimpleNamespace(host="stub")
+    for k, v in attrs.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def gl(emu: EmulatorServer, **kw) -> GLKVMDriver:
+    d = GLKVMDriver("127.0.0.1", "admin", "s3cr3t", port=emu.port, scheme="http", **kw)
+    d._http._backoff_base = 0.0
+    return d
+
+
+# ---- framework ------------------------------------------------------------ #
+
+
+def test_severity_is_ordered_worst_last():
+    assert Severity.OK < Severity.INFO < Severity.WARNING < Severity.CRITICAL
+    assert max([Severity.OK, Severity.WARNING, Severity.INFO]) is Severity.WARNING
+
+
+def test_report_worst_and_criticals():
+    r_ok = CheckResult("a", Pillar.READINESS, Severity.OK, "t", "d")
+    r_crit = CheckResult("b", Pillar.READINESS, Severity.CRITICAL, "t", "d")
+    rep = HealthReport("h", "glkvm", "4.82", [r_ok, r_crit])
+    assert rep.worst is Severity.CRITICAL
+    assert rep.criticals == [r_crit]
+    assert rep.cache_key == "glkvm@h#4.82"
+    assert rep.to_dict()["worst"] == "CRITICAL"
+
+
+def test_empty_report_is_ok():
+    assert HealthReport("h", "fake", None).worst is Severity.OK
+
+
+# ---- individual check branches ------------------------------------------- #
+
+
+def test_recovery_path_critical_when_atx_unwired_and_no_gpio():
+    d = stub(
+        get_atx_state=lambda: {"enabled": False, "leds": {"power": False}},
+        get_gpio_state=lambda: {"state": {"outputs": {}}},
+    )
+    res = check_recovery_path(d)
+    assert res.severity is Severity.CRITICAL
+    assert "out-of-band" in res.detail.lower()
+
+
+def test_recovery_path_ok_when_atx_wired():
+    d = stub(get_atx_state=lambda: {"enabled": True})
+    assert check_recovery_path(d).severity is Severity.OK
+
+
+def test_recovery_path_ok_via_gpio_when_atx_off():
+    d = stub(
+        get_atx_state=lambda: {"enabled": False},
+        get_gpio_state=lambda: {"state": {"outputs": {"reset": {}}}},
+    )
+    res = check_recovery_path(d)
+    assert res.severity is Severity.OK
+    assert "GPIO" in res.detail
+
+
+def test_recovery_path_ok_for_power_capable_bmc_without_atx():
+    # No ATX surface but advertises POWER -> genuine OOB reset (BMC/fake).
+    assert check_recovery_path(FakeDriver()).severity is Severity.OK
+
+
+def test_tls_posture_warns_when_verification_disabled():
+    d = stub(_http=types.SimpleNamespace(_verify_ssl=False, _ssl_ca_file=None))
+    assert check_tls_posture(d).severity is Severity.WARNING
+
+
+def test_tls_posture_ok_when_pinned():
+    d = stub(_http=types.SimpleNamespace(_verify_ssl=False, _ssl_ca_file="/pki/dev.pem"))
+    assert check_tls_posture(d).severity is Severity.OK
+
+
+def test_default_creds_warns_on_known_default():
+    d = stub(_http=types.SimpleNamespace(_user="admin", _passwd="admin"))
+    assert check_default_creds(d).severity is Severity.WARNING
+
+
+def test_default_creds_ok_otherwise():
+    d = stub(_http=types.SimpleNamespace(_user="admin", _passwd="s3cr3t"))
+    assert check_default_creds(d).severity is Severity.OK
+
+
+def test_msd_online_warns_when_attached_but_offline():
+    d = stub(get_msd_state=lambda: {"online": False, "drive": {"image": {"name": "x.iso"}}})
+    res = check_msd_online(d)
+    assert res.severity is Severity.WARNING
+    assert res.cacheable is False
+    assert res.auto_fix is None  # this stub has no msd_connect/disconnect
+
+
+def test_msd_online_ok_when_no_image():
+    d = stub(get_msd_state=lambda: {"online": False, "drive": {"image": None}})
+    assert check_msd_online(d).severity is Severity.OK
+
+
+def test_msd_online_offers_autofix_when_reconnect_available():
+    d = stub(
+        get_msd_state=lambda: {"online": False, "drive": {"image": {"name": "x.iso"}}},
+        msd_connect=lambda: None,
+        msd_disconnect=lambda: None,
+    )
+    res = check_msd_online(d)
+    assert res.auto_fix is not None and res.auto_fix.safe_reversible
+
+
+def test_exposed_services_warns_on_vnc():
+    d = stub(get_info=lambda: {"extras": {"vnc": {"enabled": True}, "webterm": {"enabled": True}}})
+    res = check_exposed_services(d)
+    assert res.severity is Severity.WARNING
+    assert "vnc" in res.detail
+
+
+# ---- run_healthcheck ------------------------------------------------------ #
+
+
+def test_run_healthcheck_on_fake_is_all_ok():
+    rep = run_healthcheck(FakeDriver())
+    assert rep.driver_kind == "fake"
+    assert rep.worst is Severity.OK
+    assert {r.id for r in rep.results} >= {"api-reachable", "recovery-path"}
+
+
+def test_broken_check_does_not_crash_audit():
+    def boom(_driver):
+        raise RuntimeError("kaboom")
+
+    rep = run_healthcheck(FakeDriver(), checks=[boom])
+    assert rep.results[0].severity is Severity.INFO
+    assert "kaboom" in rep.results[0].detail
+
+
+# ---- gate ----------------------------------------------------------------- #
+
+
+def _crit_report():
+    return HealthReport(
+        "h", "glkvm", "4.82",
+        [CheckResult("recovery-path", Pillar.READINESS, Severity.CRITICAL, "t", "d")],
+    )
+
+
+def test_gate_fails_closed_unattended():
+    with pytest.raises(HealthGateError):
+        enforce_gate(_crit_report(), confirm=None)
+
+
+def test_gate_prompts_and_can_proceed():
+    enforce_gate(_crit_report(), confirm=lambda op, d: True)  # no raise
+
+
+def test_gate_aborts_when_operator_declines():
+    with pytest.raises(HealthGateError):
+        enforce_gate(_crit_report(), confirm=lambda op, d: False)
+
+
+def test_gate_skips_acknowledged_criticals():
+    enforce_gate(_crit_report(), confirm=None, acknowledged=frozenset({"recovery-path"}))
+
+
+def test_gate_skip_flag_bypasses():
+    enforce_gate(_crit_report(), confirm=None, skip=True)
+
+
+def test_gate_noop_when_no_criticals():
+    rep = HealthReport("h", "fake", None, [
+        CheckResult("x", Pillar.SECURITY, Severity.WARNING, "t", "d"),
+    ])
+    enforce_gate(rep, confirm=None)  # warnings never block
+
+
+# ---- cache ---------------------------------------------------------------- #
+
+
+def test_cache_roundtrip_only_stores_stable(tmp_path):
+    cache = HealthCache(tmp_path / "hc.json")
+    rep = HealthReport("h", "glkvm", "4.82", [
+        CheckResult("firmware-report", Pillar.FIRMWARE, Severity.INFO, "t", "d", cacheable=True),
+        CheckResult("video-signal", Pillar.READINESS, Severity.OK, "t", "d", cacheable=False),
+    ], ran_at=1000.0)
+    cache.store_stable(rep)
+    got = HealthCache(tmp_path / "hc.json").stable_results(rep.cache_key, now=1000.0)
+    assert [r.id for r in got] == ["firmware-report"]  # volatile not cached
+
+
+def test_cache_expires_after_max_age(tmp_path):
+    cache = HealthCache(tmp_path / "hc.json", max_age=10.0)
+    rep = HealthReport("h", "glkvm", "4.82",
+                       [CheckResult("firmware-report", Pillar.FIRMWARE, Severity.INFO, "t", "d")],
+                       ran_at=1000.0)
+    cache.store_stable(rep)
+    assert cache.stable_results(rep.cache_key, now=1005.0) is not None
+    assert cache.stable_results(rep.cache_key, now=2000.0) is None  # stale
+
+
+def test_cache_acknowledgements_persist(tmp_path):
+    cache = HealthCache(tmp_path / "hc.json")
+    cache.acknowledge("glkvm@h#4.82", ["recovery-path"])
+    assert "recovery-path" in HealthCache(tmp_path / "hc.json").acknowledged("glkvm@h#4.82")
+
+
+# ---- preflight (stable cache + volatile live + gate) ---------------------- #
+
+
+def test_preflight_reprobes_volatile_but_reuses_stable_cache(tmp_path):
+    cache = HealthCache(tmp_path / "hc.json")
+    # `quirks` counts the STABLE audit (known_quirks only runs inside a stable
+    # check); `api` counts the VOLATILE api-reachable check.
+    calls = {"api": 0, "quirks": 0}
+
+    def make_driver(video_ok):
+        def get_info():
+            calls["api"] += 1
+            return {}
+
+        def known_quirks(firmware=None):
+            calls["quirks"] += 1
+            return []
+
+        return stub(
+            get_info=get_info,
+            get_firmware_info=lambda: {"version": "1.0", "model": "M"},
+            known_quirks=known_quirks,
+            has_video_signal=lambda: video_ok,
+            supports=lambda cap: False,
+        )
+
+    # First run: populates the stable cache (stable audit runs once).
+    preflight(make_driver(True), cache=cache)
+    assert calls["quirks"] == 1
+    api_after_first = calls["api"]
+
+    # Second run: stable served from cache (audit NOT re-run), but the volatile
+    # api-reachable/video checks DO run live again.
+    rep = preflight(make_driver(False), cache=cache)
+    assert calls["quirks"] == 1  # stable cached -> audit not re-run
+    assert calls["api"] > api_after_first  # volatile re-probed live
+    video = next(r for r in rep.results if r.id == "video-signal")
+    assert video.severity is Severity.WARNING  # live change reflected, not stale OK
+
+
+def test_preflight_enforces_gate_on_critical(tmp_path):
+    d = stub(
+        get_info=lambda: {},
+        get_atx_state=lambda: {"enabled": False},
+        get_gpio_state=lambda: {"state": {"outputs": {}}},
+        has_video_signal=lambda: True,
+        supports=lambda cap: False,
+    )
+    with pytest.raises(HealthGateError):
+        preflight(d, cache=HealthCache(tmp_path / "hc.json"), confirm=None)
+
+
+# ---- GLKVM real-transport integration ------------------------------------ #
+
+
+@pytest.fixture()
+def emu():
+    with EmulatorServer() as server:
+        yield server
+
+
+def test_healthcheck_over_real_transport_glkvm(emu):
+    rep = run_healthcheck(gl(emu))
+    by_id = {r.id: r for r in rep.results}
+    # TLS off by default -> warning; firmware quirks surfaced; recovery-path OK (atx wired).
+    assert by_id["tls-posture"].severity is Severity.WARNING
+    assert by_id["recovery-path"].severity is Severity.OK
+    assert by_id["firmware-report"].severity is Severity.INFO
+    assert by_id["firmware-quirks"].severity is Severity.WARNING  # api-disabled quirk applies
+
+
+def test_recovery_path_critical_over_transport_when_atx_disabled(emu):
+    emu.state.atx_enabled = False
+    rep = run_healthcheck(gl(emu))
+    rec = next(r for r in rep.results if r.id == "recovery-path")
+    assert rec.severity is Severity.CRITICAL
+    assert rep.worst is Severity.CRITICAL

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -27,7 +27,7 @@ from mcp.client.stdio import stdio_client  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SERVER = REPO_ROOT / "mcp_server" / "server.py"
 
-EXPECTED_TOOLS = {"info", "power_state", "snapshot", "classify_screen", "power"}
+EXPECTED_TOOLS = {"info", "power_state", "snapshot", "classify_screen", "power", "healthcheck"}
 
 
 @pytest.fixture()
@@ -74,7 +74,7 @@ def result_json(result) -> dict:
     return json.loads(result.content[0].text)
 
 
-def test_handshake_lists_five_annotated_tools(config_file):
+def test_handshake_lists_annotated_tools(config_file):
     async def interact(session):
         return (await session.list_tools()).tools
 
@@ -86,6 +86,17 @@ def test_handshake_lists_five_annotated_tools(config_file):
     power = by_name["power"].annotations
     assert power.readOnlyHint is False
     assert power.destructiveHint is True
+
+
+def test_healthcheck_tool_returns_report(config_file):
+    async def interact(session):
+        return await session.call_tool("healthcheck", {})
+
+    result = run_session(server_env(config_file), interact)
+    parsed = result_json(result)
+    assert parsed["driver"] == "fake"
+    assert parsed["worst"] in {"OK", "INFO", "WARNING", "CRITICAL"}
+    assert any(r["id"] == "recovery-path" for r in parsed["results"])
 
 
 def test_power_errors_without_operator_gate(config_file):


### PR DESCRIPTION
Implements the device preflight healthcheck (#80): audit a KVM's **readiness/recovery**, **security posture**, and **firmware** before trusting it, and gate destructive ops on the result.

## What's here
- **`src/kvm_pilot/health.py`** — `Severity`/`Pillar`/`CheckResult`/`HealthReport`/`AutoFix`, nine self-guarding checks, the severity gate, and the stable-vs-volatile cache.
- **`recovery-path` check** (the crown jewel): is there ANY out-of-band reset if the guest hangs? Distinguishes ATX *wired* from merely *enabled*, checks GPIO/BMC — the exact "hung guest, no way back" case from #80's evidence.
- **Severity-tiered gate**: CRITICAL blocks until overridden; interactive prompts continue/abort, unattended fails closed unless acknowledged.
- **Stable-vs-volatile cache**: stable posture cached & invalidated on firmware change; volatile readiness (media-online, video/HID) always re-probed live so a stale OK can't mask a runtime change.
- **Surfaces**: `kvm-pilot healthcheck [--json] [--fix]`, a preflight gate on every destructive subcommand (after the capability check; bypass via `--dry-run`/`--skip-healthcheck`), an MCP `healthcheck` tool, and public API exports.

## Decisions (confirmed on #80)
All three pillars; severity-tiered gate; auto-on-connect (cached) + command + MCP; report-only with opt-in safe auto-fix.

## Tests
TDD in `tests/test_health.py` (every check branch, gate, cache split, preflight) + CLI/MCP integration; emulator extended to serve ATX-enabled/GPIO/MSD/streamer. **Full suite: 433 passed, 4 skipped; ruff + mypy clean; `health.py` 90% coverage.**

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)
