### PR TITLE
MCP mouse tool with generation-keyed staleness gate (#124)

### DIFF
--- a/src/kvm_pilot/mcp/README.md
+++ b/src/kvm_pilot/mcp/README.md
@@ -30,6 +30,7 @@ client/driver code stays stdlib-only; `mcp` is imported only in this subpackage.
 | `press_key` | `destructiveHint` | Press one key (e.g. `Enter`, `F2`) — needs `KVM_PILOT_MCP_ALLOW_HID` + approval |
 | `send_shortcut` | `destructiveHint` | Send a key chord (e.g. `ControlLeft,AltLeft,F2`). Gated **by effect**: a reboot/power chord (Ctrl+Alt+Del, Magic SysRq) needs `ALLOW_POWER`; an ordinary session chord needs `ALLOW_HID` |
 | `ctrl_alt_delete` | `destructiveHint` | Send Ctrl+Alt+Del (a reboot) — classified `power_soft`, so it needs `KVM_PILOT_MCP_ALLOW_POWER`, not the HID gate |
+| `mouse` | `destructiveHint` | Move (and optionally click) the mouse. Coords in `percent` (0.0-1.0, default), `pixel`, or `raw` kvmd. A **click** must carry `observed_frame_ref` from a prior `snapshot`; it's refused if the host rebooted/swapped media since (generation changed) so it can't land on a stale screen. Needs `KVM_PILOT_MCP_ALLOW_HID` |
 | `ssh_exec` | `destructiveHint` | Run a command on the managed host's OS over SSH — **disabled unless the operator opts in** (`KVM_PILOT_MCP_ALLOW_SSH`) |
 | `ssh_discover` | `readOnlyHint` | Scan a CIDR for open SSH — **RISKY/opt-in** (active network scan; `confirm=true` required). Only to help find a target the user can't address, on networks they own |
 
@@ -78,7 +79,7 @@ right interface (the skill's *Choosing an interface* matrix is the full guide):
 
 - **`firmware-check`/`firmware-update`, `events`, `watch`, `mount`/`eject`** →
   the **CLI** (`kvm-pilot <cmd>`); no MCP tool.
-- **Mouse move/click, MSD mode switching** → the **Python library**.
+- **MSD mode switching** → the **Python library**.
 - **Reboot the KVM appliance / restart `kvmd`** → **out-of-band SSH** to the
   appliance. No kvm-pilot interface reboots the box; `power` acts on the
   *managed host*, not the appliance.

--- a/src/kvm_pilot/mcp/act.py
+++ b/src/kvm_pilot/mcp/act.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import threading
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -301,6 +302,70 @@ def result(
     return out
 
 
+# --------------------------------------------------------------------------- #
+# Generation-keyed frame identity (mouse staleness, issue #124)               #
+# --------------------------------------------------------------------------- #
+#
+# A per-host counter, bumped after any media/power effect. It is folded into the
+# frame_ref an agent gets from `snapshot`, so a reference minted before a
+# reboot/ISO-swap/retarget can't match one minted after (even if the pixels
+# coincide) — an absolute mouse click can't land on a stale screen. Comparing the
+# generation is a free in-memory check (no re-snapshot), and doesn't false-block
+# on spinners/clocks/cursor blink the way a pixel hash would. In-memory only: a
+# server restart resets it to 0, which conservatively invalidates old refs.
+
+_GENERATIONS: dict[str, int] = {}
+_gen_lock = threading.Lock()
+
+# Effects that change the screen enough to invalidate a prior observation.
+_GENERATION_BUMPING = (EffectClass.MEDIA, EffectClass.POWER_SOFT, EffectClass.POWER_HARD)
+
+
+def generation(host: str) -> int:
+    with _gen_lock:
+        return _GENERATIONS.get(host, 0)
+
+
+def bump_generation(host: str) -> int:
+    with _gen_lock:  # read-modify-write is atomic under the lock
+        _GENERATIONS[host] = _GENERATIONS.get(host, 0) + 1
+        return _GENERATIONS[host]
+
+
+def bumps_generation(effect: EffectClass) -> bool:
+    return effect in _GENERATION_BUMPING
+
+
+def frame_ref(host: str, image: bytes) -> str:
+    """An observation token ``host:generation:shorthash`` for a captured frame."""
+    return f"{host}:{generation(host)}:{hashlib.sha256(image).hexdigest()[:16]}"
+
+
+def frame_ref_generation(ref: str) -> int | None:
+    """Parse the generation segment of a frame_ref, or None if malformed.
+
+    ``rsplit(':', 2)`` so a host containing ':' (IPv6, host:port) still parses.
+    """
+    parts = ref.rsplit(":", 2)
+    if len(parts) != 3:
+        return None
+    try:
+        return int(parts[1])
+    except ValueError:
+        return None
+
+
+def pct_to_kvmd(p: float) -> int:
+    """Map a 0.0-1.0 screen fraction to kvmd's centered absolute axis (-32768..32767).
+
+    Resolution-free: the kvmd absolute space already *is* a fraction of the screen,
+    so a percentage coordinate survives a mode/resolution change (BIOS->GRUB->OS)
+    that would invalidate a pixel coordinate.
+    """
+    p = max(0.0, min(1.0, p))
+    return round(-32768 + p * 65535)
+
+
 __all__ = [
     "EFFECT_ENABLE_FLAG",
     "env_flag",
@@ -311,4 +376,10 @@ __all__ = [
     "Approval",
     "approve_or_deny",
     "result",
+    "generation",
+    "bump_generation",
+    "bumps_generation",
+    "frame_ref",
+    "frame_ref_generation",
+    "pct_to_kvmd",
 ]

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -33,6 +33,7 @@ hardware). Treat every result as unverified. See issue #7.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import threading
@@ -267,12 +268,20 @@ def logs(seek: int = 0, profile: str | None = None) -> dict:
 
 @mcp.tool(annotations=_READ_ONLY)
 def snapshot(profile: str | None = None):
-    """Capture the current KVM screen and return it as a viewable JPEG image (read-only)."""
+    """Capture the current KVM screen (read-only).
+
+    Returns ``[json_text, image]``: the JSON carries a ``frame_ref``
+    (``host:generation:hash``) — pass it back to the ``mouse`` tool as
+    ``observed_frame_ref`` so an absolute click can be refused if the host rebooted
+    or swapped media since you looked.
+    """
     with _driver(profile, confirm=deny_all, capability=Capability.VIDEO) as (cfg, kvm):
+        img = cast("Video", kvm).snapshot()
         note = f"screen of host '{cfg.host}' via the '{cfg.driver}' driver"
         if _dry_run():
             note += " (dry-run session)"
-        return [note, Image(data=cast("Video", kvm).snapshot(), format="jpeg")]
+        payload = {**_provenance(cfg), "frame_ref": act.frame_ref(cfg.host, img), "note": note}
+        return [json.dumps(payload), Image(data=img, format="jpeg")]
 
 
 @mcp.tool(annotations=_READ_ONLY)
@@ -351,6 +360,10 @@ async def _act(
         if not approval.approved:
             return {**_provenance(cfg), **act.result(inv, approval)}
         run(kvm)
+        # A media/power effect changes the screen enough to invalidate prior
+        # observations — bump the frame generation so a stale mouse ref won't match.
+        if not inv.dry_run and act.bumps_generation(inv.effect):
+            act.bump_generation(cfg.host)
         return {**_provenance(cfg), **act.result(inv, approval, detail=detail)}
 
 
@@ -425,6 +438,86 @@ async def ctrl_alt_delete(
         run=lambda kvm: cast("HID", kvm).send_shortcut("ControlLeft,AltLeft,Delete"),
         detail="sent Ctrl+Alt+Del",
     )
+
+
+def _mouse_stale(host: str, observed_frame_ref: str | None) -> str | None:
+    """A denial reason if the observation is missing or from a stale generation, else None."""
+    if not observed_frame_ref:
+        return "a mouse click requires observed_frame_ref from a prior snapshot"
+    obs_gen = act.frame_ref_generation(observed_frame_ref)
+    if obs_gen is None:
+        return f"observed_frame_ref {observed_frame_ref!r} is not a valid frame reference"
+    if obs_gen != act.generation(host):
+        return (
+            "frame was observed before a power/media state change on this host; "
+            "re-snapshot and retry so the click can't land on a stale screen"
+        )
+    return None
+
+
+def _run_mouse(kvm: KVMDriver, x: float, y: float, coord_space: str, button: str | None) -> None:
+    hid = cast("HID", kvm)
+    if coord_space == "percent":
+        hid.mouse_move(act.pct_to_kvmd(x), act.pct_to_kvmd(y))
+    elif coord_space == "raw":
+        hid.mouse_move(int(x), int(y))
+    else:  # pixel — needs a driver that reports its capture resolution
+        move_px = getattr(kvm, "mouse_move_pixels", None)
+        if move_px is None:
+            raise ToolError(
+                "this driver has no pixel-coordinate mouse support; use coord_space='percent'"
+            )
+        move_px(int(x), int(y))
+    if button is not None:
+        hid.mouse_click(button)
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+async def mouse(
+    ctx: Context,
+    x: float,
+    y: float,
+    observed_frame_ref: str | None = None,
+    coord_space: Literal["percent", "pixel", "raw"] = "percent",
+    button: Literal["left", "right", "middle"] | None = None,
+    confirm: bool = False,
+    profile: str | None = None,
+) -> dict:
+    """Move the mouse (and optionally click) on the host. DESTRUCTIVE (HID input).
+
+    Absolute positioning depends on current screen state, so a **click** must carry
+    the ``observed_frame_ref`` it was planned against (from a prior ``snapshot``). If
+    the host has since rebooted or swapped media (its frame *generation* changed) the
+    call is refused so the click can't land on a stale screen — re-``snapshot`` and
+    retry. A move-only call (``button`` omitted) needs no ref.
+
+    ``coord_space``: ``percent`` (0.0-1.0, default — robust to a resolution change),
+    ``pixel`` (screen pixels; needs a driver that reports resolution), or ``raw``
+    (kvmd centered -32768..32767). ``button``: omit to move only, else move + click.
+    Gated by ``KVM_PILOT_MCP_ALLOW_HID`` + per-invocation approval.
+    """
+    with _driver(profile, confirm=allow_all, capability=Capability.HID) as (cfg, kvm):
+        inv = act.new_invocation(
+            host=cfg.host, profile=profile, tool="mouse", effect=EffectClass.HID_INPUT,
+            op="hid.mouse_click" if button else "hid.mouse_move", transport="hid.mouse",
+            args={"x": x, "y": y, "coord_space": coord_space, "button": button},
+            dry_run=_dry_run(),
+        )
+        # Staleness gate (clicks only): the observation must be from this generation.
+        if button is not None:
+            stale = _mouse_stale(cfg.host, observed_frame_ref)
+            if stale is not None:
+                return {**_provenance(cfg), **act.result(inv, act.Approval(False, reason=stale))}
+        approval = await act.approve_or_deny(ctx, inv, confirm=confirm)
+        if not approval.approved:
+            return {**_provenance(cfg), **act.result(inv, approval)}
+        if not inv.dry_run:
+            _run_mouse(kvm, x, y, coord_space, button)
+        detail = f"moved to ({x}, {y}) [{coord_space}]" + (f" + {button} click" if button else "")
+        return {
+            **_provenance(cfg),
+            **act.result(inv, approval, detail=detail, extra={"coord_space": coord_space}),
+        }
 
 
 @mcp.tool(annotations=_READ_ONLY)

--- a/src/kvm_pilot/skill/SKILL.md
+++ b/src/kvm_pilot/skill/SKILL.md
@@ -50,8 +50,9 @@ remote before physical**, below).
 | List what the driver supports | **MCP** `capabilities` or CLI `capabilities` | Structural/offline — no network, no preflight. Use it to pick the right interface up front. |
 | **Read the device/host event log** | **MCP** `logs` or **CLI `logs`** | The text diagnostic when video/streamer/power looks wrong — it names a fault (e.g. a stuck encoder behind a `snapshot` 503) a screenshot can't. |
 | Type / press a key / send a shortcut on the host console | **MCP** `type_text` / `press_key` / `send_shortcut` / `ctrl_alt_delete`, or CLI `type` / `key` | HID input, gated by effect: needs `KVM_PILOT_MCP_ALLOW_HID` + per-call approval; a reboot chord (Ctrl+Alt+Del, SysRq) needs `ALLOW_POWER`. |
+| Move / click the mouse (installers, BIOS, desktops) | **MCP** `mouse` | Absolute positioning; `percent` coords by default. A click must carry `observed_frame_ref` from a recent `snapshot` (refused if the host rebooted since). Needs `KVM_PILOT_MCP_ALLOW_HID`. |
 | firmware-check/update, events, watch, mount/eject | **CLI only** | The MCP server does not expose these. |
-| Mouse move/click, MSD mode switching | **Python library only** | Not in MCP or CLI. |
+| MSD mode switching | **Python library only** | Not in MCP or CLI. |
 | Change **host** power (on/off/cycle/reset) | **MCP `power`** (gated) or CLI `power` / `power-cycle` | Destructive — confirm each step. MCP `power` is operator-enabled + per-call approval. |
 | Reboot the **KVM appliance** / restart `kvmd` / inspect `/etc/kvmd` | **SSH to the appliance** | No kvm-pilot interface does this — out-of-band only. |
 | Check if the **target host** is reachable / run commands on it once its OS is up | **MCP `ssh_reachable` / `ssh_exec`**, or CLI `ssh-check` / `ssh-exec` (in-band) | Prefer SSH over KVM keystrokes once the OS is up. Configure the target's IP/host/FQDN via `ssh_host` (≠ the KVM's address); `ssh_exec` is gated (operator opt-in `KVM_PILOT_MCP_ALLOW_SSH`). See "Recovery order" below. |

--- a/tests/test_act.py
+++ b/tests/test_act.py
@@ -154,3 +154,48 @@ def test_approval_invalidated_on_midflight_state_change(monkeypatch):
     res = asyncio.run(act.approve_or_deny(None, _inv(), confirm=True))
     assert res.approved is False
     assert "invalidated" in res.reason
+
+
+# -- generation-keyed frame identity (#124) ----------------------------------
+
+
+def test_frame_ref_format_and_generation_parse():
+    ref = act.frame_ref("10.0.0.5", b"abc")
+    host, gen, digest = ref.rsplit(":", 2)
+    assert host == "10.0.0.5"
+    assert gen == "0"
+    assert len(digest) == 16
+    assert act.frame_ref_generation(ref) == 0
+
+
+def test_frame_ref_generation_handles_colon_bearing_host():
+    # rsplit(':', 2) keeps an IPv6 / host:port intact.
+    assert act.frame_ref_generation("fe80::1:3:deadbeefdeadbeef") == 3
+
+
+def test_frame_ref_generation_none_on_malformed():
+    assert act.frame_ref_generation("garbage") is None
+    assert act.frame_ref_generation("h:notanint:hash") is None
+
+
+def test_bump_generation_increments_per_host():
+    h = "gen-increment-host"
+    start = act.generation(h)
+    assert act.bump_generation(h) == start + 1
+    assert act.generation(h) == start + 1
+
+
+def test_bumps_generation_only_for_media_and_power():
+    assert act.bumps_generation(EffectClass.MEDIA) is True
+    assert act.bumps_generation(EffectClass.POWER_SOFT) is True
+    assert act.bumps_generation(EffectClass.POWER_HARD) is True
+    assert act.bumps_generation(EffectClass.HID_INPUT) is False
+    assert act.bumps_generation(EffectClass.HID_CONTROL) is False
+
+
+@pytest.mark.parametrize(
+    "p,expected",
+    [(0.0, -32768), (0.5, 0), (1.0, 32767), (-1.0, -32768), (2.0, 32767)],
+)
+def test_pct_to_kvmd_maps_and_clamps(p, expected):
+    assert act.pct_to_kvmd(p) == expected

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -40,10 +40,11 @@ EXPECTED_TOOLS = {
     "press_key",
     "send_shortcut",
     "ctrl_alt_delete",
+    "mouse",
 }
 # Tools that change state (readOnlyHint=False, destructiveHint=True).
 DESTRUCTIVE_TOOLS = {
-    "power", "ssh_exec", "type_text", "press_key", "send_shortcut", "ctrl_alt_delete",
+    "power", "ssh_exec", "type_text", "press_key", "send_shortcut", "ctrl_alt_delete", "mouse",
 }
 
 
@@ -305,6 +306,86 @@ def test_allowlist_allows_listed_profile(config_file):
 
     env = server_env(config_file, KVM_PILOT_MCP_PROFILES="fakebox")
     assert run_session(env, interact).isError is False
+
+
+# -- mouse + generation-keyed staleness (#124) -------------------------------
+
+
+def test_snapshot_returns_frame_ref(config_file):
+    async def interact(session):
+        return await session.call_tool("snapshot", {})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is False
+    payload = json.loads(result.content[0].text)
+    assert payload["host"] == "fakebox.local"
+    assert payload["frame_ref"].startswith("fakebox.local:0:")
+    assert any(c.type == "image" for c in result.content)
+
+
+def test_mouse_move_only_needs_no_ref(config_file):
+    async def interact(session):
+        return await session.call_tool("mouse", {"x": 0.5, "y": 0.5, "confirm": True})
+
+    parsed = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert parsed["approved"] is True
+    assert parsed["op"] == "hid.mouse_move"
+    assert parsed["coord_space"] == "percent"
+
+
+def test_mouse_click_requires_observed_frame_ref(config_file):
+    async def interact(session):
+        return await session.call_tool(
+            "mouse", {"x": 0.5, "y": 0.5, "button": "left", "confirm": True}
+        )
+
+    parsed = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert parsed["approved"] is False
+    assert "observed_frame_ref" in parsed["denied_reason"]
+
+
+def test_mouse_click_with_fresh_ref_is_approved(config_file):
+    async def interact(session):
+        snap = await session.call_tool("snapshot", {})
+        ref = json.loads(snap.content[0].text)["frame_ref"]
+        return await session.call_tool(
+            "mouse",
+            {"x": 0.67, "y": 0.28, "button": "left", "observed_frame_ref": ref, "confirm": True},
+        )
+
+    parsed = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert parsed["approved"] is True
+    assert parsed["op"] == "hid.mouse_click"
+
+
+def test_mouse_click_refused_after_generation_bump(config_file):
+    # A reboot (ctrl_alt_delete, power_soft) bumps the frame generation, so a click
+    # planned against the pre-reboot frame is refused rather than landing blind.
+    async def interact(session):
+        snap = await session.call_tool("snapshot", {})
+        ref = json.loads(snap.content[0].text)["frame_ref"]
+        await session.call_tool("ctrl_alt_delete", {"confirm": True})
+        return await session.call_tool(
+            "mouse",
+            {"x": 0.5, "y": 0.5, "button": "left", "observed_frame_ref": ref, "confirm": True},
+        )
+
+    env = server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1", KVM_PILOT_MCP_ALLOW_POWER="1")
+    parsed = result_json(run_session(env, interact))
+    assert parsed["approved"] is False
+    assert "stale screen" in parsed["denied_reason"]
+
+
+def test_mouse_click_malformed_ref_refused(config_file):
+    async def interact(session):
+        return await session.call_tool(
+            "mouse",
+            {"x": 0.5, "y": 0.5, "button": "left", "observed_frame_ref": "garbage", "confirm": True},
+        )
+
+    parsed = result_json(run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_HID="1"), interact))
+    assert parsed["approved"] is False
+    assert "valid frame reference" in parsed["denied_reason"]
 
 
 def test_ssh_exec_errors_without_operator_gate(config_file):


### PR DESCRIPTION
**Stacked on the act-layer PR.** Absolute `mouse` tool (move + optional click); percent coords by default (resolution-free). A click must carry `observed_frame_ref` from a prior `snapshot`; frame refs are keyed `host:generation:hash` and the per-host generation bumps after any media/power effect, so a click planned against a pre-reboot frame is refused rather than landing on a stale screen (free in-memory check, no false-blocking on spinners).

Closes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)