### PR TITLE
docs: record preflight + firmware-registry work (CHANGELOG, reconcile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added — preflight on first connection + firmware registry (2026-07-02 batch, #80)
+- **Preflight healthcheck runs on first connection**, not only ahead of a
+  destructive op. Read-only intake (CLI reads, MCP read tools) audits the device
+  and surfaces findings without blocking; destructive paths still enforce the
+  gate (`health.preflight_once`). The operating docs (`skill/SKILL.md`,
+  `mcp_server/README.md`, `CLAUDE.md`) now require it as the first-contact step.
+- **Firmware registry** (`src/kvm_pilot/data/firmware_registry.json`, schema v2)
+  — the single source of truth for firmware currency and a device's capability /
+  UX profile, keyed by `(vendor, product)` from each driver's normalized
+  `get_firmware_info()`. Generic across PiKVM/GLKVM/Redfish (iDRAC/iLO/XCC) and
+  future IPMI/AMT. New checks `check_firmware_currency` (ordered `_vercmp`:
+  update-available / known-bad ranges / quiet when current) and
+  `check_capability_profile` (mouse / vmedia / power-trust / video).
+- **GLKVM reports the GL product firmware** the UI shows (`V1.9.1 release1
+  (RM1PE)` via `/api/upgrade/version`), not just the kvmd component version.
+  `get_firmware_info()` now returns `{vendor, product, version}` for the PiKVM
+  family and Redfish; fixes the GLKVM `system.platform` path that returned
+  `model=null`.
+- **Reconcile loop** — `GLKVMDriver.get_available_update()` (GL's
+  `/api/upgrade/compare`) + `firmware_registry.reconcile()` diff a device-reported
+  latest against the SSoT; `kvm-pilot firmware-check` prints the currency verdict
+  and a ready-to-contribute report. The fleet keeps the registry current.
+- **Automated ingestion** — a `firmware-report` GitHub Issue Form and an
+  hourly-capped workflow that no-ops cheaply when idle, dedups via the `ingested`
+  label + idempotent merge, validates untrusted issue bodies as data, and opens
+  one batched PR (degrading gracefully when Actions can't open PRs).
+- **Distribution** — the registry ships bundled (offline default); loader
+  precedence `KVM_PILOT_FIRMWARE_DB` > user cache > bundled for an opt-in refresh.
+- New CLI subcommands: `healthcheck`, `firmware-check`.
+
 ### Changed — safety & transport (2026-07-01 deep-review batch)
 - **Breaking:** `snapshot()` / `snapshot_save()` / `snapshot_base64()` lost the
   `quality` parameter — kvmd silently ignored `preview_quality` without

--- a/docs/firmware-registry.md
+++ b/docs/firmware-registry.md
@@ -85,10 +85,32 @@ report adding `vmedia` once an ISO has actually been booted).
   mouse, non-`reliable` vmedia, untrusted power).
 
 `_vercmp` compares each dot/dash segment numerically (correct for `4.82`,
-`7.10.30.00`, `2.78`); genuinely non-numeric schemes only ever compare equal and
-fall through to exact `known_bad` matches rather than a bogus ordering. Version
-strings in the registry must use the device's own scheme (write `4.90`, not `4.9`,
-if you mean build 90).
+`7.10.30.00`, `2.78`, `V1.9.1 release1`); genuinely non-numeric schemes only ever
+compare equal and fall through to exact `known_bad` matches rather than a bogus
+ordering. Version strings in the registry must use the device's own scheme (write
+`4.90`, not `4.9`, if you mean build 90).
+
+## Reconcile: the fleet feeds the registry
+
+Some devices report not just their installed version but their vendor's **latest**
+release — GLKVM exposes both at `/api/upgrade/compare` (`local_version` vs
+`server_version`). That telemetry lets a device keep the SSoT current:
+
+- `driver.get_available_update()` → `{current, latest, beta, update_available}`
+  (GLKVM via `/api/upgrade/compare`; other drivers return `None` until they wire
+  their own update check — e.g. Redfish `UpdateService`).
+- `firmware_registry.reconcile(vendor, product, latest, registry=…)` returns a
+  ready-to-file "Latest known release" submission when the SSoT has no `latest`
+  for that `(vendor, product)` or its `latest` is older than the device-reported
+  one; `None` when the SSoT already reflects it.
+- `kvm-pilot firmware-check --profile <name>` runs detection + reconcile and
+  prints the currency verdict plus the contribution to file (or `--json`). File
+  it through the Issue Form and the ingest workflow folds it in — so a device in
+  the field that sees a newer `server_version` than the SSoT contributes the bump.
+
+`get_firmware_info()` reports the **product** firmware the operator sees (GLKVM
+uses `/api/upgrade/version` → `V1.9.1 release1 (RM1PE)`), not just the kvmd
+component version, so the report and the registry key match the UI.
 
 ## Distribution & refresh
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -175,9 +175,11 @@ The CLI is a **fallback** — prefer the MCP server (see above) when it's
 enabled. Reach for the CLI for one-off checks, for capabilities the MCP server
 doesn't expose, or when no MCP host is in the loop.
 
-`kvm-pilot info | capabilities | healthcheck | snapshot | power | power-cycle |
-type | key | mount | eject | classify | watch | events`. Run `healthcheck` on
-first contact (see above); it also auto-runs ahead of destructive subcommands.
+`kvm-pilot info | capabilities | healthcheck | firmware-check | snapshot | power |
+power-cycle | type | key | mount | eject | classify | watch | events`. Run
+`healthcheck` on first contact (see above); it also auto-runs ahead of destructive
+subcommands. `firmware-check` reports firmware currency and, where a device knows
+its vendor's latest, the update to contribute to the registry.
 `--dry-run` logs destructive
 actions without sending them (it short-circuits before any prompt, so it is
 safe in automation); `--yes` skips the interactive y/N confirmation on a real


### PR DESCRIPTION
Documentation close-out for this session: CHANGELOG entry, reconcile/firmware-check loop in docs/firmware-registry.md, firmware-check in the SKILL CLI list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)