### PR TITLE
classify_screen: caller-side vision fallback when server has no key (#125)

### DIFF
--- a/src/kvm_pilot/mcp/README.md
+++ b/src/kvm_pilot/mcp/README.md
@@ -23,7 +23,7 @@ client/driver code stays stdlib-only; `mcp` is imported only in this subpackage.
 | `power_state` | `readOnlyHint` | `powered_on` plus ATX detail where the driver has it |
 | `logs` | `readOnlyHint` | Device/host event log as text (`seek` = seconds of lookback). The text diagnostic when video/streamer/power looks wrong — it names a fault (e.g. a stuck encoder behind a `snapshot` 503) a screenshot can't |
 | `snapshot` | `readOnlyHint` | Current screen, returned as a real JPEG **image** content block the model can see |
-| `classify_screen` | `readOnlyHint` | Boot/run phase via the vision backend (Anthropic or a local VLM, see below) |
+| `classify_screen` | `readOnlyHint` | Boot/run phase. Uses the server-side vision backend (Anthropic or a local VLM, see below) when configured; **if the server has no vision key it falls back to caller-side** — returning the screenshot + prompt/schema for a vision-capable agent to classify. Cheap on-device gates (power-off/no-signal/boot-progress/OCR) resolve with no key at all. Result is a `mode="server"` dict, or a `[json, image]` list to classify yourself |
 | `ssh_reachable` | `readOnlyHint` | Is the **managed host's OS** reachable over SSH (in-band)? Targets the host *behind* the KVM (its own `ssh_host`), not the appliance — use it to prefer remote recovery before physical intervention |
 | `power` | `destructiveHint` | `on` / `off` / `off-hard` / `reset` — **disabled unless the operator opts in** |
 | `ssh_exec` | `destructiveHint` | Run a command on the managed host's OS over SSH — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_SSH`) |
@@ -130,7 +130,7 @@ kvm-pilot-mcp                    # start the stdio server (or: python -m kvm_pil
 | `KVM_PILOT_VISION_BACKEND` | Vision backend for `classify_screen`: `anthropic` (default) or `local` (any OpenAI-compatible VLM: LM Studio, Ollama, vLLM) |
 | `KVM_PILOT_VISION_URL` | Base URL of the local VLM (required for `local`) |
 | `KVM_PILOT_VISION_MODEL` | Vision model id — required for `local`; optional pin for `anthropic` (otherwise the newest model is auto-resolved once per process) |
-| `ANTHROPIC_API_KEY` | Required for the `anthropic` vision backend |
+| `ANTHROPIC_API_KEY` | The `anthropic` vision backend uses it when set; **not required** — without any vision key, `classify_screen` falls back to caller-side classification (returns the screenshot + prompt for a vision-capable agent) |
 
 ## Claude Desktop
 

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -28,6 +28,7 @@ hardware). Treat every result as unverified. See issue #7.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import threading
@@ -42,9 +43,15 @@ from mcp.types import ToolAnnotations
 from kvm_pilot import resolve_host
 from kvm_pilot.config import HostConfig
 from kvm_pilot.drivers import Capability, KVMDriver, make_driver_from_config
-from kvm_pilot.errors import CapabilityError
+from kvm_pilot.errors import CapabilityError, VisionError
 from kvm_pilot.safety import allow_all, deny_all
-from kvm_pilot.vision import ScreenAnalyzer, VisionBackend, make_backend
+from kvm_pilot.vision import (
+    ALL_PHASES,
+    SYSTEM_PROMPT,
+    ScreenAnalyzer,
+    VisionBackend,
+    make_backend,
+)
 
 if TYPE_CHECKING:
     # ``_driver(capability=…)`` guarantees the driver supports the capability at
@@ -269,11 +276,56 @@ def snapshot(profile: str | None = None):
 
 
 @mcp.tool(annotations=_READ_ONLY)
-def classify_screen(hint: str = "", profile: str | None = None) -> dict:
-    """Classify the current screen's boot/run phase via the vision backend (read-only)."""
+def classify_screen(hint: str = "", profile: str | None = None):
+    """Classify the current screen's boot/run phase (read-only).
+
+    Uses the server-side vision backend when one is configured. If the server has
+    no vision credentials (no ``ANTHROPIC_API_KEY`` / ``KVM_PILOT_VISION_*``), it
+    falls back to *caller-side* classification: it returns the screenshot plus the
+    classification prompt/schema so a vision-capable agent can classify the image
+    itself. Cheap on-device gates (power-off, no-signal, boot-progress, OCR rules)
+    still resolve with no credentials at all.
+
+    Return shapes:
+      * server-side / cheap-gate → a dict with ``mode="server"`` + phase fields.
+      * caller-side fallback → a ``[json_text, Image]`` list; classify the image
+        yourself against the ``system_prompt`` / ``phases`` in the JSON block.
+    """
     with _driver(profile, confirm=deny_all, capability=Capability.VIDEO) as (cfg, kvm):
-        state = ScreenAnalyzer(kvm, _vision_backend()).classify(hint=hint)
-        return {**_provenance(cfg), **state.to_dict()}
+        try:
+            state = ScreenAnalyzer(kvm, _vision_backend()).classify(hint=hint)
+        except VisionError as exc:
+            return _classify_fallback(cfg, kvm, hint, exc)
+        return {**_provenance(cfg), "mode": "server", **state.to_dict()}
+
+
+def _classify_fallback(cfg: HostConfig, kvm: KVMDriver, hint: str, exc: VisionError):
+    """Return the screenshot + classification prompt for caller-side vision (#125).
+
+    Server-side vision is unavailable (no key/model, or a backend failure); the
+    calling agent already has vision, so hand it the frame and the same
+    prompt/schema ``classify_screen`` would have used. If we can't even capture a
+    frame there is nothing to delegate — surface a tool error instead.
+    """
+    try:
+        img = cast("Video", kvm).snapshot()
+    except Exception as e:  # noqa: BLE001 - no image means nothing to delegate
+        raise ToolError(
+            f"server-side vision unavailable ({exc}); a fallback snapshot also failed: {e}"
+        ) from e
+    payload = {
+        **_provenance(cfg),
+        "mode": "caller_classify",
+        "reason": str(exc),
+        "hint": hint,
+        "instructions": (
+            "Server-side vision is unavailable. Classify the attached screenshot and "
+            "reply with a JSON object matching the schema in 'system_prompt'."
+        ),
+        "phases": ALL_PHASES,
+        "system_prompt": SYSTEM_PROMPT,
+    }
+    return [json.dumps(payload), Image(data=img, format="jpeg")]
 
 
 @mcp.tool(annotations=_DESTRUCTIVE)

--- a/src/kvm_pilot/skill/SKILL.md
+++ b/src/kvm_pilot/skill/SKILL.md
@@ -44,7 +44,7 @@ remote before physical**, below).
 | Action | Best interface | Notes / fallback |
 |---|---|---|
 | See the screen as a model-visible image | **MCP** `snapshot` | Returns a real image content block — no screenshot-file round-trip. CLI `snapshot` writes a file. |
-| Classify boot/run phase | **MCP** `classify_screen` | Needs a vision backend (Anthropic key or local VLM). CLI: `classify` / `watch`. |
+| Classify boot/run phase | **MCP** `classify_screen` | Uses the server's vision backend if configured; **with no server key it falls back to caller-side** — hands you the screenshot + prompt to classify yourself (a `[json, image]` result). CLI: `classify` / `watch`. |
 | Preflight audit (run first) | **MCP** `healthcheck` or CLI `healthcheck` | The intake gate — see below. |
 | Device info / host power state | **MCP** `info` / `power_state`, or CLI | Either works. |
 | List what the driver supports | **MCP** `capabilities` or CLI `capabilities` | Structural/offline — no network, no preflight. Use it to pick the right interface up front. |
@@ -102,8 +102,11 @@ Prefer remote recovery, in this order, and present the options in this order:
 **The 8 tools it exposes**, all named `mcp__kvm-pilot__<tool>`:
 - Read-only: `info`, `power_state`, `capabilities`, `healthcheck`, `logs`
 - `snapshot` — returns a model-visible JPEG of the screen
-- `classify_screen` — boot/run phase (needs a vision backend: `ANTHROPIC_API_KEY`
-  or a local VLM configured in the **server's** env, else it errors)
+- `classify_screen` — boot/run phase. Uses a server-side vision backend
+  (`ANTHROPIC_API_KEY` or a local VLM in the **server's** env) when present; with
+  no server key it returns `mode="caller_classify"` — the screenshot + prompt for
+  you to classify. Cheap on-device gates (power-off/no-signal/boot-progress/OCR)
+  still resolve with no key at all.
 - `power` — **destructive**, on/off/cycle/reset of the managed host; disabled
   unless the operator set `KVM_PILOT_MCP_ALLOW_POWER=1`, and requires `confirm=true`
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -287,6 +287,71 @@ def test_classify_screen_supports_local_backend(config_file):
     parsed = result_json(result)
     assert parsed["phase"] == "power_off"
     assert parsed["host"] == "fakebox.local"
+    assert parsed["mode"] == "server"
+
+
+def test_classify_screen_cheap_gate_works_without_any_key(config_file):
+    """Keyless deployments (#125) still get structured results for cheap-gate
+    phases: the fake is powered off, so the power gate resolves with no vision
+    credentials and no VLM call — the default anthropic backend is never used."""
+
+    async def interact(session):
+        return await session.call_tool("classify_screen", {})
+
+    # server_env strips ANTHROPIC_API_KEY; the default backend is anthropic.
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is False
+    parsed = result_json(result)
+    assert parsed["mode"] == "server"
+    assert parsed["phase"] == "power_off"
+
+
+def test_classify_fallback_returns_image_and_prompt():
+    """When server-side vision is unavailable, classify_screen hands the caller
+    the screenshot + the prompt/schema to classify it itself (#125). Unit-level
+    because the fake driver over MCP is always powered off (power gate resolves
+    before the backend), so the fallback can't be reached end-to-end there."""
+    from types import SimpleNamespace
+
+    from mcp.server.fastmcp import Image
+
+    from kvm_pilot.drivers import FakeDriver
+    from kvm_pilot.errors import VisionError
+    from kvm_pilot.mcp import server
+
+    cfg = SimpleNamespace(host="fakebox.local", driver="fake")
+    out = server._classify_fallback(
+        cfg, FakeDriver(host="fakebox.local"), "look for a login prompt",
+        VisionError("No Anthropic API key."),
+    )
+    assert isinstance(out, list) and len(out) == 2
+    text, image = out
+    payload = json.loads(text)
+    assert payload["mode"] == "caller_classify"
+    assert payload["host"] == "fakebox.local"
+    assert "No Anthropic API key." in payload["reason"]
+    assert payload["hint"] == "look for a login prompt"
+    assert isinstance(payload["phases"], list) and payload["phases"]
+    assert "phase" in payload["system_prompt"]  # the classification schema prompt
+    assert isinstance(image, Image)
+
+
+def test_classify_fallback_raises_when_snapshot_also_fails():
+    """No image means nothing to delegate -> a clean tool error, not a fallback."""
+    from types import SimpleNamespace
+
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    from kvm_pilot.errors import VisionError
+    from kvm_pilot.mcp import server
+
+    class NoSnapshot:
+        def snapshot(self):
+            raise RuntimeError("streamer offline")
+
+    cfg = SimpleNamespace(host="h", driver="fake")
+    with pytest.raises(ToolError):
+        server._classify_fallback(cfg, NoSnapshot(), "", VisionError("no key"))
 
 
 def test_video_tools_error_cleanly_on_capability_less_driver(config_file):


### PR DESCRIPTION
The MCP server no longer needs its own vision credentials. `classify_screen` tries server-side vision first; on `VisionError` it returns the screenshot + the classification prompt/schema so a vision-capable calling agent classifies the frame. Cheap on-device gates still resolve keyless and report `mode=server`.

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)