### PR TITLE
feat: in-band SSH-to-target channel (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added — in-band SSH-to-target channel (2026-07-04, #81)
+- **SSH to the managed host's OS** — a new per-profile channel (targets the host
+  *behind* the KVM, not the appliance) so an agent can probe reachability and run
+  recovery commands once the target OS is on the network, and prefer remote
+  recovery over asking a user to physically intervene (surfaced by the #111
+  first-run experience). CLI `ssh-check` (read-only) / `ssh-exec` (destructive,
+  gated); MCP `ssh_reachable` (read-only) / `ssh_exec` (destructive, disabled
+  unless the operator sets `KVM_PILOT_MCP_ALLOW_SSH`).
+- Config: `ssh_host` / `ssh_user` / `ssh_port` / `ssh_key` profile keys +
+  `KVM_PILOT_SSH_*` env (separate from the KVM appliance creds). Zero new
+  dependencies — reachability is a stdlib `socket` probe, exec shells out to the
+  system `ssh`; every exec is gated via the new `ssh.exec` destructive op. Modeled
+  as a `Capability.SSH` / `RemoteShell` seam, not a KVM-driver capability (see
+  `docs/decisions.md`).
+
 ## [0.1.0a6] — 2026-07-03
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,10 @@ Every key `resolve_host()` reads, with its default:
 | `totp_secret` | `KVM_PILOT_TOTP_SECRET` | unset | Base32 secret for 2FA; needs the `totp` extra. |
 | `driver` | `KVM_PILOT_DRIVER` | `pikvm` | `pikvm` \| `glkvm` \| `blikvm` \| `fake` \| `redfish`; the CLI `--driver` flag overrides. |
 | `redfish_auth` | `KVM_PILOT_REDFISH_AUTH` | `session` | Redfish driver only: `session` or `basic` (for BMCs/emulators without a SessionService). Ignored by the PiKVM family. |
+| `ssh_host` | `KVM_PILOT_SSH_HOST` | unset | The **managed host's own** IP/hostname (a *different* machine from the KVM) for the in-band SSH channel (`ssh-check`/`ssh-exec`, MCP `ssh_reachable`/`ssh_exec`). Unset = SSH-to-target disabled. |
+| `ssh_user` | `KVM_PILOT_SSH_USER` | unset | SSH login on the target host. |
+| `ssh_port` | `KVM_PILOT_SSH_PORT` | `22` | SSH port on the target host. |
+| `ssh_key` | `KVM_PILOT_SSH_KEY` | unset | Private-key path for the target SSH login; omit to use the agent's SSH config / default keys. Auth is key-based (no password). |
 
 Naming a `--profile` that doesn't exist in the file is an error (`KeyError`),
 not a silent fallback.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -5,6 +5,25 @@ are intentional**, so they don't get re-litigated. Newest first.
 
 ## Drivers
 
+### SSH-to-target is a per-profile channel, not a KVM-driver capability ([#81](https://github.com/DustinTrap/kvm-pilot/issues/81))
+The in-band SSH channel targets the **managed host's OS** — a different machine from
+the KVM appliance, with its own address (`ssh_host`) and login. It could have been a
+driver capability, but capability detection is **structural** (`detect_capabilities`
+is `hasattr`-based via `runtime_checkable` protocols) and therefore config-independent:
+a driver that merely *had* `ssh_reachable`/`ssh_exec` would report SSH support even with
+no target configured. So SSH is a standalone `SSHChannel` (`src/kvm_pilot/ssh.py`) built
+from the profile's `ssh_*` fields and **gated on "is `ssh_host` set?"** (raising
+`CapabilityError` otherwise), never inferred from the KVM's address. `Capability.SSH` +
+the `RemoteShell` protocol exist as a **seam** (like `SerialConsole`), implemented by the
+channel rather than by KVM drivers. Dependency-free by design: reachability is a stdlib
+`socket` probe and exec shells out to the **system `ssh`** (`BatchMode`), so no
+`paramiko` — matching the stdlib-only-at-core convention. Every exec routes through
+`safety.guard("ssh.exec", …)` (an arbitrary command can't be statically classified);
+the reachability probe is read-only and ungated. SSH is deliberately **not** folded into
+the `recovery-path` healthcheck: that check answers "can a *hung* host be reset?", and a
+hung host won't answer SSH — so SSH reachability is a complementary in-band lever, not an
+out-of-band reset path.
+
 ### Remote firmware flash is its own gated command, not a healthcheck auto-fix ([#92](https://github.com/DustinTrap/kvm-pilot/issues/92))
 The healthcheck already carries an `AutoFix` mechanism (applied, with per-item consent,
 by `healthcheck --fix`), so attaching the firmware update there looks natural — but

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -79,9 +79,9 @@ def _resolve_secret(direct, file_path, ask: bool, prompt: str) -> str | None:
     return None
 
 
-def _build_client(args) -> AnyDriver:
-    confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
-    dry_run = getattr(args, "dry_run", False)
+def _resolve_cfg(args):
+    """Resolve a HostConfig from CLI args (no driver built). Shared by the driver
+    path and the SSH-channel commands, which target the OS, not the KVM."""
     passwd = _resolve_secret(
         getattr(args, "passwd", None), getattr(args, "passwd_file", None),
         getattr(args, "ask_passwd", False), "Password: ",
@@ -90,7 +90,7 @@ def _build_client(args) -> AnyDriver:
         getattr(args, "totp_secret", None), getattr(args, "totp_secret_file", None),
         False, "",
     )
-    cfg = resolve_host(
+    return resolve_host(
         getattr(args, "profile", None),
         host=getattr(args, "host", None),
         user=getattr(args, "user", None),
@@ -104,6 +104,12 @@ def _build_client(args) -> AnyDriver:
         driver=getattr(args, "driver", None),
         redfish_auth=getattr(args, "redfish_auth", None),
     )
+
+
+def _build_client(args) -> AnyDriver:
+    confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
+    dry_run = getattr(args, "dry_run", False)
+    cfg = _resolve_cfg(args)
     # Shared with the MCP server so cfg.driver is honored the same way everywhere.
     kvm = make_driver_from_config(cfg, confirm=confirm, dry_run=dry_run)
     # Stash it so main() can close() it on the way out — a RedfishDriver holds a
@@ -249,6 +255,29 @@ def cmd_boot_progress(args) -> int:
     # None = the device can't report yet (e.g. powered off with no BootProgress).
     print(phase if phase is not None else "unknown")
     return 0
+
+
+def cmd_ssh_check(args) -> int:
+    """Probe whether the managed host's OS is reachable over SSH (read-only)."""
+    from .ssh import SSHChannel
+
+    ch = SSHChannel.from_config(_resolve_cfg(args))  # CapabilityError if not configured
+    reachable = ch.ssh_reachable()
+    print(json.dumps({"target": ch.target, "port": ch.port, "reachable": reachable}, indent=2))
+    return 0 if reachable else 1
+
+
+def cmd_ssh_exec(args) -> int:
+    """Run a command on the managed host's OS over SSH (destructive — gated)."""
+    from .ssh import SSHChannel
+
+    confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
+    ch = SSHChannel.from_config(
+        _resolve_cfg(args), confirm=confirm, dry_run=getattr(args, "dry_run", False)
+    )
+    result = ch.ssh_exec(args.command)
+    print(json.dumps(result, indent=2, default=str))
+    return 0 if (result["dry_run"] or result["ok"]) else int(result["returncode"] or 1)
 
 
 def cmd_snapshot(args) -> int:
@@ -690,6 +719,15 @@ def build_parser() -> argparse.ArgumentParser:
                    help="Seconds of lookback (0 = everything available)")
     _add_common(p)
     p.set_defaults(func=cmd_logs)
+
+    p = sub.add_parser("ssh-check",
+                       help="Is the managed host's OS reachable over SSH? (read-only)")
+    p.set_defaults(func=cmd_ssh_check)
+
+    p = sub.add_parser("ssh-exec",
+                       help="Run a command on the managed host's OS over SSH (in-band; gated)")
+    p.add_argument("command", help="The command to run on the target host")
+    p.set_defaults(func=cmd_ssh_exec)
 
     p = sub.add_parser("boot-progress", help="Structured boot phase (BMC BootProgress)")
     _add_common(p)

--- a/src/kvm_pilot/config.py
+++ b/src/kvm_pilot/config.py
@@ -69,6 +69,15 @@ class HostConfig:
     # endpoints without a SessionService, e.g. emulators or BMCs with session
     # auth disabled). Ignored by the PiKVM family.
     redfish_auth: str = "session"
+    # In-band SSH to the managed HOST's OS (the machine behind the KVM), NOT the
+    # KVM appliance — a separate address and login. Used by the SSH channel
+    # (src/kvm_pilot/ssh.py) for reachability probes and recovery commands. Auth is
+    # key-based: ssh_key is a private-key path, or omit it to use the agent's SSH
+    # config / default keys. No password auth (avoids an sshpass dependency).
+    ssh_host: str | None = None
+    ssh_user: str | None = None
+    ssh_port: int = 22
+    ssh_key: str | None = None
 
 
 def _load_file(path: Path) -> dict[str, Any]:
@@ -121,6 +130,10 @@ def resolve_host(
     ssl_ca_file: str | None = None,
     driver: str | None = None,
     redfish_auth: str | None = None,
+    ssh_host: str | None = None,
+    ssh_user: str | None = None,
+    ssh_port: int | None = None,
+    ssh_key: str | None = None,
     config_path: Path | None = None,
 ) -> HostConfig:
     """Resolve a HostConfig from args > env > file (in that priority)."""
@@ -189,6 +202,10 @@ def resolve_host(
         totp_secret=pick("totp_secret", totp_secret, "KVM_PILOT_TOTP_SECRET"),
         driver=resolved_driver,
         redfish_auth=pick("redfish_auth", redfish_auth, "KVM_PILOT_REDFISH_AUTH", "session"),
+        ssh_host=pick("ssh_host", ssh_host, "KVM_PILOT_SSH_HOST"),
+        ssh_user=pick("ssh_user", ssh_user, "KVM_PILOT_SSH_USER"),
+        ssh_port=int(pick("ssh_port", ssh_port, "KVM_PILOT_SSH_PORT", 22)),
+        ssh_key=pick("ssh_key", ssh_key, "KVM_PILOT_SSH_KEY"),
     )
 
 

--- a/src/kvm_pilot/drivers/base.py
+++ b/src/kvm_pilot/drivers/base.py
@@ -41,6 +41,10 @@ class Capability(StrEnum):
     SERIAL_CONSOLE = "serial_console"
     WATCHDOG = "watchdog"
     FIRMWARE_UPDATE = "firmware_update"
+    # In-band control of the managed HOST's OS over SSH (the machine behind the
+    # KVM, not the KVM appliance). A per-profile channel, not something a KVM
+    # driver implements — see src/kvm_pilot/ssh.py and RemoteShell below.
+    SSH = "ssh"
 
 
 @runtime_checkable
@@ -166,6 +170,21 @@ class SerialConsole(Protocol):
 
 
 @runtime_checkable
+class RemoteShell(Protocol):
+    """In-band control of the managed HOST's OS over SSH — reachability plus
+    command execution, once the target OS is on the network.
+
+    This targets the host *behind* the KVM, not the KVM appliance, and is a
+    per-profile channel (built from the profile's ``ssh_*`` config) rather than a
+    KVM-driver capability. ``ssh_reachable`` is a read-only probe; ``ssh_exec``
+    can change the target's state and MUST route through
+    ``safety.guard("ssh.exec", …)``. See ``src/kvm_pilot/ssh.py``."""
+
+    def ssh_reachable(self) -> bool: ...
+    def ssh_exec(self, command: str, *, timeout: float | None = None) -> dict: ...
+
+
+@runtime_checkable
 class Watchdog(Protocol):
     """Arm / pet / inspect a hardware watchdog timer (IPMI) — an OS-liveness
     primitive whose expiry pinpoints a hang."""
@@ -209,6 +228,7 @@ CAPABILITY_PROTOCOLS: dict[Capability, type] = {
     Capability.SERIAL_CONSOLE: SerialConsole,
     Capability.WATCHDOG: Watchdog,
     Capability.FIRMWARE_UPDATE: FirmwareUpdate,
+    Capability.SSH: RemoteShell,
 }
 
 
@@ -295,6 +315,7 @@ __all__ = [
     "SerialConsole",
     "Watchdog",
     "FirmwareUpdate",
+    "RemoteShell",
     "KVMDriver",
     "CapabilityMixin",
     "PowerMixin",

--- a/src/kvm_pilot/mcp/README.md
+++ b/src/kvm_pilot/mcp/README.md
@@ -24,7 +24,9 @@ client/driver code stays stdlib-only; `mcp` is imported only in this subpackage.
 | `logs` | `readOnlyHint` | Device/host event log as text (`seek` = seconds of lookback). The text diagnostic when video/streamer/power looks wrong — it names a fault (e.g. a stuck encoder behind a `snapshot` 503) a screenshot can't |
 | `snapshot` | `readOnlyHint` | Current screen, returned as a real JPEG **image** content block the model can see |
 | `classify_screen` | `readOnlyHint` | Boot/run phase via the vision backend (Anthropic or a local VLM, see below) |
+| `ssh_reachable` | `readOnlyHint` | Is the **managed host's OS** reachable over SSH (in-band)? Targets the host *behind* the KVM (its own `ssh_host`), not the appliance — use it to prefer remote recovery before physical intervention |
 | `power` | `destructiveHint` | `on` / `off` / `off-hard` / `reset` — **disabled unless the operator opts in** |
+| `ssh_exec` | `destructiveHint` | Run a command on the managed host's OS over SSH — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_SSH`) |
 
 Every tool result names the **host and driver it acted on**, and read-only
 tools always run with a deny-all confirm callback, so a bug in a read path can
@@ -121,6 +123,8 @@ kvm-pilot-mcp                    # start the stdio server (or: python -m kvm_pil
 | `KVM_PILOT_HOST` / `KVM_PILOT_USER` / `KVM_PILOT_PASSWD` / … | Direct device config (see `kvm_pilot.config`); beats file-profile values |
 | `KVM_PILOT_CONFIG` | Path of the config file (default `~/.config/kvm-pilot/config.toml`) |
 | `KVM_PILOT_MCP_ALLOW_POWER` | **Operator-only** opt-in that enables the `power` tool (`1`/`true`/`yes`) |
+| `KVM_PILOT_MCP_ALLOW_SSH` | **Operator-only** opt-in that enables the `ssh_exec` tool (`1`/`true`/`yes`) |
+| `KVM_PILOT_SSH_HOST` / `KVM_PILOT_SSH_USER` / `KVM_PILOT_SSH_PORT` / `KVM_PILOT_SSH_KEY` | The **managed host's** SSH target (a different machine from the KVM) for `ssh_reachable` / `ssh_exec`; also settable per-profile as `ssh_host` etc. |
 | `KVM_PILOT_MCP_DRY_RUN` | Build every driver with `dry_run=True`; destructive calls are logged, never sent |
 | `KVM_PILOT_VISION_BACKEND` | Vision backend for `classify_screen`: `anthropic` (default) or `local` (any OpenAI-compatible VLM: LM Studio, Ollama, vLLM) |
 | `KVM_PILOT_VISION_URL` | Base URL of the local VLM (required for `local`) |

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -42,6 +42,7 @@ from mcp.types import ToolAnnotations
 from kvm_pilot import resolve_host
 from kvm_pilot.config import HostConfig
 from kvm_pilot.drivers import Capability, KVMDriver, make_driver_from_config
+from kvm_pilot.errors import CapabilityError
 from kvm_pilot.safety import allow_all, deny_all
 from kvm_pilot.vision import ScreenAnalyzer, VisionBackend, make_backend
 
@@ -309,6 +310,55 @@ def power(
                 f"host '{cfg.host}' ({cfg.driver})"
             )
         return f"power {action}: requested on host '{cfg.host}' ({cfg.driver})"
+
+
+@mcp.tool(annotations=_READ_ONLY)
+def ssh_reachable(profile: str | None = None) -> dict:
+    """Is the managed host's OS reachable over SSH? (read-only, in-band).
+
+    Targets the host *behind* the KVM (its own ``ssh_host`` / `KVM_PILOT_SSH_HOST`),
+    a different machine from the KVM appliance. Use this to prefer remote recovery
+    before asking a user to physically intervene.
+    """
+    cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
+    from kvm_pilot.ssh import SSHChannel
+
+    try:
+        ch = SSHChannel.from_config(cfg)
+    except CapabilityError as exc:
+        raise ToolError(str(exc)) from exc
+    return {
+        **_provenance(cfg),
+        "target": ch.target,
+        "port": ch.port,
+        "reachable": ch.ssh_reachable(),
+    }
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+def ssh_exec(command: str, confirm: bool = False, profile: str | None = None) -> dict:
+    """Run a command on the managed host's OS over SSH. DESTRUCTIVE / in-band.
+
+    Disabled unless the server operator set `KVM_PILOT_MCP_ALLOW_SSH` in the
+    server's own environment. ``confirm=true`` is required as a second factor.
+    """
+    if not _env_flag("KVM_PILOT_MCP_ALLOW_SSH"):
+        raise ToolError(
+            "ssh_exec is disabled on this server. Only the human operator can enable "
+            "it, by setting the SSH-enable environment variable (documented in the "
+            "server's README.md) in the MCP server's own environment before starting "
+            "it. It cannot be enabled from within an agent session."
+        )
+    if not confirm:
+        raise ToolError("ssh_exec was not confirmed")
+    cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
+    from kvm_pilot.ssh import SSHChannel
+
+    try:
+        ch = SSHChannel.from_config(cfg, confirm=allow_all, dry_run=_dry_run())
+    except CapabilityError as exc:
+        raise ToolError(str(exc)) from exc
+    return {**_provenance(cfg), **ch.ssh_exec(command)}
 
 
 def main() -> None:

--- a/src/kvm_pilot/safety.py
+++ b/src/kvm_pilot/safety.py
@@ -68,6 +68,10 @@ DESTRUCTIVE_OPS: set[str] = {
     # device reboots into a new image (dropping this control channel) and a failed
     # flash may need physical recovery. See FirmwareUpdate in drivers/base.py.
     "firmware.flash",
+    # A command run over SSH on the managed host's OS can change anything (rm -rf,
+    # reboot, service stop). An arbitrary command can't be statically classified,
+    # so every exec is gated. Reachability probes stay ungated (read-only).
+    "ssh.exec",
 }
 
 # Callback signature: (op_name, human_description) -> bool

--- a/src/kvm_pilot/skill/SKILL.md
+++ b/src/kvm_pilot/skill/SKILL.md
@@ -53,7 +53,7 @@ remote before physical**, below).
 | Mouse move/click, MSD mode switching | **Python library only** | Not in MCP or CLI. |
 | Change **host** power (on/off/cycle/reset) | **MCP `power`** (gated) or CLI `power` / `power-cycle` | Destructive — confirm each step. MCP `power` is operator-enabled + per-call approval. |
 | Reboot the **KVM appliance** / restart `kvmd` / inspect `/etc/kvmd` | **SSH to the appliance** | No kvm-pilot interface does this — out-of-band only. |
-| Run commands on / recover the **target host** once its OS is network-reachable | **SSH to the target OS** (in-band) | Prefer this over KVM keystrokes once the OS is up. Ask the user for the target's IP/host/FQDN (≠ the KVM's address). See "Recovery order" below. |
+| Check if the **target host** is reachable / run commands on it once its OS is up | **MCP `ssh_reachable` / `ssh_exec`**, or CLI `ssh-check` / `ssh-exec` (in-band) | Prefer SSH over KVM keystrokes once the OS is up. Configure the target's IP/host/FQDN via `ssh_host` (≠ the KVM's address); `ssh_exec` is gated (operator opt-in `KVM_PILOT_MCP_ALLOW_SSH`). See "Recovery order" below. |
 | View the screen when `snapshot` fails | **WebRTC/Janus stream or the vendor web UI** | The only way to see a unit that streams H.264 at its native resolution. |
 
 **Host vs. appliance — keep these straight.** The `power` tool/CLI acts on the
@@ -69,8 +69,10 @@ is black and you can't power-cycle it through the KVM (`recovery-path` is CRITIC
 Prefer remote recovery, in this order, and present the options in this order:
 1. **SSH into the target host OS** (in-band) — if its OS is on the network this is
    the fastest, most reliable lever (and far better than typing through KVM HID).
-   You must **ask the user for the target's IP / hostname / FQDN** — it's a
-   different machine from the KVM, so you cannot infer it from the KVM's address.
+   Probe with `ssh_reachable` / `ssh-check`, then act with `ssh_exec` / `ssh-exec`.
+   You must **ask the user for the target's IP / hostname / FQDN** (set it as
+   `ssh_host`) — it's a different machine from the KVM, so you cannot infer it from
+   the KVM's address.
 2. **Wake-on-LAN** — if the host is off but WoL-capable and you have its MAC.
 3. Only after remote options are exhausted, suggest **physical intervention**
    (press the power button) or **wiring the ATX cable** for future remote control.

--- a/src/kvm_pilot/ssh.py
+++ b/src/kvm_pilot/ssh.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 import shutil
 import socket
-import subprocess
+import subprocess  # nosec B404 - intentional: shells out to the system `ssh` (no SSH lib)
 
 from .config import HostConfig
 from .errors import CapabilityError, TimeoutError
@@ -116,7 +116,9 @@ class SSHChannel:
         # shell; args after the destination are never parsed as ssh options.
         argv = self._ssh_argv() + [command]
         try:
-            proc = subprocess.run(  # noqa: S603 - argv is built from config, shell=False
+            # shell=False and argv is built from config (no untrusted shell string);
+            # the single command runs via the remote shell over ssh.
+            proc = subprocess.run(  # nosec B603
                 argv,
                 capture_output=True,
                 text=True,

--- a/src/kvm_pilot/ssh.py
+++ b/src/kvm_pilot/ssh.py
@@ -1,0 +1,166 @@
+"""In-band SSH channel to the managed host's OS (issue #81).
+
+This targets the **host behind the KVM**, not the KVM appliance — a separate
+machine with its own address and login (the profile's ``ssh_*`` fields). It lets
+an agent probe whether the target OS is network-reachable and run recovery
+commands once it is, so remote recovery can be preferred over asking a user to
+physically intervene.
+
+Dependency-free: reachability uses the stdlib ``socket``; command execution shells
+out to the system ``ssh`` binary in ``BatchMode`` (no interactive prompts) — no
+third-party SSH library. State-changing execs route through ``SafetyPolicy``
+(``ssh.exec``); the reachability probe is read-only and ungated.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import socket
+import subprocess
+
+from .config import HostConfig
+from .errors import CapabilityError, TimeoutError
+from .safety import SafetyPolicy
+
+logger = logging.getLogger("kvm_pilot.ssh")
+
+DEFAULT_SSH_PORT = 22
+_REACHABLE_TIMEOUT = 5.0  # a liveness probe should be quick, regardless of cfg.timeout
+
+
+class SSHChannel:
+    """SSH reachability + command execution against the managed host's OS.
+
+    Build one with :meth:`from_config` (which enforces that SSH is configured for
+    the profile). Implements the ``RemoteShell`` capability seam
+    (``ssh_reachable`` / ``ssh_exec``) — see ``drivers/base.py``.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        user: str | None = None,
+        port: int = DEFAULT_SSH_PORT,
+        key: str | None = None,
+        timeout: float = 30.0,
+        safety: SafetyPolicy | None = None,
+    ):
+        self.host = host
+        self.user = user
+        self.port = port
+        self.key = key
+        self.timeout = timeout
+        self.safety = safety or SafetyPolicy()
+
+    @classmethod
+    def from_config(
+        cls,
+        cfg: HostConfig,
+        *,
+        safety: SafetyPolicy | None = None,
+        confirm=None,
+        dry_run: bool = False,
+    ) -> SSHChannel:
+        """Build a channel from a resolved ``HostConfig``.
+
+        Raises ``CapabilityError`` if the profile has no ``ssh_host`` — SSH-to-target
+        is opt-in and never inferred from the KVM appliance's address.
+        """
+        if not cfg.ssh_host:
+            raise CapabilityError(
+                "SSH-to-target is not configured for this profile. Set ssh_host "
+                "(or KVM_PILOT_SSH_HOST) to the managed host's own IP/hostname — "
+                "it is a different machine from the KVM appliance."
+            )
+        if safety is None:
+            safety = SafetyPolicy(dry_run=dry_run, confirm=confirm)
+        return cls(
+            cfg.ssh_host,
+            user=cfg.ssh_user,
+            port=cfg.ssh_port,
+            key=cfg.ssh_key,
+            timeout=cfg.timeout,
+            safety=safety,
+        )
+
+    # -- capability seam (RemoteShell) --------------------------------------
+
+    def ssh_reachable(self) -> bool:
+        """True if the target's SSH port accepts a TCP connection. Never raises."""
+        timeout = min(self.timeout, _REACHABLE_TIMEOUT)
+        try:
+            with socket.create_connection((self.host, self.port), timeout=timeout):
+                return True
+        except OSError:
+            return False
+
+    def ssh_exec(self, command: str, *, timeout: float | None = None) -> dict:
+        """Run ``command`` on the target over SSH. Gated as ``ssh.exec``.
+
+        Returns ``{command, returncode, stdout, stderr, ok, dry_run}``. Under
+        dry-run the command is logged and skipped (``dry_run=True``, ``ok=False``).
+        Raises ``SafetyError`` if a confirm callback denies it, ``CapabilityError``
+        if the system ``ssh`` binary is missing, and ``TimeoutError`` on timeout.
+        """
+        desc = f"ssh {self.target}: {command}"
+        if not self.safety.guard("ssh.exec", desc):
+            return _result(command, returncode=None, stdout="", stderr="", dry_run=True)
+        if shutil.which("ssh") is None:
+            raise CapabilityError(
+                "The system 'ssh' binary was not found on PATH; kvm-pilot's SSH "
+                "channel shells out to it."
+            )
+        # command is a single post-destination arg → ssh runs it via the remote
+        # shell; args after the destination are never parsed as ssh options.
+        argv = self._ssh_argv() + [command]
+        try:
+            proc = subprocess.run(  # noqa: S603 - argv is built from config, shell=False
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=timeout or self.timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError(f"ssh exec timed out after {timeout or self.timeout}s") from exc
+        return _result(
+            command,
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            dry_run=False,
+        )
+
+    # -- helpers ------------------------------------------------------------
+
+    @property
+    def target(self) -> str:
+        return f"{self.user}@{self.host}" if self.user else self.host
+
+    def _ssh_argv(self) -> list[str]:
+        argv = [
+            "ssh",
+            "-o", "BatchMode=yes",            # never block on a password/passphrase prompt
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", f"ConnectTimeout={int(min(self.timeout, _REACHABLE_TIMEOUT))}",
+            "-p", str(self.port),
+        ]
+        if self.key:
+            argv += ["-i", self.key]
+        argv.append(self.target)
+        return argv
+
+
+def _result(command, *, returncode, stdout, stderr, dry_run) -> dict:
+    return {
+        "command": command,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": stderr,
+        "ok": returncode == 0,
+        "dry_run": dry_run,
+    }
+
+
+__all__ = ["SSHChannel", "DEFAULT_SSH_PORT"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -33,7 +33,11 @@ EXPECTED_TOOLS = {
     "classify_screen",
     "power",
     "healthcheck",
+    "ssh_reachable",
+    "ssh_exec",
 }
+# Tools that change state (readOnlyHint=False, destructiveHint=True).
+DESTRUCTIVE_TOOLS = {"power", "ssh_exec"}
 
 
 @pytest.fixture()
@@ -89,11 +93,12 @@ def test_handshake_lists_annotated_tools(config_file):
     tools = run_session(server_env(config_file), interact)
     by_name = {t.name: t for t in tools}
     assert set(by_name) == EXPECTED_TOOLS
-    for name in EXPECTED_TOOLS - {"power"}:
+    for name in EXPECTED_TOOLS - DESTRUCTIVE_TOOLS:
         assert by_name[name].annotations.readOnlyHint is True, name
-    power = by_name["power"].annotations
-    assert power.readOnlyHint is False
-    assert power.destructiveHint is True
+    for name in DESTRUCTIVE_TOOLS:
+        ann = by_name[name].annotations
+        assert ann.readOnlyHint is False, name
+        assert ann.destructiveHint is True, name
 
 
 def test_healthcheck_tool_returns_report(config_file):
@@ -141,6 +146,30 @@ def test_power_executes_on_fake_driver_when_fully_gated(config_file):
     text = result.content[0].text
     assert "requested on host 'fakebox.local' (fake)" in text
     assert "DRY-RUN" not in text
+
+
+def test_ssh_exec_errors_without_operator_gate(config_file):
+    """The env gate is the floor, checked before anything else (mirrors power)."""
+
+    async def interact(session):
+        return await session.call_tool("ssh_exec", {"command": "reboot", "confirm": True})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is True
+    text = result.content[0].text
+    assert "operator" in text
+    assert "KVM_PILOT_MCP_ALLOW_SSH" not in text  # no copy-pasteable incantation
+
+
+def test_ssh_reachable_errors_when_not_configured(config_file):
+    """The fake profile has no ssh_host — SSH-to-target must not be inferred."""
+
+    async def interact(session):
+        return await session.call_tool("ssh_reachable", {})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is True
+    assert "not configured" in result.content[0].text
 
 
 def test_dry_run_marks_results_and_skips_the_command(config_file):

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -1,0 +1,128 @@
+"""Unit tests for the in-band SSH-to-target channel (issue #81).
+
+No real network or ssh binary: socket and subprocess are mocked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from kvm_pilot.config import HostConfig, resolve_host
+from kvm_pilot.drivers.base import CAPABILITY_PROTOCOLS, Capability, RemoteShell
+from kvm_pilot.errors import CapabilityError, SafetyError, TimeoutError
+from kvm_pilot.safety import DESTRUCTIVE_OPS, SafetyPolicy, deny_all
+from kvm_pilot.ssh import SSHChannel
+
+
+def _cfg(**kw) -> HostConfig:
+    base = {"host": "10.0.0.1", "ssh_host": "10.0.0.2", "ssh_user": "root"}
+    base.update(kw)
+    return HostConfig(**base)
+
+
+# -- capability seam ---------------------------------------------------------
+
+def test_ssh_is_a_registered_capability():
+    assert CAPABILITY_PROTOCOLS[Capability.SSH] is RemoteShell
+
+
+def test_channel_satisfies_remote_shell_protocol():
+    assert isinstance(SSHChannel("h"), RemoteShell)
+
+
+def test_ssh_exec_is_gated_as_destructive():
+    assert "ssh.exec" in DESTRUCTIVE_OPS
+
+
+# -- construction ------------------------------------------------------------
+
+def test_from_config_requires_ssh_host():
+    with pytest.raises(CapabilityError, match="not configured"):
+        SSHChannel.from_config(HostConfig(host="10.0.0.1"))  # no ssh_host
+
+
+def test_from_config_carries_target_fields():
+    ch = SSHChannel.from_config(_cfg(ssh_port=2222))
+    assert ch.host == "10.0.0.2"
+    assert ch.user == "root"
+    assert ch.port == 2222
+    assert ch.target == "root@10.0.0.2"
+
+
+# -- reachability ------------------------------------------------------------
+
+def test_reachable_true_when_socket_connects():
+    with mock.patch("kvm_pilot.ssh.socket.create_connection") as conn:
+        conn.return_value.__enter__.return_value = object()
+        assert SSHChannel("h", port=22).ssh_reachable() is True
+        conn.assert_called_once()
+
+
+def test_reachable_false_and_never_raises_on_oserror():
+    with mock.patch("kvm_pilot.ssh.socket.create_connection", side_effect=OSError("refused")):
+        assert SSHChannel("h").ssh_reachable() is False
+
+
+# -- exec --------------------------------------------------------------------
+
+def test_exec_runs_and_reports_result():
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="ok\n", stderr="")
+    with mock.patch("kvm_pilot.ssh.shutil.which", return_value="/usr/bin/ssh"), \
+         mock.patch("kvm_pilot.ssh.subprocess.run", return_value=completed) as run:
+        res = SSHChannel("h").ssh_exec("uname -a")
+    assert res == {
+        "command": "uname -a", "returncode": 0, "stdout": "ok\n",
+        "stderr": "", "ok": True, "dry_run": False,
+    }
+    # the command is the final argv element (a single post-destination arg)
+    assert run.call_args.args[0][-1] == "uname -a"
+
+
+def test_exec_dry_run_skips_subprocess():
+    ch = SSHChannel("h", safety=SafetyPolicy(dry_run=True))
+    with mock.patch("kvm_pilot.ssh.subprocess.run") as run:
+        res = ch.ssh_exec("rm -rf /")
+    run.assert_not_called()
+    assert res["dry_run"] is True and res["ok"] is False
+
+
+def test_exec_denied_by_confirm_raises_safety_error():
+    ch = SSHChannel("h", safety=SafetyPolicy(confirm=deny_all))
+    with mock.patch("kvm_pilot.ssh.subprocess.run") as run, pytest.raises(SafetyError):
+        ch.ssh_exec("reboot")
+    run.assert_not_called()
+
+
+def test_exec_missing_ssh_binary_raises_capability_error():
+    with mock.patch("kvm_pilot.ssh.shutil.which", return_value=None), \
+         pytest.raises(CapabilityError, match="ssh"):
+        SSHChannel("h").ssh_exec("true")
+
+
+def test_exec_timeout_maps_to_kvm_pilot_timeout():
+    with mock.patch("kvm_pilot.ssh.shutil.which", return_value="/usr/bin/ssh"), \
+         mock.patch("kvm_pilot.ssh.subprocess.run",
+                    side_effect=subprocess.TimeoutExpired("ssh", 5)), \
+         pytest.raises(TimeoutError):
+        SSHChannel("h", timeout=5).ssh_exec("sleep 99")
+
+
+# -- config resolution -------------------------------------------------------
+
+def test_resolve_host_reads_ssh_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("KVM_PILOT_SSH_HOST", "192.168.1.50")
+    monkeypatch.setenv("KVM_PILOT_SSH_USER", "admin")
+    monkeypatch.setenv("KVM_PILOT_SSH_PORT", "2200")
+    cfg = resolve_host(host="10.0.0.1", config_path=tmp_path / "none.toml")
+    assert cfg.ssh_host == "192.168.1.50"
+    assert cfg.ssh_user == "admin"
+    assert cfg.ssh_port == 2200
+
+
+def test_resolve_host_ssh_port_defaults_to_22(tmp_path):
+    cfg = resolve_host(host="10.0.0.1", config_path=tmp_path / "none.toml")
+    assert cfg.ssh_host is None
+    assert cfg.ssh_port == 22


### PR DESCRIPTION
Implements the **in-band SSH-to-target channel** (#81), surfaced by the #111 first-run experience — so an agent can prefer remote recovery over asking a user to physically intervene when the KVM can't power-cycle a black/wedged host.

## Design (posted to #81 before coding)
- **SSH is a per-profile channel, not a KVM-driver capability.** It targets the managed host's OS (a different machine from the KVM); structural capability detection is config-independent, so SSH-as-driver-capability would misreport. A standalone `SSHChannel` (`src/kvm_pilot/ssh.py`) is built from the profile's `ssh_*` config and **gated on `ssh_host` being set** (raises `CapabilityError` otherwise, never inferred from the KVM's address). `Capability.SSH` + `RemoteShell` exist as a **seam** (like `SerialConsole`).
- **Zero new deps:** reachability = stdlib `socket` probe; exec = `subprocess` to the system `ssh` (`BatchMode`). Every exec routes through `safety.guard("ssh.exec", …)`; the probe is read-only/ungated.

## Surface
- **CLI:** `ssh-check` (read-only) / `ssh-exec` (destructive, confirm/dry-run gated).
- **MCP:** `ssh_reachable` (read-only) / `ssh_exec` (destructive, disabled unless the operator sets `KVM_PILOT_MCP_ALLOW_SSH` — mirrors the `power` gate).
- **Config:** `ssh_host` / `ssh_user` / `ssh_port` / `ssh_key` + `KVM_PILOT_SSH_*` (separate from KVM creds).
- **Docs:** MCP README, `configuration.md`, `decisions.md` (channel-vs-driver rationale; why SSH is **not** folded into `recovery-path` — a hung host won't answer SSH), CHANGELOG; SKILL.md recovery guidance now points at the tools.

## Tests
`tests/test_ssh.py` (14 — capability seam, config resolution, reachability, exec success/dry-run/deny/missing-binary/timeout, all sockets+subprocess mocked) + MCP integration tests for both gates. ruff / mypy / full pytest green.

## Deferred (noted, not in this PR)
- A healthcheck `ssh-reachable` check (needs driver plumbing; it's a complementary in-band lever, **not** a hang-reset path).
- The opt-in network **sweep** (`ssh-discover`) — the next PR.

Refs #81, #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
