### PR TITLE
SSH: runtime host override + ssh-reachable healthcheck (#81)

### DIFF
--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -103,6 +103,10 @@ def _resolve_cfg(args):
         ssl_ca_file=getattr(args, "ssl_ca_file", None),
         driver=getattr(args, "driver", None),
         redfish_auth=getattr(args, "redfish_auth", None),
+        ssh_host=getattr(args, "ssh_host", None),
+        ssh_user=getattr(args, "ssh_user", None),
+        ssh_port=getattr(args, "ssh_port", None),
+        ssh_key=getattr(args, "ssh_key", None),
     )
 
 
@@ -663,6 +667,21 @@ def _add_common(p: argparse.ArgumentParser) -> None:
                         "destructive action (KVM_PILOT_SKIP_HEALTHCHECK=1 also works)")
 
 
+def _add_ssh_target(p: argparse.ArgumentParser) -> None:
+    """Target selection for the ssh-* commands (the managed host's OS, not the KVM).
+
+    Lets a caller pick a profile and/or override the SSH address at runtime — e.g.
+    an install-time DHCP IP the profile can't know until the target boots. These
+    beat the profile/``KVM_PILOT_SSH_*`` env via the usual resolve_host precedence.
+    """
+    p.add_argument("--profile", help="Named host profile from the config file")
+    p.add_argument("--ssh-host", dest="ssh_host",
+                   help="Managed host's SSH address (overrides the profile/env ssh_host)")
+    p.add_argument("--ssh-user", dest="ssh_user", help="SSH username for the managed host")
+    p.add_argument("--ssh-port", dest="ssh_port", type=int, help="SSH port (default 22)")
+    p.add_argument("--ssh-key", dest="ssh_key", help="Path to an SSH private key")
+
+
 def _add_vision(p: argparse.ArgumentParser) -> None:
     p.add_argument("--backend", choices=["anthropic", "local", "openai"], default="anthropic")
     p.add_argument("--vision-url", dest="vision_url",
@@ -735,11 +754,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     p = sub.add_parser("ssh-check",
                        help="Is the managed host's OS reachable over SSH? (read-only)")
+    _add_ssh_target(p)
     p.set_defaults(func=cmd_ssh_check)
 
     p = sub.add_parser("ssh-exec",
                        help="Run a command on the managed host's OS over SSH (in-band; gated)")
     p.add_argument("command", help="The command to run on the target host")
+    _add_ssh_target(p)
+    p.add_argument("--dry-run", dest="dry_run", action="store_true",
+                   help="Log the command without sending it")
+    p.add_argument("--yes", "-y", action="store_true",
+                   help="Skip interactive confirmation")
     p.set_defaults(func=cmd_ssh_exec)
 
     p = sub.add_parser("ssh-discover",

--- a/src/kvm_pilot/drivers/__init__.py
+++ b/src/kvm_pilot/drivers/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from ..errors import KVMPilotError
+from ..errors import CapabilityError, KVMPilotError
 from .base import (
     CAPABILITY_PROTOCOLS,
     GPIO,
@@ -131,22 +131,37 @@ def make_driver_from_config(
     if kind == "fake":
         from .fake import FakeDriver
 
-        return FakeDriver(host=cfg.host, confirm=confirm, dry_run=dry_run)
-    if kind in ("pikvm", "glkvm", "blikvm"):
+        drv: KVMClient | FakeDriver | RedfishDriver = FakeDriver(
+            host=cfg.host, confirm=confirm, dry_run=dry_run
+        )
+    elif kind in ("pikvm", "glkvm", "blikvm"):
         from ..client import PiKVMDriver
         from .pikvm import BliKVMDriver, GLKVMDriver
 
         cls = {"pikvm": PiKVMDriver, "glkvm": GLKVMDriver, "blikvm": BliKVMDriver}[kind]
-        return cls.from_config(cfg, confirm=confirm, dry_run=dry_run)
-    if kind == "redfish":
+        drv = cls.from_config(cfg, confirm=confirm, dry_run=dry_run)
+    elif kind == "redfish":
         from .redfish import RedfishDriver
 
-        return RedfishDriver.from_config(cfg, confirm=confirm, dry_run=dry_run)
-    raise KVMPilotError(
-        f"Driver {kind!r} does not support from-config construction here "
-        "(supported: pikvm, glkvm, blikvm, redfish, fake). Build it directly with "
-        f"make_driver({kind!r}, ...) from the library."
-    )
+        drv = RedfishDriver.from_config(cfg, confirm=confirm, dry_run=dry_run)
+    else:
+        raise KVMPilotError(
+            f"Driver {kind!r} does not support from-config construction here "
+            "(supported: pikvm, glkvm, blikvm, redfish, fake). Build it directly with "
+            f"make_driver({kind!r}, ...) from the library."
+        )
+    # Attach the in-band SSH channel to the managed host's OS when the profile
+    # configures one, so the healthcheck can probe reachability (#81). It adds no
+    # RemoteShell methods, so detect_capabilities is unaffected — SSH-to-target
+    # stays a per-profile channel, not a driver capability.
+    if cfg.ssh_host:
+        from ..ssh import SSHChannel
+
+        try:
+            drv.ssh_channel = SSHChannel.from_config(cfg)  # type: ignore[union-attr]
+        except CapabilityError:
+            pass  # a malformed ssh_host must never break KVM operation
+    return drv
 
 
 def __getattr__(name: str) -> object:

--- a/src/kvm_pilot/health.py
+++ b/src/kvm_pilot/health.py
@@ -221,6 +221,45 @@ def check_api_reachable(driver: Any) -> CheckResult | None:
     )
 
 
+def check_ssh_reachable(driver: Any) -> CheckResult | None:
+    """The managed host's OS answers on its SSH port. Volatile; self-skips.
+
+    Complements ``recovery-path``: an in-band SSH channel to the target OS is a
+    remote-recovery lever (#81). Only present when the profile configured
+    ``ssh_host`` — the driver factory attaches ``driver.ssh_channel`` then, and
+    this check self-skips otherwise. A host that is down is **INFO, not a
+    warning**: powered-off / pre-network / mid-install hosts normally don't
+    answer, and that must not inflate the report or gate a destructive op.
+    """
+    channel = getattr(driver, "ssh_channel", None)
+    if channel is None:
+        return None  # SSH-to-target not configured for this profile
+    try:
+        up = channel.ssh_reachable()
+    except Exception:  # noqa: BLE001 - a liveness probe must never break the audit
+        up = False
+    if up:
+        return CheckResult(
+            id="ssh-reachable",
+            pillar=Pillar.READINESS,
+            severity=Severity.OK,
+            title="Host SSH reachable",
+            detail=f"{channel.target}:{channel.port} accepts TCP — in-band recovery available.",
+            cacheable=False,
+        )
+    return CheckResult(
+        id="ssh-reachable",
+        pillar=Pillar.READINESS,
+        severity=Severity.INFO,
+        title="Host SSH reachable",
+        detail=(
+            f"{channel.target}:{channel.port} did not answer — the OS may be off, "
+            "pre-network, or firewalled."
+        ),
+        cacheable=False,
+    )
+
+
 def check_recovery_path(driver: Any) -> CheckResult | None:
     """Is there ANY out-of-band reset if the guest hangs? (Stable posture.)
 
@@ -672,6 +711,7 @@ def check_capability_profile(driver: Any) -> CheckResult | None:
 # The registry — each check self-guards, so the same list serves every driver.
 CHECKS: list[Check] = [
     check_api_reachable,
+    check_ssh_reachable,
     check_recovery_path,
     check_video_signal,
     check_msd_online,
@@ -946,6 +986,7 @@ def preflight_once(
 def _is_volatile(check: Check) -> bool:
     return getattr(check, "__name__", "") in {
         "check_api_reachable",
+        "check_ssh_reachable",
         "check_video_signal",
         "check_msd_online",
     }

--- a/src/kvm_pilot/mcp/README.md
+++ b/src/kvm_pilot/mcp/README.md
@@ -24,9 +24,9 @@ client/driver code stays stdlib-only; `mcp` is imported only in this subpackage.
 | `logs` | `readOnlyHint` | Device/host event log as text (`seek` = seconds of lookback). The text diagnostic when video/streamer/power looks wrong — it names a fault (e.g. a stuck encoder behind a `snapshot` 503) a screenshot can't |
 | `snapshot` | `readOnlyHint` | Current screen, returned as a real JPEG **image** content block the model can see |
 | `classify_screen` | `readOnlyHint` | Boot/run phase via the vision backend (Anthropic or a local VLM, see below) |
-| `ssh_reachable` | `readOnlyHint` | Is the **managed host's OS** reachable over SSH (in-band)? Targets the host *behind* the KVM (its own `ssh_host`), not the appliance — use it to prefer remote recovery before physical intervention |
+| `ssh_reachable` | `readOnlyHint` | Is the **managed host's OS** reachable over SSH (in-band)? Targets the host *behind* the KVM (its own `ssh_host`), not the appliance — use it to prefer remote recovery before physical intervention. Pass `host=` to override the target at runtime (e.g. an install-time DHCP address the profile can't know); also surfaced as an `ssh-reachable` healthcheck when `ssh_host` is configured |
 | `power` | `destructiveHint` | `on` / `off` / `off-hard` / `reset` — **disabled unless the operator opts in** |
-| `ssh_exec` | `destructiveHint` | Run a command on the managed host's OS over SSH — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_SSH`) |
+| `ssh_exec` | `destructiveHint` | Run a command on the managed host's OS over SSH — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_SSH`). `host=` overrides the target at runtime |
 | `ssh_discover` | `readOnlyHint` | Scan a CIDR for open SSH — **RISKY/opt-in** (active network scan; `confirm=true` required). Only to help find a target the user can't address, on networks they own |
 
 Every tool result names the **host and driver it acted on**, and read-only

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -313,14 +313,19 @@ def power(
 
 
 @mcp.tool(annotations=_READ_ONLY)
-def ssh_reachable(profile: str | None = None) -> dict:
+def ssh_reachable(profile: str | None = None, host: str | None = None) -> dict:
     """Is the managed host's OS reachable over SSH? (read-only, in-band).
 
     Targets the host *behind* the KVM (its own ``ssh_host`` / `KVM_PILOT_SSH_HOST`),
     a different machine from the KVM appliance. Use this to prefer remote recovery
     before asking a user to physically intervene.
+
+    ``host`` overrides the profile/env ``ssh_host`` at runtime — e.g. an install-time
+    DHCP address the profile can't know until the target boots.
     """
     cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
+    if host:
+        cfg.ssh_host = host
     from kvm_pilot.ssh import SSHChannel
 
     try:
@@ -336,11 +341,15 @@ def ssh_reachable(profile: str | None = None) -> dict:
 
 
 @mcp.tool(annotations=_DESTRUCTIVE)
-def ssh_exec(command: str, confirm: bool = False, profile: str | None = None) -> dict:
+def ssh_exec(
+    command: str, confirm: bool = False, profile: str | None = None, host: str | None = None
+) -> dict:
     """Run a command on the managed host's OS over SSH. DESTRUCTIVE / in-band.
 
     Disabled unless the server operator set `KVM_PILOT_MCP_ALLOW_SSH` in the
     server's own environment. ``confirm=true`` is required as a second factor.
+    ``host`` overrides the profile/env ``ssh_host`` at runtime (e.g. a discovered
+    install-time DHCP address).
     """
     if not _env_flag("KVM_PILOT_MCP_ALLOW_SSH"):
         raise ToolError(
@@ -352,6 +361,8 @@ def ssh_exec(command: str, confirm: bool = False, profile: str | None = None) ->
     if not confirm:
         raise ToolError("ssh_exec was not confirmed")
     cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
+    if host:
+        cfg.ssh_host = host
     from kvm_pilot.ssh import SSHChannel
 
     try:

--- a/src/kvm_pilot/ssh.py
+++ b/src/kvm_pilot/ssh.py
@@ -86,6 +86,14 @@ class SSHChannel:
         timeout: float = 30.0,
         safety: SafetyPolicy | None = None,
     ):
+        # A host beginning with '-' can be misparsed by the ssh binary (and by
+        # socket tooling) as an option flag — e.g. '-oProxyCommand=…'. Reject it
+        # rather than pass an attacker-influenced runtime override into argv.
+        if host.startswith("-"):
+            raise CapabilityError(
+                f"Refusing SSH host {host!r}: a leading '-' can be misparsed as an "
+                "ssh option. Provide a hostname or IP address."
+            )
         self.host = host
         self.user = user
         self.port = port

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,23 @@ def test_power_subcommand_parsed():
     assert args.dry_run is True
 
 
+def test_ssh_check_forwards_ssh_target_overrides(monkeypatch):
+    # A runtime --ssh-host (e.g. an install-time DHCP IP the profile can't know)
+    # flows through _resolve_cfg into the HostConfig, beating profile/env (#81).
+    # (ssh-check still resolves a full HostConfig, so give it a KVM host.)
+    from kvm_pilot.cli import _resolve_cfg
+
+    monkeypatch.setenv("KVM_PILOT_HOST", "kvm.local")
+    parser = build_parser()
+    args = parser.parse_args(
+        ["ssh-check", "--ssh-host", "10.9.9.9", "--ssh-port", "2222", "--ssh-user", "root"]
+    )
+    cfg = _resolve_cfg(args)
+    assert cfg.ssh_host == "10.9.9.9"
+    assert cfg.ssh_port == 2222
+    assert cfg.ssh_user == "root"
+
+
 def test_watch_requires_phase():
     parser = build_parser()
     args = parser.parse_args(

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -154,6 +154,28 @@ def test_make_driver_from_config_dispatches_on_cfg_driver() -> None:
         make_driver_from_config(HostConfig(host="h", driver="ipmi"))
 
 
+def test_factory_attaches_ssh_channel_when_configured() -> None:
+    # A profile with ssh_host gets an in-band SSH channel to the target OS (#81),
+    # so the healthcheck can probe reachability. It's a per-profile channel, not a
+    # driver capability, so it must not change detect_capabilities.
+    from kvm_pilot.config import HostConfig
+    from kvm_pilot.drivers import make_driver_from_config
+    from kvm_pilot.drivers.base import Capability, detect_capabilities
+
+    cfg = HostConfig(host="fakebox.local", driver="fake", ssh_host="10.0.0.2", ssh_user="root")
+    drv = make_driver_from_config(cfg)
+    assert drv.ssh_channel.host == "10.0.0.2"  # type: ignore[attr-defined]
+    assert Capability.SSH not in detect_capabilities(drv)  # not a driver capability
+
+
+def test_factory_no_ssh_channel_when_unconfigured() -> None:
+    from kvm_pilot.config import HostConfig
+    from kvm_pilot.drivers import make_driver_from_config
+
+    drv = make_driver_from_config(HostConfig(host="fakebox.local", driver="fake"))
+    assert getattr(drv, "ssh_channel", None) is None
+
+
 # -- shared PowerMixin.hard_cycle (#63) ------------------------------------
 
 def test_hard_cycle_is_shared_from_power_mixin():

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -20,6 +20,7 @@ from kvm_pilot.health import (
     check_exposed_services,
     check_msd_online,
     check_recovery_path,
+    check_ssh_reachable,
     check_tls_posture,
     enforce_gate,
     preflight,
@@ -94,6 +95,45 @@ def test_recovery_path_ok_via_gpio_when_atx_off():
 def test_recovery_path_ok_for_power_capable_bmc_without_atx():
     # No ATX surface but advertises POWER -> genuine OOB reset (BMC/fake).
     assert check_recovery_path(FakeDriver()).severity is Severity.OK
+
+
+def _ssh_channel(*, up: bool | None = True):
+    def reach():
+        if up is None:
+            raise OSError("probe blew up")
+        return up
+    return types.SimpleNamespace(ssh_reachable=reach, target="root@10.0.0.2", port=22)
+
+
+def test_ssh_reachable_check_skips_when_unconfigured():
+    # No ssh_channel attached (profile has no ssh_host) -> the check self-skips.
+    assert check_ssh_reachable(FakeDriver()) is None
+
+
+def test_ssh_reachable_check_ok_when_up():
+    res = check_ssh_reachable(stub(ssh_channel=_ssh_channel(up=True)))
+    assert res is not None
+    assert res.id == "ssh-reachable"
+    assert res.severity is Severity.OK
+    assert res.cacheable is False  # volatile: never cached
+
+
+def test_ssh_reachable_check_info_when_down():
+    # Down is INFO, not WARNING — a pre-network/installer host normally won't
+    # answer and must not inflate the report or gate a destructive op.
+    res = check_ssh_reachable(stub(ssh_channel=_ssh_channel(up=False)))
+    assert res.severity is Severity.INFO
+
+
+def test_ssh_reachable_check_info_when_probe_raises():
+    res = check_ssh_reachable(stub(ssh_channel=_ssh_channel(up=None)))
+    assert res.severity is Severity.INFO
+
+
+def test_ssh_reachable_check_is_volatile():
+    from kvm_pilot.health import _is_volatile
+
+    assert _is_volatile(check_ssh_reachable) is True
 
 
 def test_tls_posture_warns_when_verification_disabled():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -173,6 +173,32 @@ def test_ssh_reachable_errors_when_not_configured(config_file):
     assert "not configured" in result.content[0].text
 
 
+def test_ssh_reachable_host_override_unblocks_unconfigured_profile(config_file):
+    """host= lets a caller target a runtime-discovered address even when the
+    profile has no ssh_host — the install-time DHCP case (#81)."""
+
+    async def interact(session):
+        return await session.call_tool("ssh_reachable", {"host": "127.0.0.1"})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is False  # no longer "not configured"
+    parsed = result_json(result)
+    assert parsed["target"] == "127.0.0.1"
+    assert "reachable" in parsed
+
+
+def test_ssh_reachable_rejects_hyphen_host(config_file):
+    """A host starting with '-' is refused (ssh option-injection) — which also
+    proves the host= override flows into channel construction."""
+
+    async def interact(session):
+        return await session.call_tool("ssh_reachable", {"host": "-oProxyCommand=touch /tmp/x"})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is True
+    assert "misparsed" in result.content[0].text
+
+
 def test_ssh_discover_requires_confirm(config_file):
     """A network scan is risky — it must not run without an explicit acknowledgement."""
 

--- a/tests/test_ssh.py
+++ b/tests/test_ssh.py
@@ -52,6 +52,16 @@ def test_from_config_carries_target_fields():
     assert ch.target == "root@10.0.0.2"
 
 
+def test_reject_hyphen_prefixed_host():
+    # A host beginning with '-' can be misparsed by the ssh binary as an option
+    # (e.g. -oProxyCommand=…). A runtime host override must not smuggle one in.
+    with pytest.raises(CapabilityError, match="misparsed"):
+        SSHChannel("-oProxyCommand=touch /tmp/pwn")
+    # The from_config path (how the CLI/MCP runtime override funnels in) too.
+    with pytest.raises(CapabilityError):
+        SSHChannel.from_config(_cfg(ssh_host="-badhost"))
+
+
 # -- reachability ------------------------------------------------------------
 
 def test_reachable_true_when_socket_connects():


### PR DESCRIPTION
Completes the deferred #81 items: CLI `--ssh-host` and MCP `host=` runtime overrides (so an install-time DHCP IP works without editing config), a `-`-prefix guard against ssh-argv option injection, a driver-attached `ssh_channel`, and a volatile `ssh-reachable` healthcheck (OK up / INFO down / self-skips).

Part of #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)