### PR TITLE
Guided ssh-bootstrap during install: CLI + helper (#81)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -353,6 +353,28 @@ destructive action, which is exactly the risk the invariant guards against. All
 destructive steps keep their `DESTRUCTIVE_OPS` / `safety.guard()` routing, and the
 health preflight gate still runs before the run.
 
+### SSH bootstrap during install: guided, not blind full-auto (#81)
+The "expensive HID phase sets up the cheap phase" — reading the DHCP IP off the
+installer console and starting `sshd` over KVM HID so the rest of the install runs
+in-band over SSH (`kvm_pilot/bootstrap.py`, CLI `ssh-bootstrap`). It is deliberately
+conservative rather than blind full-auto, because the failure modes are severe:
+- **Plan by default.** `execute=False` sends nothing; it returns the plan. This is
+  the CLI default (like `firmware-update`), with one top-level confirmation before
+  the first keystroke (not a prompt per keystroke).
+- **The IP probe doubles as a console canary.** A marker-wrapped `echo` is typed and
+  OCR'd back; if the marker never echoes, the keystrokes were not consumed by a
+  shell (silently-failed VT-switch, or a graphical/Windows installer), so it
+  **aborts before typing any `sshd` command** — a dropped command must never land in
+  the installer's partitioner. "Marker present but no IP" vs "marker absent"
+  distinguishes retry-with-`--ssh-host` from hard-abort.
+- **Reachability is necessary but not sufficient.** Success requires a trivial
+  `ssh_exec` to actually authenticate — a reachable port is not a working channel.
+  The default bootstrap commands only start `sshd`; the operator adds auth (a key or
+  password) via `--command`, and the auth probe reports if it's still unusable.
+- **Not an MCP tool in v1.** Agents should orchestrate the same flow with
+  `snapshot`/`classify`/`type_text` + `ssh_reachable(host=…)` so a human stays in the
+  loop; a single ungated auto-bootstrap MCP tool is deferred.
+
 ## Process
 
 Most structural choices came from adversarial review passes (find → verify →

--- a/src/kvm_pilot/bootstrap.py
+++ b/src/kvm_pilot/bootstrap.py
@@ -1,0 +1,241 @@
+"""Guided SSH bootstrap during an OS install (issue #81).
+
+The "expensive HID phase sets up the cheap phase": once an installer is running we
+can, over KVM HID + vision, switch to a text console, read the target's DHCP IP,
+start ``sshd``, point the profile's SSH channel at the discovered address, and hand
+off to the fast, deterministic in-band SSH channel for the rest of the install.
+
+Deliberately conservative — OCR IP-reads, distro-specific ``sshd``, VT-switch
+assumptions, and one-way HID (no exit codes) make blind automation risky:
+
+* **Plan by default.** With ``execute=False`` it sends nothing — it returns the
+  plan. Only ``execute=True`` touches the device.
+* **The IP probe doubles as a console canary.** After the VT-switch it types a
+  marker-wrapped ``echo`` and OCRs the result. If the marker never echoes back the
+  keystrokes were *not* consumed by a shell (a silently-failed VT-switch, or a
+  graphical/Windows installer), so it **aborts before typing any sshd command** —
+  a dropped command must never land in the installer's partitioner.
+* **Reachability + an auth probe are the only trusted success signals.** A reachable
+  port is not a working channel, so success requires a trivial ``ssh_exec`` to
+  actually authenticate.
+
+Every step escalates with full context on failure rather than pushing on. This is a
+CLI/library helper; it is intentionally **not** an MCP tool in v1 (agents should
+orchestrate the same flow with ``snapshot``/``classify``/``type_text`` +
+``ssh_reachable(host=…)`` so a human stays in the loop).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+# A marker-wrapped probe so OCR can locate the value unambiguously; the marker
+# also proves a shell consumed the keystrokes (the canary). The fallback covers
+# minimal environments where `ip` is absent but `hostname -I` works.
+_IP_PROBE = (
+    'echo "KVMIP=$(ip -4 -o addr show scope global 2>/dev/null | '
+    "awk 'NR==1{split($4,a,\"/\");print a[1]}')\""
+)
+_IP_FALLBACK_PROBE = 'echo "KVMIP=$(hostname -I 2>/dev/null | awk \'{print $1}\')"'
+_MARKER = "KVMIP="
+_IP_RE = re.compile(r"KVMIP=(\d{1,3}(?:\.\d{1,3}){3})")
+
+# Best-effort, distro-dependent defaults: generate host keys and start sshd. They
+# deliberately do NOT set up auth — install a key or password via `commands` (the
+# CLI's --command); the auth probe reports if the channel is reachable but unusable.
+DEFAULT_BOOTSTRAP_COMMANDS: tuple[str, ...] = (
+    "ssh-keygen -A",
+    "systemctl start sshd 2>/dev/null || /usr/sbin/sshd",
+)
+
+DEFAULT_VT_SHORTCUT = "ControlLeft,AltLeft,F2"
+
+
+@dataclass
+class BootstrapStep:
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass
+class BootstrapResult:
+    ok: bool
+    stage: str
+    discovered_host: str | None = None
+    reachable: bool = False
+    steps: list[BootstrapStep] = field(default_factory=list)
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "stage": self.stage,
+            "discovered_host": self.discovered_host,
+            "reachable": self.reachable,
+            "message": self.message,
+            "steps": [{"name": s.name, "ok": s.ok, "detail": s.detail} for s in self.steps],
+        }
+
+
+def _valid_ip(ip: str) -> bool:
+    try:
+        octets = [int(o) for o in ip.split(".")]
+    except ValueError:
+        return False
+    if len(octets) != 4 or any(o < 0 or o > 255 for o in octets):
+        return False
+    # Reject loopback / unspecified / link-local — never a usable target address.
+    return octets[0] not in (0, 127) and octets[:2] != [169, 254]
+
+
+def _read_target_ip(kvm: Any, ip_region: Any) -> tuple[str | None, bool]:
+    """Type the marker probe(s), OCR the console, return ``(ip, saw_marker)``.
+
+    ``ip`` is the discovered address or None; ``saw_marker`` distinguishes "shell
+    reached but IP unreadable" (marker present, no valid IP) from "console not
+    reached at all" (marker absent) — the abort-vs-retry decision.
+    """
+    saw_marker = False
+    for probe in (_IP_PROBE, _IP_FALLBACK_PROBE):
+        kvm.type_text(probe + "\n", slow=True)
+        text = kvm.snapshot_ocr(region=ip_region) or ""
+        if _MARKER in text:
+            saw_marker = True
+        match = _IP_RE.search(text)
+        if match and _valid_ip(match.group(1)):
+            return match.group(1), True
+    return None, saw_marker
+
+
+def ssh_bootstrap(
+    kvm: Any,
+    cfg: Any,
+    *,
+    analyzer: Any,
+    execute: bool = False,
+    vt_shortcut: str = DEFAULT_VT_SHORTCUT,
+    ip_region: Any = None,
+    commands: tuple[str, ...] | list[str] = DEFAULT_BOOTSTRAP_COMMANDS,
+    require_installer: bool = True,
+    reachable_timeout: float = 120.0,
+    poll_interval: float = 3.0,
+    channel_factory: Callable[[Any], Any] | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+) -> BootstrapResult:
+    """Bootstrap SSH on an installer host over KVM HID, then hand off (issue #81).
+
+    With ``execute=False`` (default) returns the plan without touching the device.
+    """
+    commands = list(commands)
+    if not execute:
+        planned = [
+            BootstrapStep("plan", True, d)
+            for d in (
+                f"verify an installer is on screen (require_installer={require_installer})",
+                f"switch to a text console: send_shortcut({vt_shortcut})",
+                "read the target IP via a marker-wrapped echo (aborts if it doesn't echo)",
+                *(f"type: {c}" for c in commands),
+                "set the channel host to the discovered IP; poll ssh_reachable + ssh_exec 'true'",
+            )
+        ]
+        return BootstrapResult(
+            ok=True, stage="plan", steps=planned,
+            message="dry-run plan; re-run with execute=True to perform it",
+        )
+
+    steps: list[BootstrapStep] = []
+
+    def escalate(stage: str, message: str, **kw: Any) -> BootstrapResult:
+        steps.append(BootstrapStep(stage, False, message))
+        return BootstrapResult(ok=False, stage=stage, steps=steps, message=message, **kw)
+
+    # 1. Precondition: don't type into an unknown screen.
+    if require_installer:
+        try:
+            state = analyzer.classify()
+        except Exception as exc:  # noqa: BLE001 - surface a classify failure as escalation
+            return escalate("detect-installer", f"could not classify the screen: {exc}")
+        if not state.phase.startswith("installer"):
+            return escalate(
+                "detect-installer",
+                f"screen phase is {state.phase!r}, not an installer — refusing to type",
+            )
+        steps.append(BootstrapStep("detect-installer", True, f"installer detected ({state.phase})"))
+
+    # 2. Switch to a text console.
+    kvm.send_shortcut(vt_shortcut)
+    steps.append(BootstrapStep("vt-switch", True, f"sent {vt_shortcut}"))
+
+    # 3. IP probe / console canary — abort before any sshd command if it fails.
+    ip, saw_marker = _read_target_ip(kvm, ip_region)
+    if ip is None:
+        if saw_marker:
+            return escalate(
+                "read-ip",
+                "console reached but the target IP was unreadable — pass --ssh-host manually",
+            )
+        return escalate(
+            "read-ip",
+            "the IP marker never echoed back — the console was not reached (the VT-switch may "
+            "have failed, or this isn't a Linux text console); aborting before any sshd command",
+        )
+    steps.append(BootstrapStep("read-ip", True, f"target IP {ip}"))
+
+    # 4. Bootstrap sshd (operator-reviewed, distro-dependent).
+    for command in commands:
+        kvm.type_text(command + "\n", slow=True)
+        steps.append(BootstrapStep("bootstrap-cmd", True, f"typed: {command}"))
+
+    # 5. Point the channel at the discovered IP and confirm the hand-off.
+    cfg.ssh_host = ip
+    if channel_factory is None:
+        from .ssh import SSHChannel
+
+        channel_factory = SSHChannel.from_config
+    channel = channel_factory(cfg)
+
+    deadline = time.time() + reachable_timeout
+    reachable = False
+    while True:
+        if channel.ssh_reachable():
+            reachable = True
+            break
+        if time.time() >= deadline:
+            break
+        sleep(poll_interval)
+    if not reachable:
+        return escalate(
+            "reachability",
+            f"{ip} did not accept SSH within {reachable_timeout:.0f}s",
+            discovered_host=ip,
+        )
+    steps.append(BootstrapStep("reachability", True, f"{ip} accepts SSH"))
+
+    # 6. A reachable port is not a working channel — prove auth actually works.
+    result = channel.ssh_exec("true")
+    if not result.get("ok"):
+        return escalate(
+            "auth",
+            f"{ip} is reachable but SSH auth failed — add a key/password to your bootstrap "
+            "commands (e.g. install an authorized_keys entry)",
+            discovered_host=ip, reachable=True,
+        )
+    steps.append(BootstrapStep("auth", True, "SSH authenticated"))
+    return BootstrapResult(
+        ok=True, stage="done", discovered_host=ip, reachable=True, steps=steps,
+        message=f"SSH is ready at {ip}; hand off in-band from here",
+    )
+
+
+__all__ = [
+    "ssh_bootstrap",
+    "BootstrapResult",
+    "BootstrapStep",
+    "DEFAULT_BOOTSTRAP_COMMANDS",
+    "DEFAULT_VT_SHORTCUT",
+]

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -293,6 +293,34 @@ def cmd_ssh_discover(args) -> int:
     return 0 if found else 1
 
 
+def cmd_ssh_bootstrap(args) -> int:
+    """Bootstrap SSH on an installer host over KVM HID, then hand off (issue #81)."""
+    from .bootstrap import DEFAULT_BOOTSTRAP_COMMANDS, ssh_bootstrap
+
+    kvm = _rich_client(args, Capability.HID)
+    if args.execute and not getattr(args, "yes", False):
+        # One top-level confirmation for the whole composite, not per keystroke.
+        print(
+            "SSH bootstrap will switch the host to a text console and TYPE commands on it "
+            "over KVM HID. Only do this against an installer/console you expect.",
+            file=sys.stderr,
+        )
+        if not interactive_confirm("bootstrap.run", "Proceed with SSH bootstrap?"):
+            print("aborted", file=sys.stderr)
+            return 1
+        kvm.safety.confirm = allow_all  # consented to the run; don't re-prompt per keystroke
+    cfg = _resolve_cfg(args)
+    analyzer = _make_analyzer(kvm, args)
+    commands = args.bootstrap_command or list(DEFAULT_BOOTSTRAP_COMMANDS)
+    result = ssh_bootstrap(
+        kvm, cfg, analyzer=analyzer, execute=args.execute, vt_shortcut=args.vt,
+        ip_region=args.ip_region, commands=commands,
+        require_installer=not args.no_installer_check,
+    )
+    print(json.dumps(result.to_dict(), indent=2))
+    return 0 if result.ok else 1
+
+
 def cmd_snapshot(args) -> int:
     kvm = _rich_client(args, Capability.VIDEO)
     out = kvm.snapshot_save(args.output)
@@ -747,6 +775,25 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("cidr", help="CIDR to scan, e.g. 10.0.1.0/24")
     p.add_argument("--ssh-port", type=int, default=22, help="SSH port to probe (default 22)")
     p.set_defaults(func=cmd_ssh_discover)
+
+    p = sub.add_parser(
+        "ssh-bootstrap",
+        help="Bootstrap SSH on an installer host over KVM HID, then hand off (#81)")
+    p.add_argument("--execute", action="store_true",
+                   help="Actually perform it (default: print the plan and send nothing)")
+    p.add_argument("--vt", default="ControlLeft,AltLeft,F2",
+                   help="VT-switch shortcut to reach a text console (default Ctrl+Alt+F2)")
+    p.add_argument("--ip-region", dest="ip_region", nargs=4, type=int,
+                   metavar=("L", "T", "R", "B"),
+                   help="OCR bounding box for reading the IP (optional; default full screen)")
+    p.add_argument("--command", action="append", dest="bootstrap_command",
+                   help="A bootstrap command to type (repeatable; overrides the defaults). "
+                        "Add one that installs a key or sets a password for a usable channel.")
+    p.add_argument("--no-installer-check", dest="no_installer_check", action="store_true",
+                   help="Skip the 'is an installer on screen?' precondition (risky)")
+    _add_common(p)
+    _add_vision(p)
+    p.set_defaults(func=cmd_ssh_bootstrap, _preflight=True)
 
     p = sub.add_parser("boot-progress", help="Structured boot phase (BMC BootProgress)")
     _add_common(p)

--- a/src/kvm_pilot/skill/SKILL.md
+++ b/src/kvm_pilot/skill/SKILL.md
@@ -54,6 +54,7 @@ remote before physical**, below).
 | Change **host** power (on/off/cycle/reset) | **MCP `power`** (gated) or CLI `power` / `power-cycle` | Destructive — confirm each step. MCP `power` is operator-enabled + per-call approval. |
 | Reboot the **KVM appliance** / restart `kvmd` / inspect `/etc/kvmd` | **SSH to the appliance** | No kvm-pilot interface does this — out-of-band only. |
 | Check if the **target host** is reachable / run commands on it once its OS is up | **MCP `ssh_reachable` / `ssh_exec`**, or CLI `ssh-check` / `ssh-exec` (in-band) | Prefer SSH over KVM keystrokes once the OS is up. Configure the target's IP/host/FQDN via `ssh_host` (≠ the KVM's address); `ssh_exec` is gated (operator opt-in `KVM_PILOT_MCP_ALLOW_SSH`). See "Recovery order" below. |
+| Bootstrap SSH during an install (set up the cheap channel over the expensive one) | **CLI `ssh-bootstrap`** | Once an installer is up, switches to a text console, reads the DHCP IP off the screen, starts `sshd`, and hands off to SSH. **Plans by default** — pass `--execute` to run it; add a `--command` that installs a key/password for a usable channel. Guided/conservative (aborts if the console can't be confirmed); not an MCP tool. |
 | View the screen when `snapshot` fails | **WebRTC/Janus stream or the vendor web UI** | The only way to see a unit that streams H.264 at its native resolution. |
 
 **Host vs. appliance — keep these straight.** The `power` tool/CLI acts on the

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,132 @@
+"""Tests for the guided SSH bootstrap helper (``kvm_pilot.bootstrap``, issue #81).
+
+Driven entirely against the in-process FakeDriver (which records ``typed`` /
+``shortcuts`` and returns canned ``snapshot_ocr`` / boot phase) with an injected
+fake SSH channel — no real network, HID, or ssh binary.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from kvm_pilot.bootstrap import DEFAULT_BOOTSTRAP_COMMANDS, _valid_ip, ssh_bootstrap
+from kvm_pilot.config import HostConfig
+from kvm_pilot.drivers.fake import FakeDriver
+from kvm_pilot.vision.analyzer import ScreenAnalyzer
+
+
+class _StubBackend:
+    """A vision backend that must never be reached (boot_progress resolves first)."""
+
+    def classify(self, image_b64, hint=""):
+        raise AssertionError("the VLM backend should not be called")
+
+
+def _analyzer(kvm):
+    return ScreenAnalyzer(kvm, _StubBackend())
+
+
+def _cfg(**kw):
+    base = {"host": "kvm.local", "driver": "fake"}
+    base.update(kw)
+    return HostConfig(**base)
+
+
+def _channel(*, reachable=True, auth_ok=True):
+    return SimpleNamespace(
+        ssh_reachable=lambda: reachable,
+        ssh_exec=lambda cmd: {"ok": auth_ok, "returncode": 0 if auth_ok else 1},
+    )
+
+
+def test_valid_ip_rejects_loopback_linklocal_and_junk():
+    assert _valid_ip("192.168.1.50")
+    assert not _valid_ip("127.0.0.1")
+    assert not _valid_ip("0.0.0.0")
+    assert not _valid_ip("169.254.1.1")
+    assert not _valid_ip("999.1.1.1")
+    assert not _valid_ip("nope")
+
+
+def test_plan_mode_sends_nothing():
+    kvm = FakeDriver(powered=True, phase="installer_progress")
+    res = ssh_bootstrap(kvm, _cfg(), analyzer=_analyzer(kvm), execute=False)
+    assert res.ok is True
+    assert res.stage == "plan"
+    assert kvm.typed == [] and kvm.shortcuts == []  # nothing was sent to the device
+
+
+def test_execute_success_discovers_ip_and_hands_off():
+    kvm = FakeDriver(powered=True, phase="installer_progress", ocr_text="KVMIP=192.168.1.50")
+    cfg = _cfg()
+    res = ssh_bootstrap(
+        kvm, cfg, analyzer=_analyzer(kvm), execute=True,
+        channel_factory=lambda c: _channel(), sleep=lambda _: None,
+    )
+    assert res.ok is True
+    assert res.stage == "done"
+    assert res.discovered_host == "192.168.1.50"
+    assert res.reachable is True
+    assert cfg.ssh_host == "192.168.1.50"  # channel repointed at the discovered IP
+    assert kvm.shortcuts == ["ControlLeft,AltLeft,F2"]  # VT-switch happened
+    typed = "".join(kvm.typed)
+    assert all(command in typed for command in DEFAULT_BOOTSTRAP_COMMANDS)
+
+
+def test_canary_abort_types_no_sshd_commands():
+    # No marker echoes back -> the console was not reached -> abort before sshd.
+    kvm = FakeDriver(powered=True, phase="installer_progress", ocr_text="")
+    res = ssh_bootstrap(
+        kvm, _cfg(), analyzer=_analyzer(kvm), execute=True,
+        channel_factory=lambda c: _channel(), sleep=lambda _: None,
+    )
+    assert res.ok is False
+    assert res.stage == "read-ip"
+    typed = "".join(kvm.typed)
+    for command in DEFAULT_BOOTSTRAP_COMMANDS:
+        assert command not in typed  # the anti-catastrophe gate held
+
+
+def test_reachable_but_auth_fails_escalates():
+    kvm = FakeDriver(powered=True, phase="installer_progress", ocr_text="KVMIP=10.0.0.9")
+    res = ssh_bootstrap(
+        kvm, _cfg(), analyzer=_analyzer(kvm), execute=True,
+        channel_factory=lambda c: _channel(reachable=True, auth_ok=False), sleep=lambda _: None,
+    )
+    assert res.ok is False
+    assert res.stage == "auth"
+    assert res.discovered_host == "10.0.0.9"
+    assert res.reachable is True  # a reachable port is not a working channel
+
+
+def test_refuses_when_not_an_installer():
+    kvm = FakeDriver(powered=True, phase="login_prompt")
+    res = ssh_bootstrap(
+        kvm, _cfg(), analyzer=_analyzer(kvm), execute=True,
+        channel_factory=lambda c: _channel(), sleep=lambda _: None,
+    )
+    assert res.ok is False
+    assert res.stage == "detect-installer"
+    assert kvm.typed == [] and kvm.shortcuts == []  # never typed into an unknown screen
+
+
+def test_no_installer_check_skips_the_precondition():
+    kvm = FakeDriver(powered=True, phase="login_prompt", ocr_text="KVMIP=10.0.0.9")
+    res = ssh_bootstrap(
+        kvm, _cfg(), analyzer=_analyzer(kvm), execute=True, require_installer=False,
+        channel_factory=lambda c: _channel(), sleep=lambda _: None,
+    )
+    assert res.ok is True
+    assert res.discovered_host == "10.0.0.9"
+
+
+def test_unreachable_target_escalates_with_discovered_host():
+    kvm = FakeDriver(powered=True, phase="installer_progress", ocr_text="KVMIP=10.0.0.9")
+    res = ssh_bootstrap(
+        kvm, _cfg(), analyzer=_analyzer(kvm), execute=True, reachable_timeout=0.0,
+        channel_factory=lambda c: _channel(reachable=False), sleep=lambda _: None,
+    )
+    assert res.ok is False
+    assert res.stage == "reachability"
+    assert res.discovered_host == "10.0.0.9"
+    assert res.reachable is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,18 @@ def test_driver_fake_power_action_is_dispatched():
     assert rc == 0
 
 
+def test_ssh_bootstrap_plan_mode(capsys):
+    # Plan mode (no --execute) prints the plan and sends nothing; also proves the
+    # --command flag's dest doesn't collide with the subcommand name.
+    import json
+
+    rc = main(["ssh-bootstrap", "--driver", "fake"])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["stage"] == "plan"
+    assert any("send_shortcut" in step["detail"] for step in data["steps"])
+
+
 def test_driver_glkvm_builds_the_glkvm_subclass():
     from kvm_pilot.cli import _build_client, build_parser
     from kvm_pilot.drivers.pikvm import GLKVMDriver


### PR DESCRIPTION
The 'expensive HID phase sets up the cheap phase': once an installer is up, switch to a text console over KVM HID, read the DHCP IP off the screen, start sshd, and hand off in-band. New `bootstrap.py` + `kvm-pilot ssh-bootstrap`. Conservative: **plans by default** (--execute to run); the IP probe **doubles as a console canary** and aborts before any sshd command if the marker doesn't echo (a dropped command must never hit the partitioner); success requires an ssh_exec auth-probe. Auto-bootstrap MCP tool deferred.

Part of #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)