### PR TITLE
feat(firmware): reconcile loop + ingest workflow fix

### DIFF
--- a/.github/workflows/firmware-ingest.yml
+++ b/.github/workflows/firmware-ingest.yml
@@ -33,9 +33,10 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           gh label create ingested --description "firmware report folded into the registry" --color ededed 2>/dev/null || true
+          # Write outside the workspace so the later checkout doesn't wipe it.
           gh issue list --search "label:firmware-report -label:ingested is:open" \
-            --json number,body --limit 200 > items.json
-          echo "count=$(jq length items.json)" >> "$GITHUB_OUTPUT"
+            --json number,body --limit 200 > "$RUNNER_TEMP/items.json"
+          echo "count=$(jq length "$RUNNER_TEMP/items.json")" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: steps.collect.outputs.count != '0'
@@ -50,9 +51,8 @@ jobs:
       - name: Ingest the batch
         if: steps.collect.outputs.count != '0'
         run: |
-          mv items.json items_in.json  # checkout replaced the workspace; keep the collected list
           python -m kvm_pilot.firmware_registry \
-            --batch items_in.json \
+            --batch "$RUNNER_TEMP/items.json" \
             --registry src/kvm_pilot/data/firmware_registry.json \
             --today "$(date +%F)" \
             --results results.json || true

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -368,6 +368,57 @@ def cmd_healthcheck(args) -> int:
     return 0
 
 
+def cmd_firmware_check(args) -> int:
+    """Detect the device's firmware currency and reconcile it against the registry SSoT.
+
+    Prints the installed version, the latest the device knows about (if it self-reports,
+    e.g. GL's /api/upgrade/compare), and — when the bundled/loaded registry is behind or
+    missing this device — a ready-to-file "Latest known release" report to contribute.
+    """
+    from .firmware_registry import load_registry, reconcile
+
+    kvm = _build_client(args)
+    info_fn = getattr(kvm, "get_firmware_info", None)
+    fw = info_fn() if info_fn is not None else {}
+    vendor = (fw.get("vendor") or "").strip()
+    product = fw.get("product") or ""
+    upd = None
+    fn = getattr(kvm, "get_available_update", None)
+    if fn is not None:
+        upd = fn()
+
+    submission = None
+    if upd and upd.get("latest"):
+        submission = reconcile(vendor, product, upd["latest"], registry=load_registry())
+
+    if args.json:
+        out: dict = {"vendor": vendor, "product": product, "installed": fw.get("version"),
+                     "kvmd": fw.get("kvmd_version")}
+        if upd:
+            out.update(latest_available=upd["latest"], update_available=upd["update_available"],
+                       beta=upd.get("beta"))
+        out["registry_behind"] = submission is not None
+        if submission:
+            out["submission"] = submission
+        print(json.dumps(out, indent=2, default=str))
+        return 0
+
+    print(f"{vendor} {product}: installed {fw.get('version')} (kvmd {fw.get('kvmd_version')})")
+    if upd:
+        verdict = "UPDATE AVAILABLE" if upd["update_available"] else "up to date"
+        print(f"  vendor's latest: {upd['latest']} — {verdict}"
+              + (f" (beta {upd['beta']})" if upd.get("beta") else ""))
+    else:
+        print("  device does not self-report an available-update check")
+    if submission:
+        print("\nRegistry SSoT is behind for this device — contribute this to keep it current:")
+        print(f"  Latest known release: vendor={vendor} product={product} latest={submission['latest']}")
+        print("  File it via the 'Firmware report' issue form (the hourly workflow ingests it).")
+    elif upd:
+        print("\nRegistry SSoT already reflects this latest — nothing to contribute.")
+    return 0
+
+
 def _apply_auto_fixes(kvm, report, args) -> None:
     confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
     for r in report.results:
@@ -484,6 +535,12 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Offer to apply safe, reversible auto-fixes (with confirmation)")
     _add_common(p)
     p.set_defaults(func=cmd_healthcheck)
+
+    p = sub.add_parser("firmware-check",
+                       help="Detect firmware currency and reconcile it against the registry")
+    p.add_argument("--json", action="store_true", help="Emit the result as JSON")
+    _add_common(p)
+    p.set_defaults(func=cmd_firmware_check)
 
     p = sub.add_parser("snapshot", help="Save a screenshot")
     p.add_argument("output")

--- a/src/kvm_pilot/drivers/pikvm.py
+++ b/src/kvm_pilot/drivers/pikvm.py
@@ -117,6 +117,30 @@ class GLKVMDriver(PiKVMDriver):
                 info["model"] = up["model"]
         return info
 
+    def get_available_update(self) -> dict | None:
+        """GL's own update check (``/api/upgrade/compare``): the installed version vs
+        the latest GL publishes for this model. Returns
+        ``{current, latest, beta, update_available}`` or ``None`` if unavailable.
+
+        This is the telemetry that feeds firmware_registry.reconcile — a device
+        that knows its vendor's newest release can contribute it to the SSoT.
+        """
+        try:
+            c = self._http.get("/api/upgrade/compare")
+        except KVMPilotError:
+            return None
+        if not isinstance(c, dict):
+            return None
+        local, server = c.get("local_version"), c.get("server_version")
+        if not (local and server):
+            return None
+        return {
+            "current": local,
+            "latest": server,
+            "beta": c.get("beta_version") or None,
+            "update_available": local != server,
+        }
+
     def known_quirks(self, firmware: str | None = None) -> list[Quirk]:
         """Quirks that apply to ``firmware`` (auto-detected from the device if omitted)."""
         if firmware is None:

--- a/src/kvm_pilot/firmware_registry.py
+++ b/src/kvm_pilot/firmware_registry.py
@@ -74,6 +74,41 @@ _NO_RESPONSE = "_no response_"
 
 
 # --------------------------------------------------------------------------- #
+# Version compare (shared with health.check_firmware_currency)                #
+# --------------------------------------------------------------------------- #
+
+
+def _ver_tuple(v: str | None) -> tuple[int, ...]:
+    """A version string as its integer segments (``V1.9.1 release1`` -> ``(1, 9, 1, 1)``)."""
+    return tuple(int(x) for x in re.findall(r"\d+", v)) if v else ()
+
+
+def _vercmp(a: str | None, b: str | None) -> int:
+    """Compare two dotted-numeric versions: -1 / 0 / 1 (missing segments pad as 0).
+
+    Each numeric segment is compared numerically — correct for kvmd (``4.82``),
+    iDRAC (``7.10.30.00``), iLO (``2.78``), and GL (``V1.9.1 release1``). Purely
+    non-numeric schemes collapse to () and only ever compare equal.
+    """
+    ta, tb = _ver_tuple(a), _ver_tuple(b)
+    n = max(len(ta), len(tb))
+    ta += (0,) * (n - len(ta))
+    tb += (0,) * (n - len(tb))
+    return (ta > tb) - (ta < tb)
+
+
+def _affected(spec: str, version: str) -> bool:
+    """Does ``version`` satisfy a known-bad ``affected`` spec (``<=X`` / ``<X`` /
+    ``>=X`` / ``>X`` / ``==X`` / bare ``X`` for exact)?"""
+    spec = (spec or "").strip()
+    for op in ("<=", ">=", "==", "<", ">"):
+        if spec.startswith(op):
+            c = _vercmp(version, spec[len(op):].strip())
+            return {"<=": c <= 0, "<": c < 0, ">=": c >= 0, ">": c > 0, "==": c == 0}[op]
+    return _vercmp(version, spec) == 0
+
+
+# --------------------------------------------------------------------------- #
 # Load                                                                        #
 # --------------------------------------------------------------------------- #
 
@@ -321,6 +356,27 @@ def merge_submission(registry: dict, sub: dict[str, str], *, today: str) -> dict
 
     reg["updated"] = today
     return reg
+
+
+def reconcile(vendor: str, product: str, latest: str, *, registry: dict) -> dict | None:
+    """Diff a device-reported latest release against the SSoT.
+
+    Returns a ready-to-file "Latest known release" submission when the registry
+    has no ``latest`` for ``(vendor, product)`` or its ``latest`` is older than the
+    device-reported one; ``None`` when the SSoT already reflects it. This is the
+    fleet-feeds-the-registry step: a device that knows its vendor's newest release
+    (e.g. GL's ``server_version``) can contribute it upstream.
+    """
+    entry = _find_entry(registry, vendor, product)
+    have = (entry or {}).get("latest")
+    if have and _vercmp(latest, have) <= 0:
+        return None
+    return {
+        "vendor": vendor,
+        "product": product,
+        "kind": "Latest known release",
+        "latest": latest,
+    }
 
 
 def ingest_batch(registry: dict, items: list[dict], *, today: str) -> tuple[dict, list[dict]]:

--- a/src/kvm_pilot/health.py
+++ b/src/kvm_pilot/health.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import enum
 import json
 import os
-import re
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
@@ -40,6 +39,9 @@ from pathlib import Path
 from typing import Any
 
 from .errors import KVMPilotError
+
+# Version compare + known-bad range matching live in firmware_registry (shared with reconcile).
+from .firmware_registry import _affected, _vercmp
 from .safety import ConfirmCallback
 
 __all__ = [
@@ -523,37 +525,6 @@ def check_firmware_quirks(driver: Any) -> CheckResult | None:
 # normalizes — so one generic mechanism serves every family (PiKVM, GLKVM, Redfish
 # iDRAC/iLO/XCC, and future IPMI/AMT drivers): the vendor-specific bit is only
 # "how do I read the version off this box", which lives in the driver.
-
-
-def _ver_tuple(v: str | None) -> tuple[int, ...]:
-    """A version string as a tuple of its integer segments (``4.82`` -> ``(4, 82)``)."""
-    return tuple(int(x) for x in re.findall(r"\d+", v)) if v else ()
-
-
-def _vercmp(a: str | None, b: str | None) -> int:
-    """Compare two dotted-numeric versions: -1 / 0 / 1. Missing segments pad as 0.
-
-    Each dot/dash-separated segment is compared numerically — correct for kvmd
-    (``4.82``), iDRAC (``7.10.30.00``), iLO (``2.78``) and the like. Genuinely
-    non-numeric schemes collapse to () and only ever compare equal, so they fall
-    through to exact ``known_bad`` matches rather than a bogus ordering.
-    """
-    ta, tb = _ver_tuple(a), _ver_tuple(b)
-    n = max(len(ta), len(tb))
-    ta += (0,) * (n - len(ta))
-    tb += (0,) * (n - len(tb))
-    return (ta > tb) - (ta < tb)
-
-
-def _affected(spec: str, version: str) -> bool:
-    """Does ``version`` satisfy a known-bad ``affected`` spec (``<=X`` / ``<X`` /
-    ``>=X`` / ``>X`` / ``==X`` / bare ``X`` for exact)?"""
-    spec = (spec or "").strip()
-    for op in ("<=", ">=", "==", "<", ">"):
-        if spec.startswith(op):
-            c = _vercmp(version, spec[len(op):].strip())
-            return {"<=": c <= 0, "<": c < 0, ">=": c >= 0, ">": c > 0, "==": c == 0}[op]
-    return _vercmp(version, spec) == 0
 
 
 _REGISTRY_CACHE: dict[str, Any] | None = None

--- a/tests/test_firmware_ingest.py
+++ b/tests/test_firmware_ingest.py
@@ -183,3 +183,26 @@ def test_main_batch_mode_writes_registry_and_results(tmp_path):
     assert rc == 0
     assert json.loads(reg.read_text())["firmware"][0]["latest"] == "4.90"
     assert json.loads(res.read_text())[0]["status"] == "ingested"
+
+
+# ---- reconcile (device-reported latest vs the SSoT) ---------------------- #
+
+
+def test_reconcile_flags_when_registry_missing_latest():
+    from kvm_pilot.firmware_registry import reconcile
+
+    reg = {"schema_version": 2, "updated": "2026-01-01",
+           "firmware": [{"vendor": "gl.inet", "product": "RM1PE"}]}  # profile only, no latest
+    sub = reconcile("gl.inet", "RM1PE", "V1.9.1 release1", registry=reg)
+    assert sub == {"vendor": "gl.inet", "product": "RM1PE",
+                   "kind": "Latest known release", "latest": "V1.9.1 release1"}
+
+
+def test_reconcile_none_when_ssot_current_or_ahead():
+    from kvm_pilot.firmware_registry import reconcile
+
+    reg = {"schema_version": 2, "updated": "2026-01-01",
+           "firmware": [{"vendor": "gl.inet", "product": "RM1PE", "latest": "V1.9.1 release1"}]}
+    assert reconcile("gl.inet", "RM1PE", "V1.9.1 release1", registry=reg) is None      # equal
+    assert reconcile("gl.inet", "RM1PE", "V1.9.0 release1", registry=reg) is None      # device older
+    assert reconcile("gl.inet", "RM1PE", "V1.9.2 release1", registry=reg) is not None  # newer -> drift

--- a/tests/test_pikvm_family.py
+++ b/tests/test_pikvm_family.py
@@ -140,3 +140,18 @@ def test_glkvm_falls_back_to_kvmd_when_upgrade_endpoint_absent():
     })
     fw = d.get_firmware_info()
     assert fw["version"] == "4.82" and fw["product"] == "some-board"  # base identity
+
+
+def test_glkvm_get_available_update_reports_drift():
+    d = GLKVMDriver("h")
+    d._http = _FakeHTTP({"/api/upgrade/compare": {
+        "local_version": "V1.9.1 release1", "server_version": "V1.9.2 release1", "beta_version": ""}})
+    assert d.get_available_update() == {
+        "current": "V1.9.1 release1", "latest": "V1.9.2 release1",
+        "beta": None, "update_available": True}
+
+
+def test_glkvm_get_available_update_none_without_endpoint():
+    d = GLKVMDriver("h")
+    d._http = _FakeHTTP({})  # /api/upgrade/compare -> 404
+    assert d.get_available_update() is None


### PR DESCRIPTION
Adds the reconcile step (device-reported latest -> SSoT diff -> `firmware-check`) and fixes the ingest workflow's items.json/checkout ordering found during live end-to-end testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)