### PR TITLE
Preflight on first connect + firmware currency/capability registry (#80)

### DIFF
--- a/.github/ISSUE_TEMPLATE/firmware-report.yml
+++ b/.github/ISSUE_TEMPLATE/firmware-report.yml
@@ -1,0 +1,121 @@
+name: Firmware report
+description: Report the latest firmware for a device, or a known-bad firmware version, for the kvm-pilot firmware registry.
+title: "[firmware] "
+labels: ["firmware-report"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping keep the firmware registry current! This feeds
+        `health.check_firmware_currency`. On submit, a bot validates your entry and
+        opens a pull request automatically — no manual editing needed.
+
+        Use the **vendor** and **product** as `kvm-pilot healthcheck` / the device
+        reports them (run `kvm-pilot healthcheck --json` and read `firmware`). Versions
+        must use the same scheme the device reports (e.g. `4.82`, `7.10.30.00`, `2.78`).
+  - type: input
+    id: vendor
+    attributes:
+      label: Vendor
+      description: e.g. gl.inet, pikvm, dell, hpe, lenovo
+      placeholder: gl.inet
+    validations:
+      required: true
+  - type: input
+    id: product
+    attributes:
+      label: Product
+      description: A distinctive substring of the reported product/board (e.g. RV1126B, iDRAC9, iLO 5).
+      placeholder: RV1126B
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Submission type
+      options:
+        - Latest known release
+        - Known-bad firmware
+        - Capability profile
+    validations:
+      required: true
+  - type: input
+    id: latest
+    attributes:
+      label: Latest version (latest-known only)
+      description: The newest known release, in the device's own version scheme.
+      placeholder: "4.90"
+  - type: input
+    id: date
+    attributes:
+      label: Release date (latest-known only, YYYY-MM-DD)
+      placeholder: "2026-05-29"
+  - type: input
+    id: affected
+    attributes:
+      label: Affected versions (known-bad only)
+      description: A version spec — exact (4.82) or a range (<=4.82, <4.83, >=4.80, ==4.82).
+      placeholder: "<=4.82"
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity (known-bad only)
+      options:
+        - warning
+        - critical
+  - type: textarea
+    id: issue
+    attributes:
+      label: Issue / notes (known-bad only)
+      description: What is wrong with the affected firmware, and its impact.
+      placeholder: ATX sensing is unwired; no out-of-band reset path.
+  - type: input
+    id: fixed_in
+    attributes:
+      label: Fixed in (optional, known-bad)
+      placeholder: "4.83"
+  - type: markdown
+    attributes:
+      value: |
+        **Capability profile** (only for a "Capability profile" submission) — the
+        expected-UX differentiators a healthcheck can't safely detect live. Fill in
+        what you know now; you can file a follow-up report later to enrich it (e.g.
+        add virtual-media fidelity once you've actually booted an ISO).
+  - type: dropdown
+    id: mouse
+    attributes:
+      label: Mouse mode (profile only)
+      description: absolute = usable GUI pointer; relative = painful; none = keyboard only.
+      options:
+        - absolute
+        - relative
+        - none
+  - type: dropdown
+    id: vmedia
+    attributes:
+      label: Virtual-media fidelity (profile only)
+      description: reliable = ISO reaches the host; reports-only = API says mounted but host sees nothing; none = unsupported.
+      options:
+        - reliable
+        - reports-only
+        - none
+  - type: dropdown
+    id: power_state_trusted
+    attributes:
+      label: Power-state readings trusted (profile only)
+      description: Are ATX/LED power readings truthful? (false = don't automate blind reboots.)
+      options:
+        - "true"
+        - "false"
+  - type: input
+    id: video
+    attributes:
+      label: Video ceiling (profile only)
+      description: Transport + max mode, e.g. h264/1080p60, mjpeg/1080p30.
+      placeholder: h264/1080p60
+  - type: input
+    id: source
+    attributes:
+      label: Source URL
+      description: An authoritative link (vendor changelog, release notes, advisory). Required for latest-known and known-bad reports; optional for a capability profile.
+      placeholder: https://dl.gl-inet.com/kvm/rm1/stable

--- a/.github/workflows/firmware-ingest.yml
+++ b/.github/workflows/firmware-ingest.yml
@@ -1,0 +1,94 @@
+name: Firmware registry ingest
+
+# Runs at most once per hour (the cron is the rate cap), and does real work only
+# when there are pending `firmware-report` issues — an empty hour costs one cheap
+# `gh issue list` and stops. This is a courteous use of free public CI: a
+# per-open/edit trigger would run an obnoxious number of jobs. Dedup: issues
+# labelled `ingested` are skipped and the merge is idempotent, so a re-run never
+# churns. Free on public repos.
+
+on:
+  schedule:
+    - cron: "7 * * * *"      # at most once/hour (offset to dodge top-of-hour load)
+  workflow_dispatch: {}       # manual on-demand run
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: firmware-ingest
+  cancel-in-progress: false
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      # Cheap gate first — no checkout / no Python / no install on an empty hour.
+      - name: Collect pending firmware-report issues (skip already-ingested)
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh label create ingested --description "firmware report folded into the registry" --color ededed 2>/dev/null || true
+          gh issue list --search "label:firmware-report -label:ingested is:open" \
+            --json number,body --limit 200 > items.json
+          echo "count=$(jq length items.json)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: steps.collect.outputs.count != '0'
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        if: steps.collect.outputs.count != '0'
+        with:
+          python-version: "3.12"
+      - name: Install package
+        if: steps.collect.outputs.count != '0'
+        run: pip install -e .
+
+      - name: Ingest the batch
+        if: steps.collect.outputs.count != '0'
+        run: |
+          mv items.json items_in.json  # checkout replaced the workspace; keep the collected list
+          python -m kvm_pilot.firmware_registry \
+            --batch items_in.json \
+            --registry src/kvm_pilot/data/firmware_registry.json \
+            --today "$(date +%F)" \
+            --results results.json || true
+
+      - name: Comment each issue, label the ingested ones
+        if: steps.collect.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          jq -c '.[]' results.json | while read -r r; do
+            num=$(jq -r .number <<<"$r"); status=$(jq -r .status <<<"$r"); msg=$(jq -r .message <<<"$r")
+            case "$status" in
+              ingested) gh issue comment "$num" --body "✅ Queued in this hour's registry PR: $msg"; gh issue edit "$num" --add-label ingested ;;
+              noop)     gh issue comment "$num" --body "ℹ️ Already in the registry — nothing to change."; gh issue edit "$num" --add-label ingested ;;
+              invalid)  gh issue comment "$num" --body "❌ Couldn't ingest: $msg. Fix the issue and it retries next hour." ;;
+            esac
+          done
+
+      - name: Open one PR for the batch (only if the registry changed)
+        if: steps.collect.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet src/kvm_pilot/data/firmware_registry.json; then
+            echo "no registry change this run"; exit 0
+          fi
+          branch="firmware-ingest/$(date +%Y%m%d-%H)"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add src/kvm_pilot/data/firmware_registry.json
+          git commit -m "data(firmware): batched registry update $(date +%F' '%H:00)"
+          git push -f origin "$branch"
+          gh pr create \
+            --title "data(firmware): batched update $(date +%F' '%H:00)" \
+            --body "Automated hourly batch of \`firmware-report\` issues, validated by \`kvm_pilot.firmware_registry\`." \
+            --head "$branch" --base main \
+            || gh pr edit "$branch" --body "Updated $(date +%F' '%H:00)."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,15 @@ any docs or messaging; do not claim features are "tested" or "beta".
   `DESTRUCTIVE_OPS` in `src/kvm_pilot/safety.py` and routed through
   `self.safety.guard(op, description)`. A vision classification must never trigger
   a destructive action on its own.
+- **Preflight before trust (issue #80).** Bringing a device into use — first
+  connection, adding a managed profile, or ahead of any destructive/multi-step
+  flow — runs through the device `healthcheck` (`src/kvm_pilot/health.py`;
+  `run_healthcheck`). It is the intake gate, and `#80`'s intent is that it
+  auto-runs *on first connection*, not only before destructive ops. Today only
+  the destructive-subcommand path auto-gates (`cli.py` `_preflight_gate`) and the
+  MCP server does not auto-run it at all — until that gap is closed, the operating
+  procedure (`skill/SKILL.md`, `mcp_server/README.md`) requires running it
+  explicitly on first contact. Don't treat a bare `info`/`snapshot` as vetting.
 - **Capabilities, not a monolith.** New device support = a driver implementing the
   relevant capability protocols in `src/kvm_pilot/drivers/base.py` (`Power`,
   `HID`, `Video`, `VirtualMedia`, `GPIO`, `Events`, `SystemInfo`). See

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ on every push to `main` — edit the files here, never the wiki directly).
 - [Configuration](configuration.md) — the config file, every `KVM_PILOT_*` env var, and precedence.
 - [Design decisions](decisions.md) — the "looks wrong but is intentional" record, newest first.
 - [Redfish reference](redfish.md) — the BMC driver: hypermedia navigation, auth, and firmware quirks.
+- [Firmware registry](firmware-registry.md) — the firmware-currency check, the community registry data model, and the GitHub-based single-source-of-truth + ingestion design (#80 follow-up).
 - [Claude skill](../skill/SKILL.md) — the bundled skill for driving `kvm-pilot` from Claude.
 - [MCP server](../mcp_server/README.md) — the experimental Model Context Protocol server.
 

--- a/docs/firmware-registry.md
+++ b/docs/firmware-registry.md
@@ -1,0 +1,126 @@
+# Firmware registry: currency, capability profile & ingestion (#80 follow-up)
+
+## The finding
+
+The device preflight healthcheck (#80) has a **firmware currency** pillar, but it
+was under-built: it reported the *running* version as `INFO` and listed known
+quirks, yet **never checked whether the firmware was current or known-bad**, and
+carried nothing about a device's *capabilities / expected experience*. #80 asked
+the pillar to "flag known-bad or EOL firmware **and available updates**." A device
+on outdated firmware (often the cause of the other findings) sailed through.
+
+## One generic mechanism for every family
+
+A device is identified by the `{vendor, product, version}` its driver's
+`get_firmware_info()` normalizes. The *only* vendor-specific knowledge — how to
+read the version off the box — lives in the driver:
+
+| driver | vendor | product | version (the comparable one) |
+|---|---|---|---|
+| `glkvm` | `gl.inet` | reported board (`Rockchip RV1126B-P …`) | kvmd version (`4.82`) |
+| `pikvm` / `blikvm` | `pikvm` / `blikvm` | reported board | kvmd version |
+| `redfish` | `Manufacturer` (Dell/HPE/…) | Manager `Model` (`iDRAC 9`, `iLO 5`) | Manager `FirmwareVersion` |
+
+The registry and the checks stay 100% generic. Adding IPMI or AMT later is just a
+new driver returning the same three fields — **no change to the registry or the
+checks**. (On the PiKVM family a device can't report its *product* firmware
+version, so kvmd is the currency proxy; on BMCs the reported version *is* the
+upgradeable one.)
+
+## Data model (`data/firmware_registry.json`, schema v2)
+
+```jsonc
+{
+  "schema_version": 2,
+  "updated": "YYYY-MM-DD",
+  "firmware": [
+    {
+      "vendor": "dell",                  // == get_firmware_info().vendor (case-insensitive)
+      "product": "iDRAC9",               // substring of get_firmware_info().product
+      "latest": "7.10.30.00",            // latest known release (device's own scheme)
+      "source": "https://…", "date": "2026-05-01",
+      "known_bad": [
+        {"affected": "<=6.10.30.00", "severity": "critical",
+         "issue": "…", "fixed_in": "6.10.80.00", "source": "https://…"}
+      ],
+      "profile": {                       // capability / expected-UX (all optional, incrementally enriched)
+        "mouse": "absolute",            // absolute | relative | none  → GUI usability
+        "vmedia": "reports-only",       // reliable | reports-only | none → boot-from-ISO fidelity (#77)
+        "power_state_trusted": false,   // are ATX/LED readings truthful → safe to automate reboots?
+        "video": "h264/1080p60"         // rated transport + ceiling (fallback when unreadable live)
+      }
+    }
+  ]
+}
+```
+
+### Why these `profile` fields (and only these)
+
+The report a user actually wants — *what can this do and how good is the
+experience* — has ~5 axes, but most are **detectable live** by the healthcheck
+(video codec/res/fps from `/api/streamer`, recovery path, exposed services). We
+store **only the differentiators a live probe can't safely determine**:
+
+- **mouse** — absolute vs relative decides whether a GUI is usable; can't probe
+  without moving the pointer on a live host.
+- **vmedia** — `reports-only` is the #77 trap (API says mounted, host sees an
+  empty drive); can't probe without a reboot.
+- **power_state_trusted** — whether power/LED readings can be believed (the GL
+  quirk behind the `.18` no-recovery incident); a stored fact, not observable.
+- **video** — a fallback ceiling for devices whose stream API won't report it.
+
+Everything else on the report is computed live and combined. `get_firmware_info()`
+can auto-populate the observable half, so humans only supply these few facts —
+and can enrich them over time (an initial profile on first contact, a follow-up
+report adding `vmedia` once an ISO has actually been booted).
+
+## The checks (`health.py`, generic — no per-vendor branching)
+
+- `check_firmware_currency` — match `(vendor, product)`; then:
+  1. installed version satisfies a `known_bad.affected` range → that severity;
+  2. else `version < latest` (ordered `_vercmp`) → `WARNING` "update available";
+  3. else **nothing** — a current device stays quiet (no over-reporting).
+- `check_capability_profile` — surfaces the stored profile as the expected-UX
+  line: `INFO` when all-good, `WARNING` when any axis is degraded (relative/no
+  mouse, non-`reliable` vmedia, untrusted power).
+
+`_vercmp` compares each dot/dash segment numerically (correct for `4.82`,
+`7.10.30.00`, `2.78`); genuinely non-numeric schemes only ever compare equal and
+fall through to exact `known_bad` matches rather than a bogus ordering. Version
+strings in the registry must use the device's own scheme (write `4.90`, not `4.9`,
+if you mean build 90).
+
+## Distribution & refresh
+
+- **Bundled on PyPI.** `data/firmware_registry.json` ships in the wheel, so the
+  check works fully **offline** — the stdlib-only core never fetches on its own.
+- **Loader precedence** (`load_registry`): `KVM_PILOT_FIRMWARE_DB` (explicit
+  file) → the user cache a refresh writes (`~/.cache/kvm-pilot/`) → the bundled
+  copy. A missing or invalid override is skipped, so a bad refresh can never take
+  the check offline.
+- **Opt-in refresh** (not the default, never automatic): pull the latest registry
+  from `DEFAULT_DB_URL` (the repo's raw file on GitHub's CDN — the single source
+  of truth), validate it, and write it to the user cache. Explicit only —
+  air-gapped / mgmt-LAN use and privacy mean we don't phone home per run.
+
+## Ingestion — fully automated on GitHub (free on public repos)
+
+1. **Issue Form** (`.github/ISSUE_TEMPLATE/firmware-report.yml`) — a contributor
+   picks a submission type (latest release / known-bad / capability profile) and
+   fills structured fields.
+2. **Action** (`.github/workflows/firmware-ingest.yml`, gated on the
+   `firmware-report` label) runs `python -m kvm_pilot.firmware_registry`, which
+   parses the issue body **as data** (never eval'd), validates it, merges it, and
+   the workflow **opens a PR automatically** via `GITHUB_TOKEN`. Invalid
+   submissions comment the errors back on the issue; duplicates are a no-op.
+3. Profiles merge **field by field**, so partial/enriching reports accumulate.
+
+GitHub-hosted runners are free and unlimited for public repos; each run is
+seconds. The issue body is untrusted input, so a spam/injection issue just fails
+validation harmlessly.
+
+## Seed data
+
+The registry ships empty; real `(vendor, product)` entries are added through the
+ingestion pipeline (no fabricated firmware facts — see CLAUDE.md). The mechanism
+is verified end-to-end against a live GLKVM.

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -16,6 +16,7 @@ from the stdlib-only core library — it depends on the
 | Tool | Annotations | What it does |
 |---|---|---|
 | `info` | `readOnlyHint` | Device / system info |
+| `healthcheck` | `readOnlyHint` | **Preflight audit** of the KVM itself — readiness/recovery, security posture, firmware currency (issue #80). Run this **first, on connecting to any device**, before trusting it for real work; a `CRITICAL` (e.g. no out-of-band recovery path) should gate any subsequent destructive op |
 | `power_state` | `readOnlyHint` | `powered_on` plus ATX detail where the driver has it |
 | `snapshot` | `readOnlyHint` | Current screen, returned as a real JPEG **image** content block the model can see |
 | `classify_screen` | `readOnlyHint` | Boot/run phase via the vision backend (Anthropic or a local VLM, see below) |
@@ -29,18 +30,25 @@ device-side (a leaked session can lock operators out of the BMC).
 
 ### Which tools work with which driver
 
-| Driver kind | `info` | `power_state` | `snapshot` | `classify_screen` | `power` |
-|---|---|---|---|---|---|
-| `pikvm` / `glkvm` / `blikvm` | ✅ | ✅ (with ATX detail) | ✅ | ✅ | ✅ |
-| `redfish` (iDRAC, iLO, XCC, OpenBMC, …) | ✅ | ✅ | ❌ no video capability | ❌ no video capability | ✅ |
-| `fake` (in-process test double) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Driver kind | `info` | `healthcheck` | `power_state` | `snapshot` | `classify_screen` | `power` |
+|---|---|---|---|---|---|---|
+| `pikvm` / `glkvm` / `blikvm` | ✅ | ✅ | ✅ (with ATX detail) | ✅ | ✅ | ✅ |
+| `redfish` (iDRAC, iLO, XCC, OpenBMC, …) | ✅ | ✅ (checks it can't serve are omitted) | ✅ | ❌ no video capability | ❌ no video capability | ✅ |
+| `fake` (in-process test double) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 A tool the active driver cannot serve returns a clean MCP tool error naming
 the driver kind and the missing capability (it never `AttributeError`s).
 
 ## Safety model
 
-The gate is layered; no single layer is trusted on its own:
+**Preflight first.** On connecting to any device, call `healthcheck` before you
+trust it for real work (issue #80) — it surfaces readiness/recovery, security,
+and firmware risks up front (most importantly, whether there is *any* out-of-band
+recovery path if the guest hangs). A `CRITICAL` finding should gate the
+destructive `power` tool below. Note: the server does not yet auto-run this on
+connect, so the agent must call it as the first step.
+
+The `power` gate is layered; no single layer is trusted on its own:
 
 1. **Operator opt-in (the real gate).** The `power` tool is *disabled by
    default*. It only works when the human operator sets

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -26,6 +26,7 @@ hardware). Treat every result as unverified. See issue #7.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from collections.abc import Callable, Iterator
@@ -43,6 +44,7 @@ from kvm_pilot.safety import allow_all, deny_all
 from kvm_pilot.vision import ScreenAnalyzer, VisionBackend, make_backend
 
 mcp = FastMCP("kvm-pilot")
+_log = logging.getLogger("kvm_pilot.mcp")
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True)
 _DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False)
@@ -65,13 +67,21 @@ def _dry_run() -> bool:
 
 @contextmanager
 def _driver(
-    profile: str | None, *, confirm: Callable[[str, str], bool], capability: Capability
+    profile: str | None,
+    *,
+    confirm: Callable[[str, str], bool],
+    capability: Capability,
+    enforce_health: bool = False,
 ) -> Iterator[tuple[HostConfig, KVMDriver]]:
     """Resolve the profile, build its driver, and always close it afterwards.
 
     The capability gate is checked structurally (``supports()``, no network) so a
     tool the driver cannot serve fails with a clear MCP tool error instead of an
     ``AttributeError`` — e.g. a Redfish BMC has no video capture.
+
+    Runs the device preflight healthcheck (#80) on first connection: read-only
+    tools inform (once per device, non-blocking); ``enforce_health`` (the ``power``
+    tool) fails closed on an unacknowledged CRITICAL.
     """
     cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
     kvm = make_driver_from_config(cfg, confirm=confirm, dry_run=_dry_run())
@@ -81,11 +91,56 @@ def _driver(
                 f"the '{cfg.driver}' driver for host '{cfg.host}' does not provide the "
                 f"'{capability.value}' capability this tool needs"
             )
+        _preflight(kvm, enforce=enforce_health)
         yield cfg, kvm
     finally:
         close = getattr(kvm, "close", None)
         if close is not None:
             close()
+
+
+def _preflight(kvm: KVMDriver, *, enforce: bool) -> None:
+    """Audit the device on first connection (#80).
+
+    Skipped under dry-run or ``KVM_PILOT_SKIP_HEALTHCHECK``. When ``enforce``, a
+    CRITICAL fails closed (automation has no operator to prompt) and surfaces as a
+    tool error; otherwise findings are audited once per device and logged, never
+    blocking a read.
+    """
+    if _dry_run() or _env_flag("KVM_PILOT_SKIP_HEALTHCHECK"):
+        return
+    from kvm_pilot.health import (
+        HealthCache,
+        HealthGateError,
+        Severity,
+        preflight,
+        preflight_once,
+    )
+
+    cache = HealthCache()
+    if enforce:
+        try:
+            # confirm=None -> automation fails closed on an unacknowledged critical.
+            preflight(kvm, confirm=None, cache=cache, enforce=True)
+        except HealthGateError as exc:
+            raise ToolError(f"device preflight blocked this operation: {exc}") from exc
+        return
+    try:
+        report = preflight_once(kvm, cache=cache, enforce=False)
+    except Exception:  # noqa: BLE001 - an informational audit must never break a read
+        return
+    if report is None:
+        return
+    notable = [r for r in report.results if r.severity >= Severity.WARNING]
+    if notable:
+        _log.warning(
+            "preflight %s@%s: worst %s, %d finding(s): %s",
+            report.driver_kind,
+            report.host,
+            report.worst,
+            len(notable),
+            "; ".join(f"{r.title}: {r.detail}" for r in notable),
+        )
 
 
 def _provenance(cfg: HostConfig) -> dict:
@@ -204,7 +259,9 @@ def power(
         )
     if not confirm:
         raise ToolError(f"power {action!r} was not confirmed")
-    with _driver(profile, confirm=allow_all, capability=Capability.POWER) as (cfg, kvm):
+    with _driver(
+        profile, confirm=allow_all, capability=Capability.POWER, enforce_health=True
+    ) as (cfg, kvm):
         getattr(kvm, _POWER_ACTIONS[action])()
         if _dry_run():
             return (

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -33,9 +33,9 @@ client logic into a script.
 `kvm-pilot` MCP server is enabled, and if not, prompt the user to install and
 enable it.** It is the most efficient interface: `snapshot` returns the screen
 as a real image content block the model can see directly, and
-`info`/`power_state`/`classify_screen`/`power` are first-class tools with
-`readOnlyHint`/`destructiveHint` annotations the host can gate on — no shelling
-out, no screenshot-file round-trips, no ad-hoc `curl`. The CLI and Python
+`info`/`healthcheck`/`power_state`/`classify_screen`/`power` are first-class
+tools with `readOnlyHint`/`destructiveHint` annotations the host can gate on —
+no shelling out, no screenshot-file round-trips, no ad-hoc `curl`. The CLI and Python
 library below are **fallbacks** for when the MCP server isn't available or for
 capabilities it doesn't expose yet (mouse moves/clicks, MSD mode switching).
 
@@ -86,6 +86,30 @@ URL and model.
 **GLKVM devices:** the PiKVM REST API is disabled by default on GL firmware.
 The user must enable it in `/etc/kvmd/nginx-kvmd.conf` on the device first, or
 every call returns 404. A firmware upgrade can revert it.
+
+## First contact: run the healthcheck (preflight) — do this first
+
+**The moment you connect to a KVM — before you drive it, and before you record
+it as a "managed" profile — run the device healthcheck.** This is the intake
+gate, not an optional extra: it audits the KVM appliance *itself* (readiness /
+recovery, security posture, firmware currency) and is the safety net for the
+whole tool (issue #80). A preventable KVM-side fault during a remote
+power/boot/install can brick or strand a machine you can't physically reach.
+
+- **How:** MCP — call the `healthcheck` tool. CLI — `kvm-pilot healthcheck
+  --profile <name>`. Library — `run_healthcheck(driver)` from `kvm_pilot`.
+- **Treat it as a severity-tiered gate.** Surface every `WARNING`/`CRITICAL` to
+  the user with its implication; a `CRITICAL` **blocks** — do not proceed to a
+  destructive or multi-step flow until the user explicitly decides to continue.
+- **The highest-value finding is `recovery-path`** — whether *any* out-of-band
+  reset exists (ATX wired / GPIO / Redfish / IPMI) if the guest hangs. On GLKVM
+  units the ATX is frequently unwired, leaving only in-guest levers; the operator
+  must learn this *before* committing to a remote install, not mid-outage.
+- **Coverage caveat (know this):** destructive CLI subcommands auto-run the gate
+  (`--skip-healthcheck` / `KVM_PILOT_SKIP_HEALTHCHECK=1` bypasses it), but
+  **read-only intake — `info`/`capabilities`/`snapshot` — does _not_ auto-run it
+  yet.** So on first contact you must run `healthcheck` yourself; don't assume a
+  clean `info` means the device was vetted.
 
 ## Use the library, not raw HTTP
 
@@ -151,8 +175,10 @@ The CLI is a **fallback** — prefer the MCP server (see above) when it's
 enabled. Reach for the CLI for one-off checks, for capabilities the MCP server
 doesn't expose, or when no MCP host is in the loop.
 
-`kvm-pilot info | capabilities | snapshot | power | power-cycle | type | key |
-mount | eject | classify | watch | events`. `--dry-run` logs destructive
+`kvm-pilot info | capabilities | healthcheck | snapshot | power | power-cycle |
+type | key | mount | eject | classify | watch | events`. Run `healthcheck` on
+first contact (see above); it also auto-runs ahead of destructive subcommands.
+`--dry-run` logs destructive
 actions without sending them (it short-circuits before any prompt, so it is
 safe in automation); `--yes` skips the interactive y/N confirmation on a real
 run. See `kvm-pilot --help`.

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -125,6 +125,33 @@ def _preflight_gate(kvm, confirm, *, skip: bool) -> None:
     preflight(kvm, confirm=confirm, cache=HealthCache(), skip=skip)
 
 
+def _inform_on_connect(kvm, *, skip: bool) -> None:
+    """Audit a device once on first connection and print any findings (#80).
+
+    Non-blocking: read-only intake informs and proceeds (the destructive gate is
+    the blocker). Runs at most once per device per process; findings go to stderr
+    so JSON on stdout stays clean.
+    """
+    from .health import HealthCache, Severity, preflight_once
+
+    try:
+        report = preflight_once(kvm, cache=HealthCache(), enforce=False, skip=skip)
+    except Exception:  # noqa: BLE001 - an informational audit must never break the read
+        return
+    if report is None:
+        return
+    notable = [r for r in report.results if r.severity >= Severity.WARNING]
+    if not notable:
+        return
+    print(
+        f"preflight {report.driver_kind}@{report.host}: worst {report.worst}, "
+        f"{len(notable)} finding(s) — run `kvm-pilot healthcheck` for detail:",
+        file=sys.stderr,
+    )
+    for r in notable:
+        print(f"  [{r.severity}] {r.pillar}: {r.title} — {r.detail}", file=sys.stderr)
+
+
 def _make_analyzer(kvm: KVMClient | FakeDriver, args):
     from .vision import ScreenAnalyzer, make_backend
 
@@ -166,14 +193,20 @@ def _client(args, capability: Capability) -> AnyDriver:
             f"'{args.command}' needs the {capability.value} capability, which the "
             f"{_driver_label(kvm)} driver does not provide"
         )
-    # Destructive subcommands set _preflight=True: gate them on the device
-    # healthcheck (#80), but only AFTER the capability check so a command the
+    # Preflight healthcheck (#80), run AFTER the capability check so a command the
     # driver cannot serve still fails cleanly without any network probe. Dry-run
-    # and --skip-healthcheck bypass; --yes means the operator pre-approved, so a
-    # critical informs-and-proceeds rather than blocking.
-    if getattr(args, "_preflight", False) and not getattr(args, "dry_run", False):
-        confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
-        _preflight_gate(kvm, confirm, skip=_skip_healthcheck(args))
+    # and --skip-healthcheck bypass both paths.
+    if not getattr(args, "dry_run", False):
+        if getattr(args, "_preflight", False):
+            # Destructive subcommands: enforce the gate. --yes means the operator
+            # pre-approved, so a critical informs-and-proceeds rather than blocking.
+            confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
+            _preflight_gate(kvm, confirm, skip=_skip_healthcheck(args))
+        else:
+            # Read-only intake: audit the device on first connection and surface
+            # findings, but never block — a standing CRITICAL (e.g. no out-of-band
+            # recovery path) must not make a plain `info`/`snapshot` impossible.
+            _inform_on_connect(kvm, skip=_skip_healthcheck(args))
     return kvm
 
 

--- a/src/kvm_pilot/client.py
+++ b/src/kvm_pilot/client.py
@@ -80,6 +80,9 @@ class PiKVMDriver(PowerMixin, CapabilityMixin):
     # clear ApiDisabledError with device-specific guidance. None for stock PiKVM.
     _NOT_FOUND_HINT: str | None = None
 
+    # Vendor identity for the firmware registry; subclasses override (GL/BliKVM).
+    _vendor: str = "pikvm"
+
     # ATX power ops don't block on the state change, so hard_cycle (from
     # PowerMixin) settles between the off and on. Overridable per call.
     _hard_cycle_off_delay: float = 5.0
@@ -165,13 +168,20 @@ class PiKVMDriver(PowerMixin, CapabilityMixin):
 
         system = _sub(info, "system")
         kvmd = _sub(system, "kvmd")
-        platform = _sub(_sub(info, "hw"), "platform")
+        # GLKVM exposes platform under system.platform; stock PiKVM under hw.platform.
+        platform = _sub(system, "platform") or _sub(_sub(info, "hw"), "platform")
         version = kvmd.get("version")
+        product = platform.get("base") or platform.get("type")
         return {
             "version": version,
             "kvmd_version": version,
-            "platform": platform.get("base") or platform.get("type"),
+            "platform": product,
             "model": platform.get("model"),
+            # Normalized identity for the firmware registry (health.check_firmware_currency).
+            # The comparable version on the PiKVM family is kvmd's; a device does not
+            # report its GL/vendor product-firmware version, so kvmd is the currency proxy.
+            "vendor": self._vendor,
+            "product": product,
         }
 
     def check_api_enabled(self) -> dict:

--- a/src/kvm_pilot/data/firmware_registry.json
+++ b/src/kvm_pilot/data/firmware_registry.json
@@ -1,5 +1,15 @@
 {
   "schema_version": 2,
   "updated": "2026-07-02",
-  "firmware": []
+  "firmware": [
+    {
+      "vendor": "gl.inet",
+      "product": "RM1PE",
+      "profile": {
+        "mouse": "absolute",
+        "video": "h264/1080p60",
+        "power_state_trusted": false
+      }
+    }
+  ]
 }

--- a/src/kvm_pilot/data/firmware_registry.json
+++ b/src/kvm_pilot/data/firmware_registry.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 2,
+  "updated": "2026-07-02",
+  "firmware": []
+}

--- a/src/kvm_pilot/data/firmware_registry.schema.json
+++ b/src/kvm_pilot/data/firmware_registry.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "kvm-pilot firmware registry",
+  "description": "Single source of truth for firmware currency. Each entry is keyed by (vendor, product) as normalized by a driver's get_firmware_info(), so one generic mechanism serves every family (PiKVM/GLKVM/Redfish/iDRAC/iLO/IPMI/AMT). Consumed by health.check_firmware_currency; maintained via the firmware-report ingestion pipeline.",
+  "type": "object",
+  "required": ["schema_version", "updated", "firmware"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {"const": 2},
+    "updated": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+    "firmware": {"type": "array", "items": {"$ref": "#/definitions/entry"}}
+  },
+  "definitions": {
+    "entry": {
+      "type": "object",
+      "required": ["vendor", "product"],
+      "additionalProperties": false,
+      "properties": {
+        "vendor": {"type": "string", "minLength": 1, "description": "Matched case-insensitively against get_firmware_info().vendor (e.g. gl.inet, dell, hpe)."},
+        "product": {"type": "string", "minLength": 1, "description": "Matched case-insensitively as a substring of get_firmware_info().product (e.g. RV1126B, iDRAC9, iLO 5)."},
+        "latest": {"type": "string", "minLength": 1, "description": "Latest known version, in the same scheme the device reports."},
+        "source": {"type": "string", "pattern": "^https?://"},
+        "date": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+        "known_bad": {"type": "array", "items": {"$ref": "#/definitions/known_bad"}},
+        "profile": {"$ref": "#/definitions/profile"}
+      }
+    },
+    "profile": {
+      "type": "object",
+      "description": "Capability / expected-UX differentiators that a healthcheck cannot safely detect live. All fields optional so a profile can be enriched incrementally.",
+      "additionalProperties": false,
+      "properties": {
+        "mouse": {"enum": ["absolute", "relative", "none"], "description": "GUI usability: absolute = usable pointer; relative = painful; none = keyboard only."},
+        "vmedia": {"enum": ["reliable", "reports-only", "none"], "description": "Boot-from-ISO fidelity: reports-only = API says mounted but the host sees nothing (#77)."},
+        "power_state_trusted": {"type": "boolean", "description": "Whether ATX/LED power readings are truthful — governs whether reboots can be automated safely."},
+        "video": {"type": "string", "minLength": 1, "description": "Rated video ceiling: transport + max mode, e.g. h264/1080p60."}
+      }
+    },
+    "known_bad": {
+      "type": "object",
+      "required": ["affected", "severity", "issue", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "affected": {"type": "string", "minLength": 1, "description": "Version spec: bare X (exact), or <=X / <X / >=X / >X / ==X."},
+        "severity": {"enum": ["warning", "critical"]},
+        "issue": {"type": "string", "minLength": 1},
+        "fixed_in": {"type": "string"},
+        "source": {"type": "string", "pattern": "^https?://"}
+      }
+    }
+  }
+}

--- a/src/kvm_pilot/drivers/pikvm.py
+++ b/src/kvm_pilot/drivers/pikvm.py
@@ -97,6 +97,26 @@ class GLKVMDriver(PiKVMDriver):
     _NOT_FOUND_HINT = _GL_API_DISABLED_HINT
     _vendor = "gl.inet"
 
+    def get_firmware_info(self) -> dict:
+        """GL reports its **product** firmware (what the UI shows) at
+        ``/api/upgrade/version`` — e.g. ``{"model": "RM1PE", "version": "V1.9.1
+        release1"}``. Use that as the identity version/product so the report
+        matches the UI; keep the kvmd component version alongside. Falls back to
+        the base (kvmd-only) info on firmware that lacks the endpoint.
+        """
+        info = super().get_firmware_info()
+        try:
+            up = self._http.get("/api/upgrade/version")
+        except KVMPilotError:
+            return info
+        if isinstance(up, dict):
+            if up.get("version"):
+                info["version"] = up["version"]        # "V1.9.1 release1" (what the UI shows)
+            if up.get("model"):
+                info["product"] = up["model"]          # "RM1PE"
+                info["model"] = up["model"]
+        return info
+
     def known_quirks(self, firmware: str | None = None) -> list[Quirk]:
         """Quirks that apply to ``firmware`` (auto-detected from the device if omitted)."""
         if firmware is None:

--- a/src/kvm_pilot/drivers/pikvm.py
+++ b/src/kvm_pilot/drivers/pikvm.py
@@ -95,6 +95,7 @@ class GLKVMDriver(PiKVMDriver):
     """
 
     _NOT_FOUND_HINT = _GL_API_DISABLED_HINT
+    _vendor = "gl.inet"
 
     def known_quirks(self, firmware: str | None = None) -> list[Quirk]:
         """Quirks that apply to ``firmware`` (auto-detected from the device if omitted)."""
@@ -112,6 +113,8 @@ class BliKVMDriver(PiKVMDriver):
     No deltas from the base client are known yet; this subclass exists so any
     BliKVM-specific behavior or quirks have a home.
     """
+
+    _vendor = "blikvm"
 
 
 __all__ = ["GLKVMDriver", "BliKVMDriver", "Quirk", "GLKVM_QUIRKS"]

--- a/src/kvm_pilot/drivers/redfish/driver.py
+++ b/src/kvm_pilot/drivers/redfish/driver.py
@@ -552,6 +552,27 @@ class RedfishDriver(PowerMixin, CapabilityMixin):
             info = {k: v for k, v in info.items() if k in fields}
         return info
 
+    def get_firmware_info(self) -> dict:
+        """Normalized firmware identity for the registry (health.check_firmware_currency).
+
+        The BMC firmware version (iDRAC/iLO/XCC) lives on the Manager resource's
+        ``FirmwareVersion`` — the real upgradeable version — not the System's
+        ``BiosVersion``. ``product`` prefers the Manager's model (e.g. "iDRAC 9",
+        "iLO 5"), falling back to the System model.
+        """
+        stable = self._system()
+        try:
+            mgr = self._http.get_json(self._manager_uri_resolved()) or {}
+        except KVMPilotError:
+            mgr = {}
+        return {
+            "vendor": stable.get("Manufacturer") or mgr.get("Manufacturer"),
+            "product": mgr.get("Model") or stable.get("Model"),
+            "version": mgr.get("FirmwareVersion"),
+            "manufacturer": stable.get("Manufacturer"),
+            "model": stable.get("Model"),
+        }
+
     # -- Power -----------------------------------------------------------
 
     def is_powered_on(self) -> bool:

--- a/src/kvm_pilot/firmware_registry.py
+++ b/src/kvm_pilot/firmware_registry.py
@@ -1,0 +1,433 @@
+"""
+Firmware registry: load / validate / ingest (issue #80 follow-up).
+
+The registry (``data/firmware_registry.json``) is the single source of truth for
+firmware **currency** (latest release, known-bad ranges) and a device's
+**capability / UX profile** (the non-live-detectable differentiators: mouse mode,
+virtual-media fidelity, power-reading trust, video ceiling), keyed by
+``(vendor, product)``. A device is identified by the ``{vendor, product,
+version}`` its driver's ``get_firmware_info()`` normalizes, so one generic
+mechanism serves every family (PiKVM/GLKVM/Redfish/iDRAC/iLO/…). See
+``docs/firmware-registry.md``.
+
+This module is **stdlib-only** and is the shared core for three consumers:
+  * ``health.check_firmware_currency`` / ``check_capability_profile`` read it;
+  * the ``firmware-report`` GitHub Action runs ``main()`` to fold a submitted
+    issue into the registry and open a PR;
+  * the tests exercise ``parse_issue_form`` / ``merge_submission`` /
+    ``validate_registry`` directly.
+
+A submission is one of three kinds (Latest known release / Known-bad firmware /
+Capability profile). Profiles merge **field by field**, so an operator can file an
+initial profile on first contact and enrich it later (e.g. add ``vmedia`` once
+they've actually booted an ISO) without re-supplying the rest.
+
+Validation is hand-rolled (no ``jsonschema`` dependency) but mirrors
+``data/firmware_registry.schema.json`` — keep the two in sync.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Where an opt-in refresh pulls the latest registry from (the repo's raw file on
+# GitHub's CDN — free, versioned, single source of truth). Overridable via
+# KVM_PILOT_FIRMWARE_DB_URL. A refresh writes to the user cache below; the loader
+# then prefers it over the bundled copy. The core never fetches automatically.
+DEFAULT_DB_URL = (
+    "https://raw.githubusercontent.com/DustinTrap/kvm-pilot/main/"
+    "src/kvm_pilot/data/firmware_registry.json"
+)
+
+SEVERITIES = {"warning", "critical"}
+MOUSE_MODES = {"absolute", "relative", "none"}
+VMEDIA_FIDELITY = {"reliable", "reports-only", "none"}
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_URL_RE = re.compile(r"^https?://")
+_AFFECTED_RE = re.compile(r"^(<=|>=|==|<|>)?\s*\d+(?:[.\-]\d+)*$")
+
+# Issue-form field labels -> internal submission keys. Keep in lockstep with
+# .github/ISSUE_TEMPLATE/firmware-report.yml.
+_FIELD_LABELS = {
+    "Vendor": "vendor",
+    "Product": "product",
+    "Submission type": "kind",
+    "Latest version (latest-known only)": "latest",
+    "Release date (latest-known only, YYYY-MM-DD)": "date",
+    "Affected versions (known-bad only)": "affected",
+    "Severity (known-bad only)": "severity",
+    "Issue / notes (known-bad only)": "issue",
+    "Fixed in (optional, known-bad)": "fixed_in",
+    "Mouse mode (profile only)": "mouse",
+    "Virtual-media fidelity (profile only)": "vmedia",
+    "Power-state readings trusted (profile only)": "power_state_trusted",
+    "Video ceiling (profile only)": "video",
+    "Source URL": "source",
+}
+_PROFILE_FIELDS = ("mouse", "vmedia", "power_state_trusted", "video")
+_NO_RESPONSE = "_no response_"
+
+
+# --------------------------------------------------------------------------- #
+# Load                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def load_registry() -> dict[str, Any]:
+    """The active registry, newest valid source first.
+
+    Precedence: ``KVM_PILOT_FIRMWARE_DB`` (an explicit file) > the user cache a
+    refresh writes > the copy bundled in the package. A cache/override that is
+    missing or fails validation is skipped, so a bad refresh can never take the
+    check offline — it just falls back to the bundled data.
+    """
+    override = os.environ.get("KVM_PILOT_FIRMWARE_DB")
+    for path in (Path(override).expanduser() if override else None, cache_path()):
+        if path is None:
+            continue
+        try:
+            if path.exists():
+                data = json.loads(path.read_text("utf-8"))
+                if isinstance(data, dict) and not validate_registry(data):
+                    return data
+        except (OSError, ValueError):
+            pass
+    return load_bundled_registry()
+
+
+def load_bundled_registry() -> dict[str, Any]:
+    """The registry that ships inside the installed package (offline default)."""
+    try:
+        from importlib.resources import files
+
+        raw = (files("kvm_pilot") / "data" / "firmware_registry.json").read_text("utf-8")
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else _empty()
+    except (OSError, ValueError, ModuleNotFoundError):
+        return _empty()
+
+
+def cache_path() -> Path:
+    """Where an opt-in refresh writes the fetched registry (never the package dir)."""
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "kvm-pilot" / "firmware_registry.json"
+
+
+def _empty() -> dict[str, Any]:
+    return {"schema_version": 2, "updated": "1970-01-01", "firmware": []}
+
+
+# --------------------------------------------------------------------------- #
+# Validate (mirrors firmware_registry.schema.json)                            #
+# --------------------------------------------------------------------------- #
+
+
+def validate_registry(data: Any) -> list[str]:
+    """Return a list of human-readable errors; empty means valid."""
+    errs: list[str] = []
+    if not isinstance(data, dict):
+        return ["registry must be a JSON object"]
+    if data.get("schema_version") != 2:
+        errs.append("schema_version must be 2")
+    if not _DATE_RE.match(str(data.get("updated", ""))):
+        errs.append("updated must be YYYY-MM-DD")
+    entries = data.get("firmware")
+    if not isinstance(entries, list):
+        return errs + ["firmware must be an array"]
+    for i, e in enumerate(entries):
+        errs.extend(f"firmware[{i}]: {m}" for m in _validate_entry(e))
+    return errs
+
+
+def _validate_entry(e: Any) -> list[str]:
+    errs: list[str] = []
+    if not isinstance(e, dict):
+        return ["must be an object"]
+    if not str(e.get("vendor", "")).strip():
+        errs.append("vendor is required")
+    if not str(e.get("product", "")).strip():
+        errs.append("product is required")
+    if "latest" in e:
+        if not str(e.get("latest", "")).strip():
+            errs.append("latest must be non-empty when present")
+        if not _URL_RE.match(str(e.get("source", ""))):
+            errs.append("source (http[s] URL) is required with latest")
+        if not _DATE_RE.match(str(e.get("date", ""))):
+            errs.append("date (YYYY-MM-DD) is required with latest")
+    for j, bad in enumerate(e.get("known_bad", []) or []):
+        errs.extend(f"known_bad[{j}]: {m}" for m in _validate_known_bad(bad))
+    if "profile" in e:
+        errs.extend(f"profile: {m}" for m in _validate_profile(e.get("profile")))
+    return errs
+
+
+def _validate_known_bad(bad: Any) -> list[str]:
+    errs: list[str] = []
+    if not isinstance(bad, dict):
+        return ["must be an object"]
+    if not _AFFECTED_RE.match(str(bad.get("affected", "")).strip()):
+        errs.append("affected must be a version spec (X, <=X, <X, >=X, >X, ==X)")
+    if bad.get("severity") not in SEVERITIES:
+        errs.append(f"severity must be one of {sorted(SEVERITIES)}")
+    if not str(bad.get("issue", "")).strip():
+        errs.append("issue is required")
+    if not _URL_RE.match(str(bad.get("source", ""))):
+        errs.append("source must be an http(s) URL")
+    return errs
+
+
+def _validate_profile(prof: Any) -> list[str]:
+    errs: list[str] = []
+    if not isinstance(prof, dict):
+        return ["must be an object"]
+    if "mouse" in prof and prof["mouse"] not in MOUSE_MODES:
+        errs.append(f"mouse must be one of {sorted(MOUSE_MODES)}")
+    if "vmedia" in prof and prof["vmedia"] not in VMEDIA_FIDELITY:
+        errs.append(f"vmedia must be one of {sorted(VMEDIA_FIDELITY)}")
+    if "power_state_trusted" in prof and not isinstance(prof["power_state_trusted"], bool):
+        errs.append("power_state_trusted must be a boolean")
+    if "video" in prof and not str(prof["video"]).strip():
+        errs.append("video must be non-empty when present")
+    return errs
+
+
+# --------------------------------------------------------------------------- #
+# Ingest an issue-form submission                                             #
+# --------------------------------------------------------------------------- #
+
+
+def parse_issue_form(body: str) -> dict[str, str]:
+    """Parse a GitHub Issue-Form rendered body (`### Label\\n\\nvalue`) to a dict.
+
+    Unknown headings are ignored; ``_No response_`` (unfilled optional fields)
+    becomes an absent key.
+    """
+    out: dict[str, str] = {}
+    parts = re.split(r"^###[ \t]+(.+?)[ \t]*$", body, flags=re.MULTILINE)
+    for label, block in zip(parts[1::2], parts[2::2], strict=False):
+        key = _FIELD_LABELS.get(label.strip())
+        if key is None:
+            continue
+        value = block.strip()
+        if value and value.lower() != _NO_RESPONSE:
+            out[key] = value
+    return out
+
+
+def _kind(sub: dict[str, str]) -> str:
+    k = (sub.get("kind") or "").lower()
+    if "known-bad" in k or "known bad" in k:
+        return "known_bad"
+    if "profile" in k or "capability" in k:
+        return "profile"
+    return "latest"
+
+
+def validate_submission(sub: dict[str, str]) -> list[str]:
+    """Errors for a parsed submission before it is merged."""
+    errs: list[str] = []
+    if not sub.get("vendor"):
+        errs.append("vendor is required")
+    if not sub.get("product"):
+        errs.append("product is required")
+    kind = _kind(sub)
+    src = sub.get("source", "")
+    if kind != "profile":  # latest / known-bad must cite a source
+        if not _URL_RE.match(src):
+            errs.append("source must be an http(s) URL")
+    elif src and not _URL_RE.match(src):  # profile source is optional but must be valid if given
+        errs.append("source must be an http(s) URL")
+
+    if kind == "known_bad":
+        if not _AFFECTED_RE.match((sub.get("affected") or "").strip()):
+            errs.append("affected must be a version spec (X, <=X, <X, >=X, >X, ==X)")
+        if sub.get("severity") not in SEVERITIES:
+            errs.append(f"severity must be one of {sorted(SEVERITIES)}")
+        if not sub.get("issue"):
+            errs.append("issue is required for a known-bad report")
+    elif kind == "profile":
+        if not any(sub.get(f) for f in _PROFILE_FIELDS):
+            errs.append("a profile report needs at least one of: " + ", ".join(_PROFILE_FIELDS))
+        if sub.get("mouse") and sub["mouse"] not in MOUSE_MODES:
+            errs.append(f"mouse must be one of {sorted(MOUSE_MODES)}")
+        if sub.get("vmedia") and sub["vmedia"] not in VMEDIA_FIDELITY:
+            errs.append(f"vmedia must be one of {sorted(VMEDIA_FIDELITY)}")
+        if sub.get("power_state_trusted") and sub["power_state_trusted"].lower() not in ("true", "false"):
+            errs.append("power_state_trusted must be true or false")
+    else:  # latest
+        if not sub.get("latest"):
+            errs.append("latest version is required for a latest-known report")
+        if not _DATE_RE.match(sub.get("date", "")):
+            errs.append("date (YYYY-MM-DD) is required for a latest-known report")
+    return errs
+
+
+def _find_entry(registry: dict, vendor: str, product: str) -> dict | None:
+    for e in registry.get("firmware", []):
+        if e.get("vendor", "").strip().lower() == vendor.strip().lower() and \
+                e.get("product", "").strip().lower() == product.strip().lower():
+            return e
+    return None
+
+
+def merge_submission(registry: dict, sub: dict[str, str], *, today: str) -> dict:
+    """Fold a validated submission into a *copy* of the registry and return it.
+
+    Idempotent; profile reports merge field-by-field so partial enrichment
+    accumulates rather than overwriting the whole profile.
+    """
+    reg = json.loads(json.dumps(registry))  # deep copy; never mutate the input
+    reg.setdefault("schema_version", 2)
+    reg.setdefault("firmware", [])
+
+    entry = _find_entry(reg, sub["vendor"], sub["product"])
+    if entry is None:
+        entry = {"vendor": sub["vendor"], "product": sub["product"]}
+        reg["firmware"].append(entry)
+
+    kind = _kind(sub)
+    if kind == "known_bad":
+        bad = {
+            "affected": sub["affected"],
+            "severity": sub["severity"],
+            "issue": sub["issue"],
+            "source": sub["source"],
+        }
+        if sub.get("fixed_in"):
+            bad["fixed_in"] = sub["fixed_in"]
+        bads = entry.setdefault("known_bad", [])
+        for i, b in enumerate(bads):
+            if b.get("affected") == bad["affected"]:
+                bads[i] = bad
+                break
+        else:
+            bads.append(bad)
+    elif kind == "profile":
+        prof = entry.setdefault("profile", {})
+        for f in ("mouse", "vmedia", "video"):
+            if sub.get(f):
+                prof[f] = sub[f]
+        if sub.get("power_state_trusted"):
+            prof["power_state_trusted"] = sub["power_state_trusted"].lower() == "true"
+    else:  # latest
+        entry["latest"] = sub["latest"]
+        entry["source"] = sub["source"]
+        entry["date"] = sub["date"]
+
+    reg["updated"] = today
+    return reg
+
+
+def ingest_batch(registry: dict, items: list[dict], *, today: str) -> tuple[dict, list[dict]]:
+    """Fold many issue submissions into one registry pass (the daily batch).
+
+    ``items`` is ``[{"number": int, "body": str}, …]``. Returns the merged
+    registry and a per-issue result list (``status`` ∈ ingested / noop / invalid),
+    so the workflow can open ONE PR and comment each issue. Idempotent: a report
+    already reflected in the registry is a ``noop`` — that dedup is what keeps an
+    hourly re-run from churning.
+    """
+    reg = json.loads(json.dumps(registry))
+    results: list[dict] = []
+    for item in items:
+        num = item.get("number")
+        sub = parse_issue_form(item.get("body", ""))
+        errs = validate_submission(sub)
+        if errs:
+            results.append({"number": num, "status": "invalid", "message": "; ".join(errs)})
+            continue
+        merged = merge_submission(reg, sub, today=today)
+        reg_errs = validate_registry(merged)
+        if reg_errs:
+            results.append({"number": num, "status": "invalid", "message": "; ".join(reg_errs)})
+            continue
+        if merged.get("firmware") == reg.get("firmware"):
+            results.append({"number": num, "status": "noop", "message": "already in the registry"})
+        else:
+            reg = merged
+            results.append({"number": num, "status": "ingested",
+                            "message": f"{sub['vendor']} {sub['product']} ({_kind(sub)})"})
+    return reg, results
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry point for the GitHub Action                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _write_registry(path: str, registry: dict) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(registry, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Ingest firmware-report issue(s) into a registry file.
+
+    ``--batch <items.json>`` (the hourly workflow) folds every pending issue in
+    one pass and writes per-issue outcomes to ``--results``. ``--issue-body-file``
+    handles a single issue (manual / tests). ``--today`` supplies the date
+    deterministically. Exit codes: 0 changed, 4 no-op, 3 invalid (single only).
+    """
+    import argparse
+
+    p = argparse.ArgumentParser(description="Ingest firmware-report issue(s) into the registry.")
+    p.add_argument("--registry", required=True)
+    p.add_argument("--today", required=True)
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--issue-body-file", help="one issue body (single-issue mode)")
+    src.add_argument("--batch", help="JSON list of {number, body} (batch mode)")
+    p.add_argument("--results", help="write per-issue batch outcomes here (JSON)")
+    args = p.parse_args(argv)
+
+    with open(args.registry, encoding="utf-8") as fh:
+        registry = json.load(fh)
+
+    if args.batch:
+        with open(args.batch, encoding="utf-8") as fh:
+            items = json.load(fh)
+        merged, results = ingest_batch(registry, items, today=args.today)
+        if args.results:
+            with open(args.results, "w", encoding="utf-8") as fh:
+                json.dump(results, fh)
+        changed = merged.get("firmware") != registry.get("firmware")
+        if changed:
+            _write_registry(args.registry, merged)
+        counts = {s: sum(1 for r in results if r["status"] == s) for s in ("ingested", "noop", "invalid")}
+        print(f"batch: {counts['ingested']} ingested, {counts['noop']} no-op, {counts['invalid']} invalid")
+        return 0 if changed else 4
+
+    with open(args.issue_body_file, encoding="utf-8") as fh:
+        body = fh.read()
+    sub = parse_issue_form(body)
+    sub_errs = validate_submission(sub)
+    if sub_errs:
+        print("INVALID SUBMISSION:", file=sys.stderr)
+        for e in sub_errs:
+            print(f"  - {e}", file=sys.stderr)
+        return 3
+
+    merged = merge_submission(registry, sub, today=args.today)
+    reg_errs = validate_registry(merged)
+    if reg_errs:
+        print("MERGED REGISTRY FAILED VALIDATION:", file=sys.stderr)
+        for e in reg_errs:
+            print(f"  - {e}", file=sys.stderr)
+        return 3
+
+    if merged.get("firmware") == registry.get("firmware"):
+        print("no change: entry already present")
+        return 4
+
+    _write_registry(args.registry, merged)
+    print(f"registry updated: {sub['vendor']} {sub['product']} ({_kind(sub)})")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/kvm_pilot/health.py
+++ b/src/kvm_pilot/health.py
@@ -479,12 +479,16 @@ def check_firmware_report(driver: Any) -> CheckResult | None:
         return None
     version = fw.get("version")
     model = fw.get("model")
+    kvmd = fw.get("kvmd_version")
+    # `version` is the product firmware the UI shows (e.g. GL "V1.9.1 release1");
+    # note the kvmd component version too when it differs.
+    kvmd_note = f" (kvmd {kvmd})" if kvmd and kvmd != version else ""
     return CheckResult(
         id="firmware-report",
         pillar=Pillar.FIRMWARE,
         severity=Severity.INFO,
         title="Firmware",
-        detail=f"model={model or '?'} kvmd/firmware={version or '?'}.",
+        detail=f"model={model or '?'} firmware={version or '?'}{kvmd_note}.",
     )
 
 

--- a/src/kvm_pilot/health.py
+++ b/src/kvm_pilot/health.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import enum
 import json
 import os
+import re
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
@@ -509,6 +510,170 @@ def check_firmware_quirks(driver: Any) -> CheckResult | None:
     )
 
 
+# -- firmware currency (registry-backed) ------------------------------------- #
+#
+# The registry is the single source of truth for "is this firmware current /
+# known-bad" (see docs/firmware-registry.md). It ships bundled (offline default);
+# entries are contributed via the firmware-report ingestion pipeline. A device is
+# identified by the (vendor, product, version) its driver's get_firmware_info()
+# normalizes — so one generic mechanism serves every family (PiKVM, GLKVM, Redfish
+# iDRAC/iLO/XCC, and future IPMI/AMT drivers): the vendor-specific bit is only
+# "how do I read the version off this box", which lives in the driver.
+
+
+def _ver_tuple(v: str | None) -> tuple[int, ...]:
+    """A version string as a tuple of its integer segments (``4.82`` -> ``(4, 82)``)."""
+    return tuple(int(x) for x in re.findall(r"\d+", v)) if v else ()
+
+
+def _vercmp(a: str | None, b: str | None) -> int:
+    """Compare two dotted-numeric versions: -1 / 0 / 1. Missing segments pad as 0.
+
+    Each dot/dash-separated segment is compared numerically — correct for kvmd
+    (``4.82``), iDRAC (``7.10.30.00``), iLO (``2.78``) and the like. Genuinely
+    non-numeric schemes collapse to () and only ever compare equal, so they fall
+    through to exact ``known_bad`` matches rather than a bogus ordering.
+    """
+    ta, tb = _ver_tuple(a), _ver_tuple(b)
+    n = max(len(ta), len(tb))
+    ta += (0,) * (n - len(ta))
+    tb += (0,) * (n - len(tb))
+    return (ta > tb) - (ta < tb)
+
+
+def _affected(spec: str, version: str) -> bool:
+    """Does ``version`` satisfy a known-bad ``affected`` spec (``<=X`` / ``<X`` /
+    ``>=X`` / ``>X`` / ``==X`` / bare ``X`` for exact)?"""
+    spec = (spec or "").strip()
+    for op in ("<=", ">=", "==", "<", ">"):
+        if spec.startswith(op):
+            c = _vercmp(version, spec[len(op):].strip())
+            return {"<=": c <= 0, "<": c < 0, ">=": c >= 0, ">": c > 0, "==": c == 0}[op]
+    return _vercmp(version, spec) == 0
+
+
+_REGISTRY_CACHE: dict[str, Any] | None = None
+
+
+def _load_firmware_registry() -> dict[str, Any]:
+    global _REGISTRY_CACHE
+    if _REGISTRY_CACHE is None:
+        from .firmware_registry import load_registry
+
+        _REGISTRY_CACHE = load_registry()
+    return _REGISTRY_CACHE
+
+
+def _match_firmware(entries: list[dict], vendor: str, product: str) -> dict | None:
+    """First registry entry whose vendor equals and whose product is a substring
+    of the device's reported product (so ``RV1126B`` matches the messy board
+    string, and ``iDRAC9`` matches exactly)."""
+    pl = product.lower()
+    for e in entries:
+        if e.get("vendor", "").strip().lower() == vendor and e.get("product", "").strip().lower() in pl:
+            return e
+    return None
+
+
+def check_firmware_currency(driver: Any) -> CheckResult | None:
+    """Flag known-bad firmware or an available update, via the firmware registry."""
+    fn = getattr(driver, "get_firmware_info", None)
+    if fn is None:
+        return None
+    try:
+        fw = fn()
+    except KVMPilotError:
+        return None
+    vendor = (fw.get("vendor") or "").strip().lower()
+    product = fw.get("product") or ""
+    version = fw.get("version")
+    if not (vendor and product and version):
+        return None
+    entry = _match_firmware(_load_firmware_registry().get("firmware", []), vendor, product)
+    if entry is None:
+        return None
+
+    # 1) Known-bad: the installed version falls in an affected range.
+    for bad in entry.get("known_bad", []):
+        if _affected(bad.get("affected", ""), version):
+            fixed = f" Fixed in {bad['fixed_in']}." if bad.get("fixed_in") else ""
+            return CheckResult(
+                id="firmware-currency",
+                pillar=Pillar.FIRMWARE,
+                severity=Severity.CRITICAL if bad.get("severity") == "critical" else Severity.WARNING,
+                title="Known-bad firmware",
+                detail=f"{product} {version} matches a known-bad range ({bad['affected']}): {bad['issue']}.{fixed}",
+                remediation=f"Update the firmware. Source: {bad.get('source', 'n/a')}.",
+            )
+
+    # 2) Out of date: strictly behind the latest known release.
+    latest = entry.get("latest")
+    if latest and _vercmp(version, latest) < 0:
+        return CheckResult(
+            id="firmware-currency",
+            pillar=Pillar.FIRMWARE,
+            severity=Severity.WARNING,
+            title="Firmware update available",
+            detail=f"{product} is on {version}; latest known is {latest} (as of {entry.get('date', '?')}).",
+            remediation=f"Update the firmware. Source: {entry.get('source', 'the vendor download page')}.",
+        )
+    return None  # current (or ahead) -> the pillar stays quiet
+
+
+def check_capability_profile(driver: Any) -> CheckResult | None:
+    """Report the stored capability / expected-UX profile for this device.
+
+    These are the differentiators a live probe can't safely determine (absolute
+    vs relative mouse, whether virtual media actually presents to the host,
+    whether power readings are truthful, the video ceiling). INFO when the profile
+    is all-good; WARNING when any axis is degraded, since those directly shape
+    what the operator can expect (and whether it's safe to automate).
+    """
+    fn = getattr(driver, "get_firmware_info", None)
+    if fn is None:
+        return None
+    try:
+        fw = fn()
+    except KVMPilotError:
+        return None
+    vendor = (fw.get("vendor") or "").strip().lower()
+    product = fw.get("product") or ""
+    if not (vendor and product):
+        return None
+    entry = _match_firmware(_load_firmware_registry().get("firmware", []), vendor, product)
+    prof = (entry or {}).get("profile")
+    if not prof:
+        return None
+
+    parts: list[str] = []
+    degraded: list[str] = []
+    if prof.get("video"):
+        parts.append(f"video {prof['video']}")
+    if "mouse" in prof:
+        parts.append(f"mouse={prof['mouse']}")
+        if prof["mouse"] != "absolute":
+            degraded.append("no absolute mouse — GUI pointer control is degraded")
+    if "vmedia" in prof:
+        parts.append(f"vmedia={prof['vmedia']}")
+        if prof["vmedia"] != "reliable":
+            degraded.append(f"virtual media is {prof['vmedia']} — boot-from-ISO may not reach the host")
+    if "power_state_trusted" in prof:
+        trusted = bool(prof["power_state_trusted"])
+        parts.append(f"power readings {'trusted' if trusted else 'NOT trusted'}")
+        if not trusted:
+            degraded.append("power/LED readings are not trustworthy — verify state visually, don't automate blind reboots")
+    if not parts:
+        return None
+    return CheckResult(
+        id="capability-profile",
+        pillar=Pillar.READINESS,
+        severity=Severity.WARNING if degraded else Severity.INFO,
+        title="Capability / expected UX",
+        detail=f"Expected experience on {product}: " + ", ".join(parts) + ".",
+        remediation="; ".join(degraded),
+    )
+
+
 # The registry — each check self-guards, so the same list serves every driver.
 CHECKS: list[Check] = [
     check_api_reachable,
@@ -520,6 +685,8 @@ CHECKS: list[Check] = [
     check_exposed_services,
     check_firmware_report,
     check_firmware_quirks,
+    check_firmware_currency,
+    check_capability_profile,
 ]
 
 

--- a/src/kvm_pilot/health.py
+++ b/src/kvm_pilot/health.py
@@ -51,6 +51,8 @@ __all__ = [
     "run_healthcheck",
     "enforce_gate",
     "preflight",
+    "preflight_once",
+    "reset_session_audit",
     "HealthCache",
     "CHECKS",
 ]
@@ -725,6 +727,56 @@ def preflight(
     acknowledged = cache.acknowledged(key) if cache is not None else frozenset()
     if enforce:
         enforce_gate(report, confirm=confirm, acknowledged=acknowledged)
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# First-connection audit (issue #80)                                          #
+# --------------------------------------------------------------------------- #
+#
+# #80 wants the audit to run "on the first connection to any KVM, before it's
+# used for anything" — not only ahead of a destructive op. A long-lived process
+# (the MCP server builds+closes a driver per tool call) must still audit a given
+# device only once, so an in-memory guard debounces within the process. The
+# persistent HealthCache handles staleness across processes; this is orthogonal.
+
+_SESSION_AUDITED: set[str] = set()
+
+
+def _session_key(driver: Any) -> str:
+    # Host identity alone means "already connected this session" — no firmware,
+    # so the guard needs no network probe; firmware-change invalidation across
+    # processes is the persistent cache's job (keyed driver@host#firmware).
+    return f"{_driver_kind(driver)}@{getattr(driver, 'host', '?')}"
+
+
+def reset_session_audit() -> None:
+    """Forget which devices were audited this process (tests / forced re-audit)."""
+    _SESSION_AUDITED.clear()
+
+
+def preflight_once(
+    driver: Any,
+    *,
+    confirm: ConfirmCallback | None = None,
+    skip: bool = False,
+    cache: HealthCache | None = None,
+    enforce: bool = True,
+) -> HealthReport | None:
+    """Run :func:`preflight` the first time this process connects to a device.
+
+    Returns the report on the first call for a given device and ``None`` on later
+    calls (already audited this session) or when ``skip``. Gate semantics are
+    :func:`preflight`'s; when ``enforce`` raises, the device is left un-recorded
+    so the next attempt re-checks rather than silently proceeding.
+    """
+    if skip:
+        return None
+    key = _session_key(driver)
+    if key in _SESSION_AUDITED:
+        return None
+    report = preflight(driver, confirm=confirm, cache=cache, enforce=enforce)
+    _SESSION_AUDITED.add(key)
     return report
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,12 @@ def _no_external_network(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _isolated_health_cache(tmp_path, monkeypatch):
-    """Redirect the healthcheck cache to a per-test tmp file (never touch ~/.cache)."""
+    """Redirect the healthcheck cache to a per-test tmp file (never touch ~/.cache),
+    and clear the per-process first-connection audit guard so tests stay independent."""
     monkeypatch.setenv("KVM_PILOT_HEALTH_CACHE", str(tmp_path / "health-cache.json"))
+    from kvm_pilot.health import reset_session_audit
+
+    reset_session_audit()
 
 
 class FakeHTTP:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,10 @@ def _isolated_health_cache(tmp_path, monkeypatch):
     """Redirect the healthcheck cache to a per-test tmp file (never touch ~/.cache),
     and clear the per-process first-connection audit guard so tests stay independent."""
     monkeypatch.setenv("KVM_PILOT_HEALTH_CACHE", str(tmp_path / "health-cache.json"))
+    # Isolate the firmware-registry cache/override so tests never read a real
+    # ~/.cache copy (loader falls back to the bundled registry).
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.delenv("KVM_PILOT_FIRMWARE_DB", raising=False)
     from kvm_pilot.health import reset_session_audit
 
     reset_session_audit()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,3 +351,76 @@ def test_destructive_gate_not_run_in_dry_run(monkeypatch):
     monkeypatch.setattr(cli, "_preflight_gate", boom)
     rc = cli.main(["power", "off-hard", "--driver", "fake", "--dry-run"])
     assert rc == 0
+
+
+# -- read-only first-connection audit (issue #80) -------------------------- #
+
+
+def test_readonly_command_audits_on_connect(monkeypatch):
+    from kvm_pilot import cli
+
+    calls = {"n": 0, "skip": None}
+
+    def spy(kvm, *, skip):
+        calls["n"] += 1
+        calls["skip"] = skip
+
+    monkeypatch.setattr(cli, "_inform_on_connect", spy)
+    assert cli.main(["info", "--driver", "fake"]) == 0
+    assert calls["n"] == 1 and calls["skip"] is False
+
+
+def test_readonly_audit_respects_skip_flag(monkeypatch):
+    from kvm_pilot import cli
+
+    seen = {}
+    monkeypatch.setattr(cli, "_inform_on_connect", lambda kvm, *, skip: seen.update(skip=skip))
+    assert cli.main(["info", "--driver", "fake", "--skip-healthcheck"]) == 0
+    assert seen["skip"] is True
+
+
+def test_readonly_audit_never_blocks_the_read(monkeypatch):
+    # The audit runs for real (fake driver is all-OK) and the read still succeeds.
+    from kvm_pilot import cli
+
+    assert cli.main(["info", "--driver", "fake"]) == 0
+
+
+def test_capabilities_does_not_preflight(monkeypatch):
+    # capabilities is offline (uses _build_client) and must trigger no audit.
+    from kvm_pilot import cli
+
+    def boom(*a, **k):
+        raise AssertionError("capabilities must not preflight")
+
+    monkeypatch.setattr(cli, "_inform_on_connect", boom)
+    monkeypatch.setattr(cli, "_preflight_gate", boom)
+    assert cli.main(["capabilities", "--driver", "fake"]) == 0
+
+
+def test_inform_on_connect_prints_findings_to_stderr(monkeypatch, capsys):
+    from kvm_pilot import cli
+    from kvm_pilot.health import CheckResult, HealthReport, Pillar, Severity
+
+    rep = HealthReport(
+        "h", "glkvm", "4.82",
+        [CheckResult("recovery-path", Pillar.READINESS, Severity.CRITICAL,
+                     "Out-of-band recovery path", "No out-of-band reset")],
+    )
+    monkeypatch.setattr("kvm_pilot.health.preflight_once", lambda *a, **k: rep)
+    cli._inform_on_connect(object(), skip=False)
+    err = capsys.readouterr().err
+    assert "preflight glkvm@h" in err
+    assert "CRITICAL" in err and "recovery path" in err.lower()
+
+
+def test_inform_on_connect_swallows_audit_errors(monkeypatch, capsys):
+    # An informational audit that blows up must not break the command.
+    from kvm_pilot import cli
+
+    def boom(*a, **k):
+        raise RuntimeError("network guard")
+
+    monkeypatch.setattr("kvm_pilot.health.preflight_once", boom)
+    cli._inform_on_connect(object(), skip=False)  # must not raise
+    assert capsys.readouterr().err == ""

--- a/tests/test_firmware_ingest.py
+++ b/tests/test_firmware_ingest.py
@@ -1,0 +1,185 @@
+"""Tests for the firmware-registry ingestion pipeline (issue #80 follow-up)."""
+
+from __future__ import annotations
+
+import json
+
+from kvm_pilot.firmware_registry import (
+    _FIELD_LABELS,
+    ingest_batch,
+    load_bundled_registry,
+    load_registry,
+    main,
+    merge_submission,
+    parse_issue_form,
+    validate_registry,
+    validate_submission,
+)
+
+_LABEL_FOR = {v: k for k, v in _FIELD_LABELS.items()}
+
+
+def body(**fields: str) -> str:
+    """Render an issue body the way a GitHub Issue Form would, from internal keys."""
+    return "\n".join(f"### {_LABEL_FOR[k]}\n\n{v}\n" for k, v in fields.items())
+
+
+def _empty_registry() -> dict:
+    return {"schema_version": 2, "updated": "2026-01-01", "firmware": []}
+
+
+# ---- parsing -------------------------------------------------------------- #
+
+
+def test_parse_issue_form_roundtrips_and_drops_no_response():
+    b = body(vendor="gl.inet", product="RV1126B", kind="Latest known release",
+             latest="4.90", date="2026-05-29", source="https://x")
+    b += "\n### Fixed in (optional, known-bad)\n\n_No response_\n"
+    sub = parse_issue_form(b)
+    assert sub["vendor"] == "gl.inet" and sub["latest"] == "4.90"
+    assert "fixed_in" not in sub  # _No response_ is dropped
+
+
+# ---- submission validation ------------------------------------------------ #
+
+
+def test_latest_requires_source_and_date():
+    errs = validate_submission({"vendor": "v", "product": "p", "kind": "Latest known release", "latest": "1.0"})
+    assert any("source" in e for e in errs) and any("date" in e for e in errs)
+
+
+def test_known_bad_requires_affected_severity_issue():
+    errs = validate_submission({"vendor": "v", "product": "p", "kind": "Known-bad firmware", "source": "https://x"})
+    assert any("affected" in e for e in errs)
+    assert any("severity" in e for e in errs)
+    assert any("issue" in e for e in errs)
+
+
+def test_profile_needs_at_least_one_field():
+    errs = validate_submission({"vendor": "v", "product": "p", "kind": "Capability profile"})
+    assert any("at least one" in e for e in errs)
+
+
+def test_profile_source_optional_but_validated():
+    ok = validate_submission({"vendor": "v", "product": "p", "kind": "Capability profile", "mouse": "absolute"})
+    assert ok == []
+    bad = validate_submission({"vendor": "v", "product": "p", "kind": "Capability profile",
+                               "mouse": "absolute", "source": "not-a-url"})
+    assert any("source" in e for e in bad)
+
+
+# ---- merge ---------------------------------------------------------------- #
+
+
+def test_merge_latest_creates_entry_and_validates():
+    out = merge_submission(_empty_registry(), {
+        "vendor": "gl.inet", "product": "RV1126B", "kind": "Latest known release",
+        "latest": "4.90", "date": "2026-05-29", "source": "https://x"}, today="2026-07-02")
+    assert out["firmware"][0]["latest"] == "4.90" and out["updated"] == "2026-07-02"
+    assert validate_registry(out) == []
+
+
+def test_profile_merges_field_by_field_across_reports():
+    reg = _empty_registry()
+    reg = merge_submission(reg, {"vendor": "gl.inet", "product": "RV1126B",
+                                 "kind": "Capability profile", "mouse": "absolute",
+                                 "power_state_trusted": "false"}, today="2026-07-02")
+    reg = merge_submission(reg, {"vendor": "gl.inet", "product": "RV1126B",
+                                 "kind": "Capability profile", "vmedia": "reports-only"}, today="2026-07-03")
+    assert reg["firmware"][0]["profile"] == {
+        "mouse": "absolute", "power_state_trusted": False, "vmedia": "reports-only"}
+    assert validate_registry(reg) == []
+
+
+def test_known_bad_replaces_same_affected_range():
+    reg = _empty_registry()
+    kb = {"vendor": "gl.inet", "product": "RV1126B", "kind": "Known-bad firmware",
+          "affected": "<=4.82", "severity": "warning", "issue": "x", "source": "https://x"}
+    reg = merge_submission(reg, kb, today="2026-07-02")
+    reg = merge_submission(reg, {**kb, "severity": "critical"}, today="2026-07-03")
+    bads = reg["firmware"][0]["known_bad"]
+    assert len(bads) == 1 and bads[0]["severity"] == "critical"
+
+
+# ---- bundled data + end-to-end CLI --------------------------------------- #
+
+
+def test_bundled_registry_is_schema_valid():
+    assert validate_registry(load_bundled_registry()) == []
+
+
+def test_loader_prefers_valid_override_over_bundled(tmp_path, monkeypatch):
+    db = tmp_path / "db.json"
+    db.write_text(json.dumps({"schema_version": 2, "updated": "2026-07-02", "firmware": [
+        {"vendor": "acme", "product": "widget"}]}))
+    monkeypatch.setenv("KVM_PILOT_FIRMWARE_DB", str(db))
+    assert load_registry()["firmware"] == [{"vendor": "acme", "product": "widget"}]
+
+
+def test_loader_falls_back_when_override_invalid(tmp_path, monkeypatch):
+    db = tmp_path / "db.json"
+    db.write_text(json.dumps({"schema_version": 99, "firmware": "nope"}))  # invalid
+    monkeypatch.setenv("KVM_PILOT_FIRMWARE_DB", str(db))
+    assert load_registry() == load_bundled_registry()  # bundled, not the bad override
+
+
+def test_main_ingests_then_is_idempotent(tmp_path):
+    reg = tmp_path / "reg.json"
+    reg.write_text(json.dumps(_empty_registry()))
+    bf = tmp_path / "body.txt"
+    bf.write_text(body(vendor="gl.inet", product="RV1126B", kind="Known-bad firmware",
+                       affected="<=4.82", severity="critical", issue="ATX unwired", source="https://x"))
+    assert main(["--issue-body-file", str(bf), "--registry", str(reg), "--today", "2026-07-02"]) == 0
+    data = json.loads(reg.read_text())
+    assert data["firmware"][0]["known_bad"][0]["severity"] == "critical"
+    # Re-running the same submission changes nothing -> no-op exit 4.
+    assert main(["--issue-body-file", str(bf), "--registry", str(reg), "--today", "2026-07-02"]) == 4
+
+
+def test_main_rejects_invalid_submission(tmp_path):
+    reg = tmp_path / "reg.json"
+    reg.write_text(json.dumps(_empty_registry()))
+    bf = tmp_path / "body.txt"
+    bf.write_text(body(vendor="v", product="p", kind="Latest known release", latest="1.0"))  # no source/date
+    assert main(["--issue-body-file", str(bf), "--registry", str(reg), "--today", "2026-07-02"]) == 3
+    assert json.loads(reg.read_text()) == _empty_registry()  # untouched
+
+
+# ---- batch (hourly workflow) --------------------------------------------- #
+
+
+def test_ingest_batch_mixed_results_land_on_one_entry():
+    items = [
+        {"number": 1, "body": body(vendor="gl.inet", product="RV1126B", kind="Latest known release",
+                                    latest="4.90", date="2026-05-29", source="https://x")},
+        {"number": 2, "body": body(vendor="v", product="p", kind="Latest known release", latest="1.0")},  # invalid
+        {"number": 3, "body": body(vendor="gl.inet", product="RV1126B", kind="Capability profile", mouse="absolute")},
+    ]
+    merged, results = ingest_batch(_empty_registry(), items, today="2026-07-02")
+    assert {r["number"]: r["status"] for r in results} == {1: "ingested", 2: "invalid", 3: "ingested"}
+    e = merged["firmware"][0]
+    assert e["latest"] == "4.90" and e["profile"]["mouse"] == "absolute"
+    assert validate_registry(merged) == []
+
+
+def test_ingest_batch_dedup_is_noop_on_rerun():
+    item = {"number": 5, "body": body(vendor="gl.inet", product="RV1126B", kind="Known-bad firmware",
+                                      affected="<=4.82", severity="critical", issue="x", source="https://x")}
+    reg, r1 = ingest_batch(_empty_registry(), [item], today="2026-07-02")
+    assert r1[0]["status"] == "ingested"
+    _, r2 = ingest_batch(reg, [item], today="2026-07-02")
+    assert r2[0]["status"] == "noop"
+
+
+def test_main_batch_mode_writes_registry_and_results(tmp_path):
+    reg = tmp_path / "reg.json"
+    reg.write_text(json.dumps(_empty_registry()))
+    items = tmp_path / "items.json"
+    items.write_text(json.dumps([{"number": 1, "body": body(
+        vendor="gl.inet", product="RV1126B", kind="Latest known release",
+        latest="4.90", date="2026-05-29", source="https://x")}]))
+    res = tmp_path / "results.json"
+    rc = main(["--batch", str(items), "--registry", str(reg), "--today", "2026-07-02", "--results", str(res)])
+    assert rc == 0
+    assert json.loads(reg.read_text())["firmware"][0]["latest"] == "4.90"
+    assert json.loads(res.read_text())[0]["status"] == "ingested"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -311,3 +311,48 @@ def test_recovery_path_critical_over_transport_when_atx_disabled(emu):
     rec = next(r for r in rep.results if r.id == "recovery-path")
     assert rec.severity is Severity.CRITICAL
     assert rep.worst is Severity.CRITICAL
+
+
+# ---- first-connection audit (issue #80) ---------------------------------- #
+
+
+def test_preflight_once_runs_then_skips_within_session():
+    from kvm_pilot.health import preflight_once, reset_session_audit
+
+    d = FakeDriver()
+    assert preflight_once(d) is not None       # first connection audits
+    assert preflight_once(d) is None           # already audited this session
+    reset_session_audit()
+    assert preflight_once(d) is not None        # reset re-enables the audit
+
+
+def test_preflight_once_skip_returns_none():
+    from kvm_pilot.health import preflight_once
+
+    assert preflight_once(FakeDriver(), skip=True) is None
+
+
+def test_preflight_once_informs_without_blocking_on_critical():
+    # enforce=False must return the report (with the CRITICAL) and never raise —
+    # a standing critical must not make a read impossible.
+    from kvm_pilot.health import preflight_once
+
+    d = stub(
+        host="crit",
+        get_atx_state=lambda: {"enabled": False, "leds": {"power": False}},
+        get_gpio_state=lambda: {"state": {"outputs": {}}},
+    )
+    rep = preflight_once(d, enforce=False)
+    assert rep is not None and rep.worst is Severity.CRITICAL
+
+
+def test_preflight_once_enforces_and_fails_closed_on_critical():
+    from kvm_pilot.health import preflight_once
+
+    d = stub(
+        host="crit",
+        get_atx_state=lambda: {"enabled": False, "leds": {"power": False}},
+        get_gpio_state=lambda: {"state": {"outputs": {}}},
+    )
+    with pytest.raises(HealthGateError):
+        preflight_once(d, confirm=None, enforce=True)  # automation -> fail closed

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -356,3 +356,102 @@ def test_preflight_once_enforces_and_fails_closed_on_critical():
     )
     with pytest.raises(HealthGateError):
         preflight_once(d, confirm=None, enforce=True)  # automation -> fail closed
+
+
+# ---- firmware currency + capability profile (registry, #80 follow-up) ----- #
+
+
+def _fw(**kw):
+    base = {"vendor": "gl.inet", "product": "Rockchip RV1126B-P EVB", "version": "4.82"}
+    base.update(kw)
+    return stub(host="h", get_firmware_info=lambda: base)
+
+
+def test_vercmp_orders_numeric_segments():
+    from kvm_pilot.health import _vercmp
+
+    assert _vercmp("4.82", "4.90") < 0
+    assert _vercmp("6.10.30.00", "6.10.80.00") < 0
+    assert _vercmp("2.78", "2.78") == 0
+    assert _vercmp("7.0", "6.99") > 0
+
+
+def test_affected_specs():
+    from kvm_pilot.health import _affected
+
+    assert _affected("<=4.82", "4.82") and not _affected("<=4.80", "4.82")
+    assert _affected("4.82", "4.82") and not _affected("4.82", "4.83")
+    assert _affected("<4.83", "4.82") and _affected(">=4.80", "4.82")
+
+
+def test_currency_update_available(monkeypatch):
+    from kvm_pilot import health
+
+    monkeypatch.setattr(health, "_REGISTRY_CACHE", {"firmware": [
+        {"vendor": "gl.inet", "product": "RV1126B", "latest": "4.90",
+         "source": "https://x", "date": "2026-05-29"}]})
+    r = health.check_firmware_currency(_fw())
+    assert r.severity is Severity.WARNING and "latest known is 4.90" in r.detail
+
+
+def test_currency_known_bad_range_is_critical(monkeypatch):
+    from kvm_pilot import health
+
+    monkeypatch.setattr(health, "_REGISTRY_CACHE", {"firmware": [
+        {"vendor": "gl.inet", "product": "RV1126B", "known_bad": [
+            {"affected": "<=4.82", "severity": "critical", "issue": "ATX unwired", "source": "https://x"}]}]})
+    assert health.check_firmware_currency(_fw()).severity is Severity.CRITICAL
+
+
+def test_currency_quiet_when_current(monkeypatch):
+    from kvm_pilot import health
+
+    monkeypatch.setattr(health, "_REGISTRY_CACHE", {"firmware": [
+        {"vendor": "gl.inet", "product": "RV1126B", "latest": "4.82",
+         "source": "https://x", "date": "2026-01-01"}]})
+    assert health.check_firmware_currency(_fw()) is None
+
+
+def test_currency_none_when_unmatched(monkeypatch):
+    from kvm_pilot import health
+
+    monkeypatch.setattr(health, "_REGISTRY_CACHE", {"firmware": []})
+    assert health.check_firmware_currency(_fw()) is None
+
+
+def test_capability_profile_warns_on_degraded_axis(monkeypatch):
+    from kvm_pilot import health
+
+    monkeypatch.setattr(health, "_REGISTRY_CACHE", {"firmware": [
+        {"vendor": "gl.inet", "product": "RV1126B", "profile": {
+            "mouse": "absolute", "vmedia": "reports-only",
+            "power_state_trusted": False, "video": "h264/1080p60"}}]})
+    r = health.check_capability_profile(_fw())
+    assert r.severity is Severity.WARNING
+    assert "vmedia=reports-only" in r.detail and "NOT trusted" in r.detail
+    assert "boot-from-ISO" in r.remediation
+
+
+def test_capability_profile_info_when_all_good(monkeypatch):
+    from kvm_pilot import health
+
+    monkeypatch.setattr(health, "_REGISTRY_CACHE", {"firmware": [
+        {"vendor": "gl.inet", "product": "RV1126B", "profile": {
+            "mouse": "absolute", "vmedia": "reliable", "power_state_trusted": True}}]})
+    r = health.check_capability_profile(_fw())
+    assert r.severity is Severity.INFO and r.remediation == ""
+
+
+def test_capability_profile_none_without_profile(monkeypatch):
+    from kvm_pilot import health
+
+    monkeypatch.setattr(health, "_REGISTRY_CACHE", {"firmware": [
+        {"vendor": "gl.inet", "product": "RV1126B", "latest": "4.90",
+         "source": "https://x", "date": "2026-01-01"}]})
+    assert health.check_capability_profile(_fw()) is None
+
+
+def test_glkvm_firmware_identity(emu):
+    fw = gl(emu).get_firmware_info()
+    assert fw["vendor"] == "gl.inet"
+    assert "product" in fw and "version" in fw

--- a/tests/test_pikvm_family.py
+++ b/tests/test_pikvm_family.py
@@ -99,3 +99,44 @@ def test_observed_atx_power_quirk_matches_its_firmware():
     assert by_id["atx-power-state-always-off"].source == "observed"
     other = {q.id for q in GLKVMDriver("h").known_quirks(firmware="9.99")}
     assert "atx-power-state-always-off" not in other
+
+
+# -- GL product firmware version (what the UI shows: /api/upgrade/version) --
+
+
+class _FakeHTTP:
+    """Minimal transport: return canned JSON per path, 404 for anything else."""
+
+    def __init__(self, results):
+        self.results = results
+
+    def get(self, path, **kw):
+        val = self.results.get(path)
+        if val is None:
+            from kvm_pilot.errors import KVMPilotError
+
+            raise KVMPilotError("not found", 404)
+        return val
+
+
+def test_glkvm_reports_gl_product_firmware_when_available():
+    d = GLKVMDriver("h")
+    d._http = _FakeHTTP({
+        "/api/info": {"system": {"kvmd": {"version": "4.82"},
+                                 "platform": {"base": "Rockchip RV1126B-P EVB", "model": "v3"}}},
+        "/api/upgrade/version": {"model": "RM1PE", "version": "V1.9.1 release1"},
+    })
+    fw = d.get_firmware_info()
+    assert fw["version"] == "V1.9.1 release1"        # what the UI shows
+    assert fw["product"] == "RM1PE" and fw["model"] == "RM1PE"
+    assert fw["kvmd_version"] == "4.82" and fw["vendor"] == "gl.inet"
+
+
+def test_glkvm_falls_back_to_kvmd_when_upgrade_endpoint_absent():
+    d = GLKVMDriver("h")
+    d._http = _FakeHTTP({
+        "/api/info": {"system": {"kvmd": {"version": "4.82"},
+                                 "platform": {"base": "some-board", "model": "v3"}}},
+    })
+    fw = d.get_firmware_info()
+    assert fw["version"] == "4.82" and fw["product"] == "some-board"  # base identity


### PR DESCRIPTION
Preflight-on-first-connect + firmware currency / capability registry with automated ingestion (#80).

## What's here
- **Preflight healthcheck on first connection** — read-only intake now audits the device and surfaces findings (non-blocking); destructive ops still gate. Docs (SKILL.md/mcp/CLAUDE.md) require it as the first-contact step.
- **Firmware registry** (`data/firmware_registry.json`, schema v2) keyed by `(vendor, product)` from each driver's normalized `get_firmware_info()` — generic across PiKVM/GLKVM/Redfish/iDRAC/iLO, with `latest` (ordered `_vercmp`), `known_bad` ranges, and a capability/UX `profile` (mouse/vmedia/power_state_trusted/video).
- **GLKVM reports the real product firmware** the UI shows (`V1.9.1 release1 (RM1PE)` via `/api/upgrade/version`), not just the kvmd component version.
- **Ingestion, courteous to public CI** — Issue Form + an **hourly-capped** workflow that no-ops cheaply when nothing's pending, dedups via the `ingested` label, validates untrusted issue bodies as data, and opens **one** batched PR.

## Testing note
Issue Forms and scheduled workflows only take effect from the **default branch** — merge this to `main` for the "Firmware report" form and the hourly ingest to go live. The workflow also has `workflow_dispatch` for an immediate manual run.

Full test suite green; verified live against GLKVM hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
