### PR TITLE
feat: opt-in SSH network sweep — ssh-discover (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   system `ssh`; every exec is gated via the new `ssh.exec` destructive op. Modeled
   as a `Capability.SSH` / `RemoteShell` seam, not a KVM-driver capability (see
   `docs/decisions.md`).
+- **Opt-in SSH host discovery** — CLI `ssh-discover <CIDR>` / MCP `ssh_discover`
+  scan a user-provided range for an open SSH port to help find a target whose
+  address the user doesn't know. **Risky/opt-in by design**: never a default,
+  bounded to ≤1024 hosts, prints a warning, and the MCP tool requires `confirm=true`.
 
 ## [0.1.0a6] — 2026-07-03
 

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -280,6 +280,19 @@ def cmd_ssh_exec(args) -> int:
     return 0 if (result["dry_run"] or result["ok"]) else int(result["returncode"] or 1)
 
 
+def cmd_ssh_discover(args) -> int:
+    """Scan a CIDR for hosts with an open SSH port (RISKY — opt-in, your networks only)."""
+    from .ssh import discover_ssh_hosts
+
+    print(
+        f"WARNING: scanning {args.cidr} for open SSH — only do this on networks you own.",
+        file=sys.stderr,
+    )
+    found = discover_ssh_hosts(args.cidr, port=args.ssh_port)
+    print(json.dumps({"cidr": args.cidr, "port": args.ssh_port, "candidates": found}, indent=2))
+    return 0 if found else 1
+
+
 def cmd_snapshot(args) -> int:
     kvm = _rich_client(args, Capability.VIDEO)
     out = kvm.snapshot_save(args.output)
@@ -728,6 +741,12 @@ def build_parser() -> argparse.ArgumentParser:
                        help="Run a command on the managed host's OS over SSH (in-band; gated)")
     p.add_argument("command", help="The command to run on the target host")
     p.set_defaults(func=cmd_ssh_exec)
+
+    p = sub.add_parser("ssh-discover",
+                       help="Scan a CIDR for open SSH (RISKY, opt-in — your networks only)")
+    p.add_argument("cidr", help="CIDR to scan, e.g. 10.0.1.0/24")
+    p.add_argument("--ssh-port", type=int, default=22, help="SSH port to probe (default 22)")
+    p.set_defaults(func=cmd_ssh_discover)
 
     p = sub.add_parser("boot-progress", help="Structured boot phase (BMC BootProgress)")
     _add_common(p)

--- a/src/kvm_pilot/mcp/README.md
+++ b/src/kvm_pilot/mcp/README.md
@@ -27,6 +27,7 @@ client/driver code stays stdlib-only; `mcp` is imported only in this subpackage.
 | `ssh_reachable` | `readOnlyHint` | Is the **managed host's OS** reachable over SSH (in-band)? Targets the host *behind* the KVM (its own `ssh_host`), not the appliance — use it to prefer remote recovery before physical intervention |
 | `power` | `destructiveHint` | `on` / `off` / `off-hard` / `reset` — **disabled unless the operator opts in** |
 | `ssh_exec` | `destructiveHint` | Run a command on the managed host's OS over SSH — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_SSH`) |
+| `ssh_discover` | `readOnlyHint` | Scan a CIDR for open SSH — **RISKY/opt-in** (active network scan; `confirm=true` required). Only to help find a target the user can't address, on networks they own |
 
 Every tool result names the **host and driver it acted on**, and read-only
 tools always run with a deny-all confirm callback, so a bug in a read path can

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -361,6 +361,29 @@ def ssh_exec(command: str, confirm: bool = False, profile: str | None = None) ->
     return {**_provenance(cfg), **ch.ssh_exec(command)}
 
 
+@mcp.tool(annotations=_READ_ONLY)
+def ssh_discover(cidr: str, confirm: bool = False, port: int = 22) -> dict:
+    """Scan a CIDR for hosts with an open SSH port. RISKY — opt-in.
+
+    An active network scan: noisy, and only acceptable on networks the user owns or
+    is authorized to probe. Use it ONLY to help find a target whose address the user
+    doesn't know, after they confirm the range — never by default. ``confirm=true``
+    is required to acknowledge the scan.
+    """
+    if not confirm:
+        raise ToolError(
+            "ssh_discover was not confirmed. A network scan is risky/noisy — only run "
+            "it on networks the user owns, after they confirm the range."
+        )
+    from kvm_pilot.ssh import discover_ssh_hosts
+
+    try:
+        candidates = discover_ssh_hosts(cidr, port=port)
+    except ValueError as exc:
+        raise ToolError(str(exc)) from exc
+    return {"cidr": cidr, "port": port, "candidates": candidates}
+
+
 def main() -> None:
     mcp.run()
 

--- a/src/kvm_pilot/ssh.py
+++ b/src/kvm_pilot/ssh.py
@@ -14,10 +14,12 @@ third-party SSH library. State-changing execs route through ``SafetyPolicy``
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import shutil
 import socket
 import subprocess  # nosec B404 - intentional: shells out to the system `ssh` (no SSH lib)
+from concurrent.futures import ThreadPoolExecutor
 
 from .config import HostConfig
 from .errors import CapabilityError, TimeoutError
@@ -27,6 +29,43 @@ logger = logging.getLogger("kvm_pilot.ssh")
 
 DEFAULT_SSH_PORT = 22
 _REACHABLE_TIMEOUT = 5.0  # a liveness probe should be quick, regardless of cfg.timeout
+MAX_SWEEP_HOSTS = 1024  # refuse an over-broad scan (~/22); ask for a smaller range
+
+
+def _port_open(host: str, port: int, timeout: float) -> bool:
+    """True if a TCP connection to ``host:port`` succeeds. Never raises."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def discover_ssh_hosts(
+    cidr: str,
+    *,
+    port: int = DEFAULT_SSH_PORT,
+    timeout: float = 0.5,
+    max_hosts: int = MAX_SWEEP_HOSTS,
+) -> list[dict]:
+    """Scan a CIDR for hosts with an open SSH port.
+
+    **RISKY / opt-in.** This is an active network scan — noisy, and only acceptable
+    on networks you own or are authorized to probe. Never run it by default; use it
+    only to help a user find a target whose address they don't know, after they
+    confirm the range. Returns ``[{"host", "port"}]`` for reachable hosts.
+
+    Raises ``ValueError`` for a malformed CIDR or a range larger than ``max_hosts``.
+    """
+    net = ipaddress.ip_network(cidr, strict=False)  # raises ValueError on bad input
+    hosts = list(net.hosts()) or [net.network_address]
+    if len(hosts) > max_hosts:
+        raise ValueError(
+            f"{cidr} covers {len(hosts)} addresses (> {max_hosts}); narrow the range."
+        )
+    with ThreadPoolExecutor(max_workers=min(64, len(hosts))) as pool:
+        checked = pool.map(lambda ip: (str(ip), _port_open(str(ip), port, timeout)), hosts)
+    return [{"host": h, "port": port} for h, is_open in checked if is_open]
 
 
 class SSHChannel:
@@ -89,12 +128,7 @@ class SSHChannel:
 
     def ssh_reachable(self) -> bool:
         """True if the target's SSH port accepts a TCP connection. Never raises."""
-        timeout = min(self.timeout, _REACHABLE_TIMEOUT)
-        try:
-            with socket.create_connection((self.host, self.port), timeout=timeout):
-                return True
-        except OSError:
-            return False
+        return _port_open(self.host, self.port, min(self.timeout, _REACHABLE_TIMEOUT))
 
     def ssh_exec(self, command: str, *, timeout: float | None = None) -> dict:
         """Run ``command`` on the target over SSH. Gated as ``ssh.exec``.
@@ -165,4 +199,4 @@ def _result(command, *, returncode, stdout, stderr, dry_run) -> dict:
     }
 
 
-__all__ = ["SSHChannel", "DEFAULT_SSH_PORT"]
+__all__ = ["SSHChannel", "DEFAULT_SSH_PORT", "MAX_SWEEP_HOSTS", "discover_ssh_hosts"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -35,6 +35,7 @@ EXPECTED_TOOLS = {
     "healthcheck",
     "ssh_reachable",
     "ssh_exec",
+    "ssh_discover",
 }
 # Tools that change state (readOnlyHint=False, destructiveHint=True).
 DESTRUCTIVE_TOOLS = {"power", "ssh_exec"}
@@ -170,6 +171,17 @@ def test_ssh_reachable_errors_when_not_configured(config_file):
     result = run_session(server_env(config_file), interact)
     assert result.isError is True
     assert "not configured" in result.content[0].text
+
+
+def test_ssh_discover_requires_confirm(config_file):
+    """A network scan is risky — it must not run without an explicit acknowledgement."""
+
+    async def interact(session):
+        return await session.call_tool("ssh_discover", {"cidr": "10.0.0.0/30"})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is True
+    assert "not confirmed" in result.content[0].text
 
 
 def test_dry_run_marks_results_and_skips_the_command(config_file):

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -14,7 +14,7 @@ from kvm_pilot.config import HostConfig, resolve_host
 from kvm_pilot.drivers.base import CAPABILITY_PROTOCOLS, Capability, RemoteShell
 from kvm_pilot.errors import CapabilityError, SafetyError, TimeoutError
 from kvm_pilot.safety import DESTRUCTIVE_OPS, SafetyPolicy, deny_all
-from kvm_pilot.ssh import SSHChannel
+from kvm_pilot.ssh import MAX_SWEEP_HOSTS, SSHChannel, discover_ssh_hosts
 
 
 def _cfg(**kw) -> HostConfig:
@@ -126,3 +126,22 @@ def test_resolve_host_ssh_port_defaults_to_22(tmp_path):
     cfg = resolve_host(host="10.0.0.1", config_path=tmp_path / "none.toml")
     assert cfg.ssh_host is None
     assert cfg.ssh_port == 22
+
+
+# -- network sweep (opt-in, risky) -------------------------------------------
+
+def test_discover_returns_only_open_hosts():
+    open_hosts = {"10.0.0.3"}
+    with mock.patch("kvm_pilot.ssh._port_open", side_effect=lambda h, p, t: h in open_hosts):
+        found = discover_ssh_hosts("10.0.0.0/29", port=22)
+    assert found == [{"host": "10.0.0.3", "port": 22}]
+
+
+def test_discover_rejects_over_broad_range():
+    with pytest.raises(ValueError, match="narrow the range"):
+        discover_ssh_hosts(f"10.0.0.0/{32 - (MAX_SWEEP_HOSTS.bit_length())}")  # > MAX_SWEEP_HOSTS
+
+
+def test_discover_rejects_malformed_cidr():
+    with pytest.raises(ValueError):
+        discover_ssh_hosts("not-a-cidr")


### PR DESCRIPTION
Adds an **opt-in, risky** network sweep to find an SSH target whose address the user does not know (per the #111 SSH clarification: ask for the IP/host/FQDN first; offer a sweep as a flagged fallback).

- `discover_ssh_hosts(cidr)` — stdlib `socket` + `ThreadPoolExecutor`, bounded to <=1024 hosts (refuses over-broad ranges), reuses a shared `_port_open` helper.
- **CLI** `ssh-discover <CIDR>` — prints a "your networks only" warning to stderr.
- **MCP** `ssh_discover` — read-only annotation (changes no target state) but **requires `confirm=true`** to acknowledge the scan; bad/oversized CIDR -> clean ToolError.

Never runs by default. Tests cover found/rejected-range/malformed-CIDR and the MCP confirm gate; ruff/mypy/bandit + ssh/mcp suites green.

Refs #81, #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)