### PR TITLE
data(firmware): add gl.inet RM1PE latest (V1.9.1 release1) from issue #87

### DIFF
--- a/src/kvm_pilot/data/firmware_registry.json
+++ b/src/kvm_pilot/data/firmware_registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "updated": "2026-07-02",
+  "updated": "2026-07-03",
   "firmware": [
     {
       "vendor": "gl.inet",
@@ -9,7 +9,10 @@
         "mouse": "absolute",
         "video": "h264/1080p60",
         "power_state_trusted": false
-      }
+      },
+      "latest": "V1.9.1 release1",
+      "source": "https://dl.gl-inet.com/kvm/rm1/stable",
+      "date": "2026-07-02"
     }
   ]
 }


### PR DESCRIPTION
Automated firmware-registry update ingested from #87 (auto-detected from the .11 GLKVM's /api/upgrade/compare). Closes #87 on merge.

Opened manually because 'Allow GitHub Actions to create and approve pull requests' is off in repo settings — enable it and the workflow opens these itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)