### PR TITLE
MCP act layer: type/key/shortcut/ctrl_alt_delete with effect gating + approval (#61, #112)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -353,6 +353,29 @@ destructive action, which is exactly the risk the invariant guards against. All
 destructive steps keep their `DESTRUCTIVE_OPS` / `safety.guard()` routing, and the
 health preflight gate still runs before the run.
 
+### MCP act tools: classify by effect, gate by effect, approve per invocation (#61)
+The MCP act tools (`type_text`/`press_key`/`send_shortcut`/`ctrl_alt_delete`) are
+authorized by an **effect class** (`EffectClass` in `safety.py`), not by tool name
+or transport. The class layer is **additive over `DESTRUCTIVE_OPS`** — the set and
+`SafetyPolicy.guard` are unchanged, so the driver stays stdlib-only and the client
+transport guard is untouched; `OP_EFFECT`/`effect_of`/`shortcut_effect` are a
+read-only lookup consumed only by the MCP layer (`mcp/act.py`).
+- **Ctrl+Alt+Del is `power_soft`, not HID.** It is a reboot delivered over the
+  keyboard, so it is gated by `KVM_PILOT_MCP_ALLOW_POWER`, and `send_shortcut`
+  computes its class from the chord (CAD, Magic SysRq `b`/`o`) so a reboot can't
+  slip through the weaker HID gate by choosing a different actuator. The result
+  records **both** transport and effect for the same reason.
+- **Two guarantees, two postures.** (a) *allowed* — operator env flag per effect +
+  a fail-closed `KVM_PILOT_MCP_PROFILES` allowlist; (b) *approved at run time* —
+  MCP elicitation when the client supports it (*interactive*), else an explicit
+  `confirm=true` under a standing policy (*pre-authorized*). The pre-authorized
+  posture is **intentional, not a fallback hack**: an unattended install loop has
+  no human to answer an elicitation, so forcing elicitation-only would break the
+  product's headline use case. Denials return through the same call path
+  (`approved:false` + reason) so the agent recovers instead of hanging.
+- **Deferred to #72:** the signed/expiring consent receipt. The MVP result already
+  carries a stable `invocation_id` + effect class so that layer can build on it.
+
 ## Process
 
 Most structural choices came from adversarial review passes (find → verify →

--- a/src/kvm_pilot/mcp/README.md
+++ b/src/kvm_pilot/mcp/README.md
@@ -25,7 +25,11 @@ client/driver code stays stdlib-only; `mcp` is imported only in this subpackage.
 | `snapshot` | `readOnlyHint` | Current screen, returned as a real JPEG **image** content block the model can see |
 | `classify_screen` | `readOnlyHint` | Boot/run phase via the vision backend (Anthropic or a local VLM, see below) |
 | `ssh_reachable` | `readOnlyHint` | Is the **managed host's OS** reachable over SSH (in-band)? Targets the host *behind* the KVM (its own `ssh_host`), not the appliance — use it to prefer remote recovery before physical intervention |
-| `power` | `destructiveHint` | `on` / `off` / `off-hard` / `reset` — **disabled unless the operator opts in** |
+| `power` | `destructiveHint` | `on` / `off` / `off-hard` / `reset` — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_POWER`) |
+| `type_text` | `destructiveHint` | Type text on the host console (HID keyboard) — needs `KVM_PILOT_MCP_ALLOW_HID` + per-invocation approval |
+| `press_key` | `destructiveHint` | Press one key (e.g. `Enter`, `F2`) — needs `KVM_PILOT_MCP_ALLOW_HID` + approval |
+| `send_shortcut` | `destructiveHint` | Send a key chord (e.g. `ControlLeft,AltLeft,F2`). Gated **by effect**: a reboot/power chord (Ctrl+Alt+Del, Magic SysRq) needs `ALLOW_POWER`; an ordinary session chord needs `ALLOW_HID` |
+| `ctrl_alt_delete` | `destructiveHint` | Send Ctrl+Alt+Del (a reboot) — classified `power_soft`, so it needs `KVM_PILOT_MCP_ALLOW_POWER`, not the HID gate |
 | `ssh_exec` | `destructiveHint` | Run a command on the managed host's OS over SSH — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_SSH`) |
 | `ssh_discover` | `readOnlyHint` | Scan a CIDR for open SSH — **RISKY/opt-in** (active network scan; `confirm=true` required). Only to help find a target the user can't address, on networks they own |
 
@@ -34,6 +38,27 @@ tools always run with a deny-all confirm callback, so a bug in a read path can
 never trip a destructive operation. Drivers are built per call and closed
 afterwards — important for Redfish BMCs, which cap concurrent sessions
 device-side (a leaked session can lock operators out of the BMC).
+
+### Act tools: two guarantees per call (issue #61)
+
+The act tools (`type_text`, `press_key`, `send_shortcut`, `ctrl_alt_delete`)
+require **two** things, not one:
+
+1. **Allowed** — the operator enabled the tool's *effect class* via an env flag in
+   the server's own environment, and the target profile is on `KVM_PILOT_MCP_PROFILES`
+   (if set). Tools are classified by **effect, not transport**: `ctrl_alt_delete`
+   and a Ctrl+Alt+Del / Magic-SysRq chord are reboots, so they need
+   `KVM_PILOT_MCP_ALLOW_POWER` — an agent can't reboot the box through the weaker
+   HID gate by picking a different actuator.
+2. **Approved at run time** — a per-invocation human approval via MCP **elicitation**
+   when the client supports it (*interactive* posture); otherwise an explicit
+   `confirm=true` under the operator's standing policy (*pre-authorized* posture —
+   what an unattended install loop uses, since no human is present to answer).
+
+Denials (gate closed, declined/cancelled, not confirmed, invalidated mid-approval)
+come back as a normal result with `approved: false` and a reason — the agent can
+re-plan, never left hanging. Each result carries a stable `invocation_id` and both
+`transport` and `effect` (the signed/expiring audit receipt is a later step, #72).
 
 ### Which tools work with which driver
 
@@ -51,8 +76,8 @@ the driver kind and the missing capability (it never `AttributeError`s).
 The MCP surface is deliberately small. For anything outside the table, pick the
 right interface (the skill's *Choosing an interface* matrix is the full guide):
 
-- **`firmware-check`/`firmware-update`, `events`, `watch`, `type`/`key`,
-  `mount`/`eject`** → the **CLI** (`kvm-pilot <cmd>`); no MCP tool.
+- **`firmware-check`/`firmware-update`, `events`, `watch`, `mount`/`eject`** →
+  the **CLI** (`kvm-pilot <cmd>`); no MCP tool.
 - **Mouse move/click, MSD mode switching** → the **Python library**.
 - **Reboot the KVM appliance / restart `kvmd`** → **out-of-band SSH** to the
   appliance. No kvm-pilot interface reboots the box; `power` acts on the
@@ -123,8 +148,11 @@ kvm-pilot-mcp                    # start the stdio server (or: python -m kvm_pil
 | `KVM_PILOT_PROFILE` | Default profile from `~/.config/kvm-pilot/config.toml` |
 | `KVM_PILOT_HOST` / `KVM_PILOT_USER` / `KVM_PILOT_PASSWD` / … | Direct device config (see `kvm_pilot.config`); beats file-profile values |
 | `KVM_PILOT_CONFIG` | Path of the config file (default `~/.config/kvm-pilot/config.toml`) |
-| `KVM_PILOT_MCP_ALLOW_POWER` | **Operator-only** opt-in that enables the `power` tool (`1`/`true`/`yes`) |
+| `KVM_PILOT_MCP_ALLOW_POWER` | **Operator-only** opt-in enabling the `power` tool **and** power-effect HID (`ctrl_alt_delete`, reboot chords) (`1`/`true`/`yes`) |
+| `KVM_PILOT_MCP_ALLOW_HID` | **Operator-only** opt-in enabling HID input (`type_text`, `press_key`, ordinary `send_shortcut`) |
 | `KVM_PILOT_MCP_ALLOW_SSH` | **Operator-only** opt-in that enables the `ssh_exec` tool (`1`/`true`/`yes`) |
+| `KVM_PILOT_MCP_PROFILES` | **Fail-closed** allowlist of profile names the server may target (comma-separated). Unset = no allowlist; set-but-empty = allow nothing; a target not on the list is refused (never a fall-back to all configured hosts) |
+| `KVM_PILOT_MCP_ELICIT` | Set to `off` to force the pre-authorized posture (env gate + `confirm=true`) even for elicitation-capable clients; otherwise a per-invocation human approval is requested when the client supports it |
 | `KVM_PILOT_SSH_HOST` / `KVM_PILOT_SSH_USER` / `KVM_PILOT_SSH_PORT` / `KVM_PILOT_SSH_KEY` | The **managed host's** SSH target (a different machine from the KVM) for `ssh_reachable` / `ssh_exec`; also settable per-profile as `ssh_host` etc. |
 | `KVM_PILOT_MCP_DRY_RUN` | Build every driver with `dry_run=True`; destructive calls are logged, never sent |
 | `KVM_PILOT_VISION_BACKEND` | Vision backend for `classify_screen`: `anthropic` (default) or `local` (any OpenAI-compatible VLM: LM Studio, Ollama, vLLM) |

--- a/src/kvm_pilot/mcp/act.py
+++ b/src/kvm_pilot/mcp/act.py
@@ -1,0 +1,314 @@
+"""Per-invocation authorization for the MCP act tools (issue #61).
+
+Two guarantees per act call, from the Armorer Labs security review:
+
+  (a) **allowed** — the effect class is operator-enabled (an env flag set in the
+      server's own environment) *and* the target profile is on the allowlist;
+  (b) **approved at run time** — either a human approved this exact invocation via
+      MCP elicitation (*interactive* posture), or a standing operator policy
+      pre-authorized it and the caller passed ``confirm=True`` (*pre-authorized /
+      unattended* posture — required so the headline unattended-install loop still
+      works when no human is present to answer an elicitation).
+
+Denials/expiries (gate closed, declined, cancelled, not confirmed, context
+changed mid-approval) return through the SAME tool call path — a result dict with
+``approved=False`` and a reason — so an agent can recover, never an out-of-band
+hang. The result records both ``transport`` and ``effect`` so an actuator can't
+launder a power effect by choosing a different tool.
+
+The full signed/expiring consent receipt is deferred to #72; the stable
+``invocation_id`` + effect class are already in the result shape here so #72 can
+build on them.
+
+This module lives under ``mcp/`` (not core), so it may import ``mcp`` and
+``pydantic``; it imports nothing from ``server`` to keep the dependency
+one-directional (server -> act).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ClientCapabilities, ElicitationCapability
+from pydantic import BaseModel
+
+from kvm_pilot.safety import EffectClass
+
+# --------------------------------------------------------------------------- #
+# Guarantee (a): the effect class is operator-enabled                         #
+# --------------------------------------------------------------------------- #
+
+# Each effect maps to the operator env flag that enables it (None = never gated).
+# HID input and HID control share the HID flag; both power tiers share the power
+# flag (so Ctrl+Alt+Del, classified power_soft, needs ALLOW_POWER — it cannot be
+# reached via the weaker HID gate).
+EFFECT_ENABLE_FLAG: dict[EffectClass, str | None] = {
+    EffectClass.OBSERVE: None,
+    EffectClass.HID_INPUT: "KVM_PILOT_MCP_ALLOW_HID",
+    EffectClass.HID_CONTROL: "KVM_PILOT_MCP_ALLOW_HID",
+    EffectClass.MEDIA: "KVM_PILOT_MCP_ALLOW_MEDIA",
+    EffectClass.POWER_SOFT: "KVM_PILOT_MCP_ALLOW_POWER",
+    EffectClass.POWER_HARD: "KVM_PILOT_MCP_ALLOW_POWER",
+    EffectClass.CONFIG_MUTATION: "KVM_PILOT_MCP_ALLOW_CONFIG",
+}
+
+
+def env_flag(name: str) -> bool:
+    """True if env var ``name`` is set to a truthy value (1/true/yes)."""
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
+def gate_enabled(effect: EffectClass) -> bool:
+    """True if the operator enabled this effect class (or it needs no gate)."""
+    flag = EFFECT_ENABLE_FLAG.get(effect, "KVM_PILOT_MCP_ALLOW_CONFIG")
+    return flag is None or env_flag(flag)
+
+
+def enforce_allowlist(profile: str | None) -> str | None:
+    """Fail-closed profile allowlist (``KVM_PILOT_MCP_PROFILES``). Returns the
+    effective profile name, or raises ``ToolError`` if the target isn't allowed.
+
+    - Var **absent** -> no allowlist (today's behavior, back-compat).
+    - Var **present but empty** -> allow nothing (an operator who sets it to ``''``
+      by intent or slip gets lockdown, not wide-open).
+    - A named profile not in the list -> refused; configured targets are never a
+      silent fall-back.
+    - No named profile *and* a single host pinned via ``KVM_PILOT_HOST`` -> allowed
+      (env-pinned, can't roam). No profile and no pinned host -> refused (ambiguous).
+    """
+    if "KVM_PILOT_MCP_PROFILES" not in os.environ:
+        return profile
+    allowed = {p.strip() for p in os.environ["KVM_PILOT_MCP_PROFILES"].split(",") if p.strip()}
+    effective = profile or os.environ.get("KVM_PILOT_PROFILE")
+    if effective is None:
+        if os.environ.get("KVM_PILOT_HOST"):
+            return None  # env-pinned single host; the allowlist governs profile names
+        raise ToolError(
+            "this server has a profile allowlist (KVM_PILOT_MCP_PROFILES) but no profile "
+            "was selected and no single host is pinned — refusing an ambiguous target"
+        )
+    if effective not in allowed:
+        raise ToolError(
+            f"profile {effective!r} is not in this server's allowlist "
+            "(KVM_PILOT_MCP_PROFILES); refusing (configured targets are not a fallback)"
+        )
+    return effective
+
+
+# --------------------------------------------------------------------------- #
+# Guarantee (b): approved at run time                                         #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class InvocationContext:
+    """The invocation an approval binds to (Armorer's binding tuple).
+
+    The signed/expiring receipt is deferred to #72; ``invocation_id`` + ``effect``
+    are stable here so that layer can build on them.
+    """
+
+    invocation_id: str
+    host: str
+    profile: str | None
+    tool: str
+    effect: EffectClass
+    op: str
+    transport: str
+    args_hash: str
+    dry_run: bool
+
+
+def new_invocation(
+    *,
+    host: str,
+    profile: str | None,
+    tool: str,
+    effect: EffectClass,
+    op: str,
+    transport: str,
+    args: dict[str, Any],
+    dry_run: bool,
+) -> InvocationContext:
+    return InvocationContext(
+        invocation_id=uuid.uuid4().hex,
+        host=host,
+        profile=profile,
+        tool=tool,
+        effect=effect,
+        op=op,
+        transport=transport,
+        args_hash=_args_hash(args),
+        dry_run=dry_run,
+    )
+
+
+def _args_hash(args: dict[str, Any]) -> str:
+    """Stable sha256 of the semantic args (canonical JSON)."""
+    canonical = json.dumps(args, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class Approval:
+    approved: bool
+    approver: str | None = None
+    reason: str | None = None
+
+
+class _ApprovalForm(BaseModel):
+    """The elicitation form a human fills to approve an act invocation."""
+
+    approve: bool = False
+    approver: str = "operator"
+
+
+def _elicit_posture_on() -> bool:
+    """Interactive elicitation is on unless the operator set KVM_PILOT_MCP_ELICIT=off."""
+    return os.environ.get("KVM_PILOT_MCP_ELICIT", "").strip().lower() != "off"
+
+
+def _client_supports_elicitation(ctx: Context | None) -> bool:
+    if ctx is None:
+        return False
+    try:
+        return ctx.session.check_client_capability(
+            ClientCapabilities(elicitation=ElicitationCapability())
+        )
+    except Exception:  # noqa: BLE001 - a capability probe must never crash the tool
+        return False
+
+
+def _bound_state(effect: EffectClass) -> tuple[bool, bool]:
+    """The mutable env state an approval is bound to: (dry_run, effect-gate-open).
+
+    Re-checked after the human responds; a change invalidates the approval (the
+    operator flipped dry-run off or revoked the gate while the call was paused).
+    """
+    return (env_flag("KVM_PILOT_MCP_DRY_RUN"), gate_enabled(effect))
+
+
+async def approve_or_deny(ctx: Context | None, inv: InvocationContext, *, confirm: bool) -> Approval:
+    """Run the two-guarantee approval for ``inv``. Never raises for a denial.
+
+    Returns an :class:`Approval`; ``approved=False`` carries a ``reason`` the agent
+    can act on. Only genuinely malformed states raise.
+    """
+    # Guarantee (a): the effect class must be operator-enabled.
+    if not gate_enabled(inv.effect):
+        flag = EFFECT_ENABLE_FLAG.get(inv.effect)
+        return Approval(
+            False,
+            reason=(
+                f"effect '{inv.effect}' is disabled on this server. Only the operator can "
+                f"enable it, by setting {flag} in the server's own environment before "
+                "starting it — it cannot be enabled from within an agent session."
+            ),
+        )
+
+    before = _bound_state(inv.effect)
+
+    # Guarantee (b): approved at run time — interactive elicitation or policy+confirm.
+    if _elicit_posture_on() and _client_supports_elicitation(ctx):
+        decision = await _elicit(ctx, inv)  # type: ignore[arg-type]
+        if not decision.approved:
+            return decision
+        approver = decision.approver or "operator"
+    else:
+        # Pre-authorized / policy posture (unattended): standing enable-flag + confirm.
+        if not confirm:
+            return Approval(
+                False,
+                reason=(
+                    "not approved: this client cannot prompt a human (no elicitation), so "
+                    "an explicit confirm=true is required under the operator's standing "
+                    "policy (the effect gate is the standing authorization)"
+                ),
+            )
+        approver = "policy"
+
+    # Invalidate if the bound env state changed while the human was deciding.
+    if _bound_state(inv.effect) != before:
+        return Approval(
+            False, reason="approval invalidated: dry-run or the effect gate changed mid-approval"
+        )
+    return Approval(True, approver=approver)
+
+
+async def _elicit(ctx: Context, inv: InvocationContext) -> Approval:
+    """Prompt a human to approve this exact invocation. Same-path on any outcome."""
+    message = (
+        f"Approve {inv.tool} on host '{inv.host}'?\n"
+        f"  effect={inv.effect}  transport={inv.transport}  op={inv.op}\n"
+        f"  args_hash={inv.args_hash[:12]}  dry_run={inv.dry_run}  "
+        f"invocation={inv.invocation_id[:8]}"
+    )
+    try:
+        result = await ctx.elicit(message=message, schema=_ApprovalForm)
+    except Exception as exc:  # noqa: BLE001 - a failed prompt is a recoverable denial
+        return Approval(False, reason=f"approval prompt failed: {exc}")
+    if result.action == "accept":
+        data = result.data
+        if data is not None and data.approve:
+            return Approval(True, approver=data.approver or "operator")
+        return Approval(False, reason="denied by approver")
+    return Approval(False, reason=f"approval {result.action}")  # decline / cancel
+
+
+# --------------------------------------------------------------------------- #
+# Result shape (superset of _provenance; #72's receipt builds on it)          #
+# --------------------------------------------------------------------------- #
+
+
+def result(
+    inv: InvocationContext,
+    approval: Approval,
+    *,
+    detail: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """The act-specific result fields (merge with ``_provenance(cfg)`` in the tool).
+
+    Records both ``transport`` and ``effect`` — the anti-bypass invariant — plus a
+    stable ``invocation_id`` and the (unsigned) approval binding tuple for #72.
+    """
+    out: dict[str, Any] = {
+        "invocation_id": inv.invocation_id,
+        "effect": str(inv.effect),
+        "transport": inv.transport,
+        "op": inv.op,
+        "approved": approval.approved,
+        "approval": {
+            "approver": approval.approver,
+            "profile": inv.profile,
+            "args_hash": inv.args_hash,
+            "dry_run": inv.dry_run,
+            "effect": str(inv.effect),
+            "expires": None,  # signed/expiring receipt deferred to #72
+        },
+        "detail": detail,
+        "denied_reason": approval.reason,
+    }
+    if extra:
+        out.update(extra)
+    return out
+
+
+__all__ = [
+    "EFFECT_ENABLE_FLAG",
+    "env_flag",
+    "gate_enabled",
+    "enforce_allowlist",
+    "InvocationContext",
+    "new_invocation",
+    "Approval",
+    "approve_or_deny",
+    "result",
+]

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -11,11 +11,16 @@ SAFETY MODEL (see the co-located README.md for the operator-facing version):
   * The read-only tools (``info``, ``healthcheck``, ``capabilities``,
     ``power_state``, ``logs``, ``snapshot``, ``classify_screen``) run with a
     deny-all confirm callback and carry a ``readOnlyHint`` tool annotation.
-  * The one destructive tool (``power``) carries ``destructiveHint`` and is
-    DISABLED until the human operator sets ``KVM_PILOT_MCP_ALLOW_POWER`` in the
-    server's own environment. The model-supplied ``confirm`` flag is only a
-    second factor, NOT human approval — MCP hosts should additionally require
-    per-call human approval for this tool. Annotations are hints, never a
+  * The destructive tools (``power`` and the HID act tools ``type_text`` /
+    ``press_key`` / ``send_shortcut`` / ``ctrl_alt_delete``) carry
+    ``destructiveHint`` and are DISABLED until the operator opts the tool's
+    *effect class* in via an env flag in the server's own environment
+    (``KVM_PILOT_MCP_ALLOW_POWER`` / ``KVM_PILOT_MCP_ALLOW_HID``). On top of that
+    each act call requires per-invocation approval — a human MCP elicitation when
+    the client supports it, else an explicit ``confirm=true`` under the operator's
+    standing policy. Tools are classified by effect not transport, so a reboot
+    (``ctrl_alt_delete``, a Ctrl+Alt+Del chord) needs the power gate, not the HID
+    gate. See ``act.py`` and the co-located README. Annotations are hints, never a
     security boundary.
   * ``KVM_PILOT_MCP_DRY_RUN=1`` builds every driver with ``dry_run=True``:
     destructive calls are logged and skipped, and results say so.
@@ -35,7 +40,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Literal, cast
 
-from mcp.server.fastmcp import FastMCP, Image
+from mcp.server.fastmcp import Context, FastMCP, Image
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
@@ -43,14 +48,15 @@ from kvm_pilot import resolve_host
 from kvm_pilot.config import HostConfig
 from kvm_pilot.drivers import Capability, KVMDriver, make_driver_from_config
 from kvm_pilot.errors import CapabilityError
-from kvm_pilot.safety import allow_all, deny_all
+from kvm_pilot.mcp import act
+from kvm_pilot.safety import EffectClass, allow_all, deny_all, shortcut_effect
 from kvm_pilot.vision import ScreenAnalyzer, VisionBackend, make_backend
 
 if TYPE_CHECKING:
     # ``_driver(capability=…)`` guarantees the driver supports the capability at
     # runtime; narrow to the owning protocol for the capability-specific calls
     # (mirrors the ``cast`` pattern in cli.py).
-    from kvm_pilot.drivers.base import Logs, Power, SystemInfo, Video
+    from kvm_pilot.drivers.base import HID, Logs, Power, SystemInfo, Video
 
 mcp = FastMCP("kvm-pilot")
 _log = logging.getLogger("kvm_pilot.mcp")
@@ -66,8 +72,8 @@ _POWER_ACTIONS = {
 }
 
 
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+# Single source of truth for the operator env flags (shared with the act layer).
+_env_flag = act.env_flag
 
 
 def _dry_run() -> bool:
@@ -95,6 +101,7 @@ def _driver(
     tool) fails closed on an unacknowledged CRITICAL. ``preflight=False`` skips it
     for structural, offline tools that never touch the network.
     """
+    act.enforce_allowlist(profile)  # fail-closed KVM_PILOT_MCP_PROFILES; raises ToolError
     cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
     kvm = make_driver_from_config(cfg, confirm=confirm, dry_run=_dry_run())
     try:
@@ -310,6 +317,114 @@ def power(
                 f"host '{cfg.host}' ({cfg.driver})"
             )
         return f"power {action}: requested on host '{cfg.host}' ({cfg.driver})"
+
+
+# -- HID act tools (issue #61): see act.py for the two-guarantee model --------
+
+
+async def _act(
+    ctx: Context,
+    profile: str | None,
+    *,
+    tool: str,
+    effect: EffectClass,
+    op: str,
+    transport: str,
+    args: dict,
+    confirm: bool,
+    run: Callable[[KVMDriver], None],
+    detail: str,
+    capability: Capability = Capability.HID,
+) -> dict:
+    """Shared act-tool flow (#61): resolve+gate the driver, run the two-guarantee
+    approval, execute on approval, and return the receipt. Denials come back
+    through the same path (a result with ``approved=False`` + a reason), never a
+    raised error, so the agent can recover. Dry-run is handled by the driver's own
+    SafetyPolicy, so ``run`` becomes a no-op and the receipt still records intent.
+    """
+    with _driver(profile, confirm=allow_all, capability=capability) as (cfg, kvm):
+        inv = act.new_invocation(
+            host=cfg.host, profile=profile, tool=tool, effect=effect, op=op,
+            transport=transport, args=args, dry_run=_dry_run(),
+        )
+        approval = await act.approve_or_deny(ctx, inv, confirm=confirm)
+        if not approval.approved:
+            return {**_provenance(cfg), **act.result(inv, approval)}
+        run(kvm)
+        return {**_provenance(cfg), **act.result(inv, approval, detail=detail)}
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+async def type_text(
+    ctx: Context, text: str, confirm: bool = False, profile: str | None = None
+) -> dict:
+    """Type ``text`` on the managed host's console over the HID keyboard. DESTRUCTIVE.
+
+    Requires the operator to enable HID (``KVM_PILOT_MCP_ALLOW_HID``) *and* a
+    per-invocation approval — a human elicitation when the client supports it, else
+    an explicit ``confirm=true`` under the operator's standing policy.
+    """
+    return await _act(
+        ctx, profile, tool="type_text", effect=EffectClass.HID_INPUT, op="hid.type_text",
+        transport="hid.keyboard", args={"text": text}, confirm=confirm,
+        run=lambda kvm: cast("HID", kvm).type_text(text),
+        detail=f"typed {len(text)} character(s)",
+    )
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+async def press_key(
+    ctx: Context, key: str, confirm: bool = False, profile: str | None = None
+) -> dict:
+    """Press a single key (a kvmd key code, e.g. ``Enter``/``Escape``/``F2``). DESTRUCTIVE.
+
+    Same gating as ``type_text`` (HID input): ``KVM_PILOT_MCP_ALLOW_HID`` + approval.
+    """
+    return await _act(
+        ctx, profile, tool="press_key", effect=EffectClass.HID_INPUT, op="hid.press_key",
+        transport="hid.keyboard", args={"key": key}, confirm=confirm,
+        run=lambda kvm: cast("HID", kvm).press_key(key),
+        detail=f"pressed {key!r}",
+    )
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+async def send_shortcut(
+    ctx: Context, keys: str, confirm: bool = False, profile: str | None = None
+) -> dict:
+    """Send a key chord — comma-separated kvmd key codes, e.g.
+    ``ControlLeft,AltLeft,Delete`` or ``ControlLeft,AltLeft,F2``. DESTRUCTIVE.
+
+    Gated by **effect**, not transport: a reboot/power chord (Ctrl+Alt+Del, Magic
+    SysRq) is classified ``power_soft``/``power_hard`` and needs
+    ``KVM_PILOT_MCP_ALLOW_POWER``; an ordinary session chord is ``hid_control`` and
+    needs ``KVM_PILOT_MCP_ALLOW_HID`` — so a reboot can't slip through the HID gate.
+    """
+    effect = shortcut_effect(keys)
+    return await _act(
+        ctx, profile, tool="send_shortcut", effect=effect, op="hid.send_shortcut",
+        transport="hid.shortcut", args={"keys": keys}, confirm=confirm,
+        run=lambda kvm: cast("HID", kvm).send_shortcut(keys),
+        detail=f"sent shortcut {keys!r}",
+    )
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+async def ctrl_alt_delete(
+    ctx: Context, confirm: bool = False, profile: str | None = None
+) -> dict:
+    """Send Ctrl+Alt+Del to the managed host. DESTRUCTIVE.
+
+    A reboot delivered over the keyboard — classified ``power_soft``, so it needs
+    ``KVM_PILOT_MCP_ALLOW_POWER`` (the same gate as the ``power`` tool), never the
+    weaker HID gate.
+    """
+    return await _act(
+        ctx, profile, tool="ctrl_alt_delete", effect=EffectClass.POWER_SOFT,
+        op="hid.send_shortcut", transport="hid.keyboard", args={}, confirm=confirm,
+        run=lambda kvm: cast("HID", kvm).send_shortcut("ControlLeft,AltLeft,Delete"),
+        detail="sent Ctrl+Alt+Del",
+    )
 
 
 @mcp.tool(annotations=_READ_ONLY)

--- a/src/kvm_pilot/skill/SKILL.md
+++ b/src/kvm_pilot/skill/SKILL.md
@@ -49,7 +49,8 @@ remote before physical**, below).
 | Device info / host power state | **MCP** `info` / `power_state`, or CLI | Either works. |
 | List what the driver supports | **MCP** `capabilities` or CLI `capabilities` | Structural/offline — no network, no preflight. Use it to pick the right interface up front. |
 | **Read the device/host event log** | **MCP** `logs` or **CLI `logs`** | The text diagnostic when video/streamer/power looks wrong — it names a fault (e.g. a stuck encoder behind a `snapshot` 503) a screenshot can't. |
-| firmware-check/update, events, watch, type/key, mount/eject | **CLI only** | The MCP server does not expose these. |
+| Type / press a key / send a shortcut on the host console | **MCP** `type_text` / `press_key` / `send_shortcut` / `ctrl_alt_delete`, or CLI `type` / `key` | HID input, gated by effect: needs `KVM_PILOT_MCP_ALLOW_HID` + per-call approval; a reboot chord (Ctrl+Alt+Del, SysRq) needs `ALLOW_POWER`. |
+| firmware-check/update, events, watch, mount/eject | **CLI only** | The MCP server does not expose these. |
 | Mouse move/click, MSD mode switching | **Python library only** | Not in MCP or CLI. |
 | Change **host** power (on/off/cycle/reset) | **MCP `power`** (gated) or CLI `power` / `power-cycle` | Destructive — confirm each step. MCP `power` is operator-enabled + per-call approval. |
 | Reboot the **KVM appliance** / restart `kvmd` / inspect `/etc/kvmd` | **SSH to the appliance** | No kvm-pilot interface does this — out-of-band only. |
@@ -99,13 +100,19 @@ Prefer remote recovery, in this order, and present the options in this order:
 
 ### Enabling the MCP server
 
-**The 8 tools it exposes**, all named `mcp__kvm-pilot__<tool>`:
-- Read-only: `info`, `power_state`, `capabilities`, `healthcheck`, `logs`
-- `snapshot` — returns a model-visible JPEG of the screen
-- `classify_screen` — boot/run phase (needs a vision backend: `ANTHROPIC_API_KEY`
-  or a local VLM configured in the **server's** env, else it errors)
-- `power` — **destructive**, on/off/cycle/reset of the managed host; disabled
-  unless the operator set `KVM_PILOT_MCP_ALLOW_POWER=1`, and requires `confirm=true`
+**The tools it exposes**, all named `mcp__kvm-pilot__<tool>`:
+- Read-only: `info`, `power_state`, `capabilities`, `healthcheck`, `logs`,
+  `snapshot` (model-visible JPEG), `classify_screen` (boot/run phase — uses a
+  server-side vision backend if configured, else falls back to caller-side
+  classification), `ssh_reachable`
+- **Destructive act tools** — each needs the operator to opt the tool's *effect*
+  in via an env flag **and** a per-invocation approval (a human elicitation, or
+  `confirm=true` under a standing policy):
+  - `power` — on/off/cycle/reset (`KVM_PILOT_MCP_ALLOW_POWER`)
+  - `type_text` / `press_key` / `send_shortcut` — HID input (`KVM_PILOT_MCP_ALLOW_HID`);
+    a reboot chord in `send_shortcut` needs `ALLOW_POWER`
+  - `ctrl_alt_delete` — a reboot, so it needs `ALLOW_POWER` (not the HID gate)
+  - `ssh_exec` — run a command over SSH (`KVM_PILOT_MCP_ALLOW_SSH`)
 
 Every tool takes an optional `profile` argument to pick a device from
 `~/.config/kvm-pilot/config.toml`; omit it to use the server's default profile.

--- a/tests/test_act.py
+++ b/tests/test_act.py
@@ -1,0 +1,156 @@
+"""Unit tests for the MCP act-layer authorization (``kvm_pilot.mcp.act``, #61).
+
+In-process (no subprocess): the effect gate, the fail-closed profile allowlist,
+the invocation/receipt shape, and the two-guarantee approval in its
+pre-authorized posture (``ctx=None`` -> no elicitation -> confirm required).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp.exceptions import ToolError  # noqa: E402
+
+from kvm_pilot.mcp import act  # noqa: E402
+from kvm_pilot.safety import EffectClass  # noqa: E402
+
+_ENV = (
+    "KVM_PILOT_MCP_ALLOW_HID",
+    "KVM_PILOT_MCP_ALLOW_POWER",
+    "KVM_PILOT_MCP_ALLOW_MEDIA",
+    "KVM_PILOT_MCP_PROFILES",
+    "KVM_PILOT_PROFILE",
+    "KVM_PILOT_HOST",
+    "KVM_PILOT_MCP_DRY_RUN",
+    "KVM_PILOT_MCP_ELICIT",
+)
+
+
+def _clear(monkeypatch):
+    for k in _ENV:
+        monkeypatch.delenv(k, raising=False)
+
+
+# -- effect gate -------------------------------------------------------------
+
+
+def test_gate_observe_always_open(monkeypatch):
+    _clear(monkeypatch)
+    assert act.gate_enabled(EffectClass.OBSERVE) is True
+
+
+def test_gate_hid_needs_allow_hid(monkeypatch):
+    _clear(monkeypatch)
+    assert act.gate_enabled(EffectClass.HID_INPUT) is False
+    monkeypatch.setenv("KVM_PILOT_MCP_ALLOW_HID", "1")
+    assert act.gate_enabled(EffectClass.HID_INPUT) is True
+
+
+def test_gate_power_soft_needs_power_not_hid(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("KVM_PILOT_MCP_ALLOW_HID", "1")
+    assert act.gate_enabled(EffectClass.POWER_SOFT) is False  # HID gate is insufficient
+    monkeypatch.setenv("KVM_PILOT_MCP_ALLOW_POWER", "1")
+    assert act.gate_enabled(EffectClass.POWER_SOFT) is True
+
+
+# -- fail-closed profile allowlist -------------------------------------------
+
+
+def test_allowlist_absent_is_passthrough(monkeypatch):
+    _clear(monkeypatch)
+    assert act.enforce_allowlist("anything") == "anything"
+
+
+def test_allowlist_present_but_empty_refuses_all(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("KVM_PILOT_MCP_PROFILES", "")  # set-but-empty -> lockdown
+    with pytest.raises(ToolError):
+        act.enforce_allowlist("fakebox")
+
+
+def test_allowlist_refuses_unlisted_profile(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("KVM_PILOT_MCP_PROFILES", "fakebox, prod")
+    assert act.enforce_allowlist("fakebox") == "fakebox"  # trimmed, listed
+    with pytest.raises(ToolError, match="allowlist"):
+        act.enforce_allowlist("bmc")
+
+
+def test_allowlist_env_pinned_host_allowed_without_profile(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("KVM_PILOT_MCP_PROFILES", "fakebox")
+    monkeypatch.setenv("KVM_PILOT_HOST", "10.0.0.1")
+    assert act.enforce_allowlist(None) is None  # env-pinned single host, can't roam
+
+
+def test_allowlist_ambiguous_default_refused(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("KVM_PILOT_MCP_PROFILES", "fakebox")
+    with pytest.raises(ToolError):
+        act.enforce_allowlist(None)  # no profile and no pinned host -> ambiguous
+
+
+# -- invocation / receipt shape ----------------------------------------------
+
+
+def _inv(**kw):
+    base = dict(
+        host="h", profile="p", tool="type_text", effect=EffectClass.HID_INPUT,
+        op="hid.type_text", transport="hid.keyboard", args={"text": "x"}, dry_run=False,
+    )
+    base.update(kw)
+    return act.new_invocation(**base)
+
+
+def test_args_hash_is_stable_and_order_independent():
+    a = _inv(args={"a": 1, "b": 2})
+    b = _inv(args={"b": 2, "a": 1})
+    assert a.args_hash == b.args_hash
+    assert a.invocation_id != b.invocation_id  # unique per invocation
+
+
+def test_result_records_transport_and_effect():
+    inv = _inv()
+    out = act.result(inv, act.Approval(True, approver="operator"), detail="typed 1")
+    assert out["effect"] == "hid_input"
+    assert out["transport"] == "hid.keyboard"  # anti-bypass: transport AND effect
+    assert out["op"] == "hid.type_text"
+    assert out["approved"] is True
+    assert out["invocation_id"] == inv.invocation_id
+    assert out["approval"]["args_hash"] == inv.args_hash
+    assert out["approval"]["expires"] is None  # signed/expiring receipt deferred to #72
+
+
+# -- approve_or_deny (pre-authorized posture: ctx=None -> no elicitation) -----
+
+
+def test_approval_denied_when_gate_closed(monkeypatch):
+    _clear(monkeypatch)
+    res = asyncio.run(act.approve_or_deny(None, _inv(), confirm=True))
+    assert res.approved is False
+    assert "disabled" in res.reason
+
+
+def test_approval_preauthorized_requires_confirm(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("KVM_PILOT_MCP_ALLOW_HID", "1")
+    assert asyncio.run(act.approve_or_deny(None, _inv(), confirm=False)).approved is False
+    ok = asyncio.run(act.approve_or_deny(None, _inv(), confirm=True))
+    assert ok.approved is True
+    assert ok.approver == "policy"
+
+
+def test_approval_invalidated_on_midflight_state_change(monkeypatch):
+    # If dry-run / the gate flips while the approval is pending, invalidate it.
+    _clear(monkeypatch)
+    monkeypatch.setenv("KVM_PILOT_MCP_ALLOW_HID", "1")
+    states = iter([(False, True), (True, True)])  # snapshot, then changed
+    monkeypatch.setattr(act, "_bound_state", lambda effect: next(states))
+    res = asyncio.run(act.approve_or_deny(None, _inv(), confirm=True))
+    assert res.approved is False
+    assert "invalidated" in res.reason

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -36,9 +36,15 @@ EXPECTED_TOOLS = {
     "ssh_reachable",
     "ssh_exec",
     "ssh_discover",
+    "type_text",
+    "press_key",
+    "send_shortcut",
+    "ctrl_alt_delete",
 }
 # Tools that change state (readOnlyHint=False, destructiveHint=True).
-DESTRUCTIVE_TOOLS = {"power", "ssh_exec"}
+DESTRUCTIVE_TOOLS = {
+    "power", "ssh_exec", "type_text", "press_key", "send_shortcut", "ctrl_alt_delete",
+}
 
 
 @pytest.fixture()
@@ -85,6 +91,28 @@ def result_json(result) -> dict:
     """Parse a dict-returning tool's JSON text content."""
     assert result.content[0].type == "text"
     return json.loads(result.content[0].text)
+
+
+def run_session_elicit(env, interact, *, action, content=None):
+    """Like ``run_session`` but the client advertises elicitation and answers every
+    approval prompt with a fixed ``(action, content)`` — the interactive posture."""
+    from mcp.types import ElicitResult
+
+    async def elicitation_callback(context, params):
+        return ElicitResult(action=action, content=content)
+
+    async def runner():
+        params = StdioServerParameters(
+            command=sys.executable, args=["-m", "kvm_pilot.mcp.server"], env=env
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(
+                read, write, elicitation_callback=elicitation_callback
+            ) as session:
+                await session.initialize()
+                return await interact(session)
+
+    return asyncio.run(asyncio.wait_for(runner(), timeout=60))
 
 
 def test_handshake_lists_annotated_tools(config_file):
@@ -147,6 +175,136 @@ def test_power_executes_on_fake_driver_when_fully_gated(config_file):
     text = result.content[0].text
     assert "requested on host 'fakebox.local' (fake)" in text
     assert "DRY-RUN" not in text
+
+
+# -- HID act tools (#61): effect gates, approval posture, receipt shape -------
+
+
+def test_type_text_denied_without_hid_gate(config_file):
+    # A denial comes back through the SAME call path (not a raised error) so the
+    # agent can recover.
+    async def interact(session):
+        return await session.call_tool("type_text", {"text": "hello", "confirm": True})
+
+    parsed = result_json(run_session(server_env(config_file), interact))
+    assert parsed["approved"] is False
+    assert "disabled" in parsed["denied_reason"]
+
+
+def test_type_text_preauthorized_with_confirm(config_file):
+    # No elicitation client -> pre-authorized posture: standing ALLOW_HID + confirm.
+    async def interact(session):
+        return await session.call_tool("type_text", {"text": "root", "confirm": True})
+
+    parsed = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert parsed["approved"] is True
+    assert parsed["effect"] == "hid_input"
+    assert parsed["transport"] == "hid.keyboard"
+    assert parsed["op"] == "hid.type_text"
+    assert parsed["invocation_id"]
+    assert parsed["approval"]["args_hash"]
+    assert parsed["approval"]["approver"] == "policy"
+
+
+def test_type_text_denied_without_confirm_in_preauthorized(config_file):
+    async def interact(session):
+        return await session.call_tool("type_text", {"text": "x"})
+
+    parsed = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert parsed["approved"] is False
+    assert "confirm=true" in parsed["denied_reason"]
+
+
+def test_ctrl_alt_delete_needs_power_gate_not_hid(config_file):
+    # CAD is classified power_soft: ALLOW_HID must NOT suffice; ALLOW_POWER does.
+    async def interact(session):
+        return await session.call_tool("ctrl_alt_delete", {"confirm": True})
+
+    hid_only = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert hid_only["approved"] is False
+    powered = result_json(
+        run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1"), interact)
+    )
+    assert powered["approved"] is True
+    assert powered["effect"] == "power_soft"
+
+
+def test_send_shortcut_cad_cannot_slip_the_hid_gate(config_file):
+    async def interact(session):
+        return await session.call_tool(
+            "send_shortcut", {"keys": "ControlLeft,AltLeft,Delete", "confirm": True}
+        )
+
+    hid_only = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert hid_only["approved"] is False  # power_soft chord, HID gate insufficient
+    powered = result_json(
+        run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1"), interact)
+    )
+    assert powered["approved"] is True
+    assert powered["effect"] == "power_soft"
+
+
+def test_send_shortcut_vt_switch_uses_hid_gate(config_file):
+    async def interact(session):
+        return await session.call_tool(
+            "send_shortcut", {"keys": "ControlLeft,AltLeft,F2", "confirm": True}
+        )
+
+    parsed = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert parsed["approved"] is True
+    assert parsed["effect"] == "hid_control"
+
+
+def test_act_interactive_elicit_accept(config_file):
+    # An elicitation-capable client uses the interactive posture (no confirm needed).
+    async def interact(session):
+        return await session.call_tool("type_text", {"text": "hi"})
+
+    env = server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1")
+    parsed = result_json(
+        run_session_elicit(env, interact, action="accept", content={"approve": True, "approver": "alice"})
+    )
+    assert parsed["approved"] is True
+    assert parsed["approval"]["approver"] == "alice"
+
+
+def test_act_interactive_elicit_decline_returns_same_path(config_file):
+    async def interact(session):
+        return await session.call_tool("type_text", {"text": "hi"})
+
+    env = server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1")
+    parsed = result_json(run_session_elicit(env, interact, action="decline"))
+    assert parsed["approved"] is False
+    assert "decline" in parsed["denied_reason"]
+
+
+def test_act_interactive_elicit_accept_but_not_approved(config_file):
+    async def interact(session):
+        return await session.call_tool("type_text", {"text": "hi"})
+
+    env = server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1")
+    parsed = result_json(
+        run_session_elicit(env, interact, action="accept", content={"approve": False})
+    )
+    assert parsed["approved"] is False
+
+
+def test_allowlist_refuses_profile_not_listed(config_file):
+    async def interact(session):
+        return await session.call_tool("info", {"profile": "bmc"})
+
+    env = server_env(config_file, KVM_PILOT_MCP_PROFILES="fakebox")
+    result = run_session(env, interact)
+    assert result.isError is True
+    assert "allowlist" in result.content[0].text
+
+
+def test_allowlist_allows_listed_profile(config_file):
+    async def interact(session):
+        return await session.call_tool("info", {})  # default profile 'fakebox' is listed
+
+    env = server_env(config_file, KVM_PILOT_MCP_PROFILES="fakebox")
+    assert run_session(env, interact).isError is False
 
 
 def test_ssh_exec_errors_without_operator_gate(config_file):


### PR DESCRIPTION
**Stacked on #130** (effect taxonomy). The MCP server can now DRIVE a box: new async HID tools authorized by two guarantees (Armorer Labs review) via a new `mcp/act.py`:
- gated by **effect** (ALLOW_HID for input; ctrl_alt_delete + reboot chords are power_soft → ALLOW_POWER), receipt records transport **and** effect;
- approved per invocation — MCP elicitation when the client supports it, else `confirm=true` under a standing policy (unattended posture);
- denials return through the same call path (never a hang); fail-closed `KVM_PILOT_MCP_PROFILES` allowlist; stable `invocation_id` + effect for #72's future signed receipt.

Part of #61, closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)