### PR TITLE
Post-a8 housekeeping: /checkpoint dev skill + 0.1.0a8 CHANGELOG entry

### DIFF
--- a/.claude/skills/checkpoint/SKILL.md
+++ b/.claude/skills/checkpoint/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: checkpoint
+description: >-
+  End-of-session safety sweep for the kvm-pilot project — "is everything I did
+  this session safe to leave?" Invoke at the end of a work session (or when the
+  user says "checkpoint", "safe to stop?", "wrap up", "am I done here") to verify
+  nothing is quietly unsaved: uncommitted/unpushed code, an unrecorded decision, a
+  stale resume pointer, or a doc (README/CHANGELOG/mcp README/SKILL) that now lies
+  about shipped behavior. Runs a read-only scan, reports a risk-ordered table with
+  a one-line verdict, and always leaves a fresh resume handoff for the next session.
+  It answers "nothing lost" only — NOT "is this releasable" and NOT the morning
+  cloud/telemetry sweep.
+---
+
+# /checkpoint — end-of-session safety sweep
+
+A checkpoint asks one question: **is everything I did this session durably captured, or is something quietly at risk of being lost?** The next session is often a fresh agent with zero memory of this one — a gap here means redone work or a decision shipped on a false assumption. This replaces "I think I saved everything" with a reproducible sweep ending in **SAFE TO STOP** or **N items need attention**, each with the exact fix.
+
+It is the mirror of a morning sweep (which asks *what happened while I was away?*). Stay in that lane: checkpoint does **not** score releasability (a separate concern) and does **not** re-run cloud/telemetry health checks.
+
+## Procedure
+
+1. **Run the read-only scan** (it mutates nothing — that's the safety property):
+   ```bash
+   bash .claude/skills/checkpoint/scan.sh
+   ```
+2. **Interpret each surface against the rubric below** — the judgement calls the script can't make. Do not skip a surface because it "looked fine"; read the facts.
+3. **Emit the risk-ordered table + one-line verdict** (format at the bottom). Highest-risk first.
+4. **Always produce the resume handoff** (§ Mandatory handoff) — this happens even on an all-✅ scan.
+5. **Offer the exact fix for every ⚠️**; run only the low-risk ones **on the operator's go** (commit-by-name, `git fetch --tags`, save-memory, fix-a-doc). Never promote/release; never blind-add.
+
+## Rubric — interpret the scan, surface by surface (risk-ordered)
+
+### C1 · Version control & working tree — *highest risk: unsaved code is unrecoverable*
+- `UNCOMMITTED` > 0 → ⚠️ commit by name: `git -C kvm-pilot commit -m "…" -- <paths>`. **Never `git add -A`/`.`** (`.gitignore` covers venv/artifacts/`config.toml`/`.env`, but a stray secret or large file under a new name would be committed irreversibly — stage by name).
+- `UNTRACKED_NOT_IGNORED` > 0 → ⚠️ eyeball each: is it source to track, or a stray artifact/secret to ignore/delete? Never bulk-add.
+- `ON_PROTECTED_BRANCH: yes (main)` **with** uncommitted or new work → ⚠️ you're working on the release branch; move to a feature branch (`git -C kvm-pilot switch -c <branch>`). Being on `main` with a clean tree (just after a merge) is ✅.
+- `UNPUSHED (ahead)` > 0 on a **feature** branch → ⚠️ offer to push it. (Don't push `main` beyond noting; that's release-adjacent.)
+- `BEHIND` > 0 → ⚠️ note; rebase before more work.
+- `DEBUG_MARKERS_IN_DIFF` > 0 (`breakpoint()`/`pdb`/`console.log`/`FIXME`/`XXX`) → ⚠️ remove before commit. Also eyeball the diff for stray `print(` added to **library** modules (`client.py`, `health.py`, drivers/ — the CLI uses `print` legitimately, so the scan doesn't flag it).
+
+### C2 · Tracking & the resume pointer — *fold tracking + resume + release-state into ONE pass*
+- **Tracked?** kvm-pilot is **issue-per-finding** (see CLAUDE.md): every meaningful change has a GitHub issue. From `RECENT COMMITS`, confirm this session's work references its issues. Untracked meaningful work → ⚠️ open/point at an issue.
+- `TAG_LAG` present → ⚠️ local tags lag the remote (releases are cut via `gh release`, which tags only the remote). Safe fix: `git -C kvm-pilot fetch --tags`.
+- `RELEASE_STATE` — context only; **checkpoint does not judge releasability.** "version == latest release" just means nothing is sitting unreleased.
+- **Resume pointer** — judged in § Mandatory handoff (its own verdict): is the newest session memory current vs. what actually happened this session?
+
+### C3 · Persistent memory — *judge worthiness, not just integrity*
+- `FILES_NOT_IN_INDEX` / `INDEX_LINKS_MISSING_FILE` ≠ none → ⚠️ index broken; add the missing `- [Title](file.md) — hook` line, or fix the dangling link.
+- **New-fact-worthiness** (the real judgement): did this session produce a durable fact not yet saved — a non-obvious decision, a "looks-wrong-but-intentional" choice, a corrected assumption, a hardware/device truth, standing user guidance? If yes → ⚠️ save it (one file, correct frontmatter `type:`, `**Why:**`/`**How to apply:**` for feedback/project) and index it in `MEMORY.md`. Don't save what the repo/git already records.
+
+### C4 · Documentation reconciliation — *touch only what changed this session*
+Sources of truth that can lie about shipped behavior: `README.md`, `CHANGELOG.md`, `src/kvm_pilot/mcp/README.md` (MCP tool table + env gates + safety model), `src/kvm_pilot/skill/SKILL.md` (bundled skill — interface matrix, tool list), `docs/decisions.md`, `__about__.py`, and the **Hardware-Compatibility wiki** (honesty about what's been exercised live).
+- Only audit docs in `DOCS CHANGED SINCE …` **and** narrow to THIS session's commits (from C2). A doc that didn't change this session is ⏭️.
+- `CHANGELOG_UNRELEASED: EMPTY` **and/or** `CHANGELOG_HAS_<ver>: NO` while a release shipped this session → ⚠️ the CHANGELOG lies about shipped behavior; add the version entry (move `[Unreleased]` items under a dated `## [<ver>]`).
+- If MCP tools / CLI commands / gates changed this session, confirm `mcp/README.md` + `SKILL.md` match the shipped surface (tool table, `KVM_PILOT_MCP_ALLOW_*`, capability notes).
+- Verified new hardware/behavior live this session (a device+capability combo) → ⚠️ record it in the Hardware-Compatibility wiki per the CLAUDE.md honesty rule; don't claim "tested" beyond what was exercised.
+- **Never hand-edit the GitHub wiki** — it is auto-generated from `docs/` + `mcp/README.md` + `SKILL.md` by `wiki-sync`. Edit the sources.
+
+### C5 · Loose ends — *cheap, last*
+- `WORKTREES` > 1 → ⚠️ stray worktree; `git worktree remove` if done.
+- `DOCKER_RUNNING` ≠ none → ⚠️ the redfish-integration sushy-tools container may be left up; stop it if idle.
+- Background jobs/agents from this session still running (check TaskList / your own shells) → ⚠️ stop them.
+- `LOCKS` — `scheduled_tasks.lock` is the cron lock and is normal; note only if a checkpoint/agent lock looks stale.
+- **Green bar** (`GREEN_BAR`) — **do not run it inside the sweep** (too slow). If this session already ran it green, mark ✅ "known-good this session"; otherwise ⚠️ "run on demand: `<GREEN_BAR>`". Never gate the checkpoint on a fresh full run.
+
+## Mandatory handoff — always, even on an all-✅ scan
+
+A checkpoint that ends with no fresh handoff **has not finished**. The resume pointer for this project is the **project session memory** (`~/.claude/projects/-Users-dustintrap-Claude-kvm-pilot/memory/`, a `type: project` file, newest = top of `MEMORY.md`). Before signing off:
+
+1. **Write or refresh** the current session's memory with three things: **current state** (branch @ sha, version, latest release, what landed, what's in-flight), **authoritative next steps**, and **standing rules** (issue-per-finding · `pip install` ships every surface · stdlib-only at core import · docs↔shipped parity · run `healthcheck` first · branch off `main` · never edit the wiki). Add its one-line pointer to the top of `MEMORY.md`.
+2. **Cross-check the handoff against live reality as you write it** (scan facts + `gh`): don't relist a closed issue/merged PR as open, don't call a done step "pending," don't name a file/flag that no longer exists. A hand-written summary regresses easily — verify each claim.
+3. If C2 shows an **open PR in flight**, also drop the resume state as a comment on that PR/issue so it's found from the tracker too.
+
+An all-✅ scan with a stale resume pointer is an **incomplete checkpoint** — refresh the pointer regardless.
+
+## Hard rules (safety properties, not preferences)
+- **Never blind-add.** No `git add -A` / `git add .`. Stage by name only. The scan is read-only and never adds.
+- **No auto-mutation except the handoff.** Propose the exact command/edit for every ⚠️; run the safe ones only on the operator's go. **Never** merge to `main`, `gh release`, publish to PyPI, force-push, or edit the wiki — checkpoint answers "nothing lost," not "ship it."
+- **Stay in your lane.** No releasability scoring, no cloud/telemetry sweep, no full test run inside the helper. Fold overlapping checks into one pass.
+
+## Output format
+
+```
+CHECKPOINT — <branch> @ <short-sha> · <timestamp>
+| #  | Surface                     | ✅/⚠️/⏭️ | Note / exact fix |
+| C1 | VCS & working tree          | …       | … |
+| C2 | Tracking & resume pointer   | …       | … |
+| C3 | Persistent memory           | …       | … |
+| C4 | Docs reconciliation         | …       | … |
+| C5 | Loose ends                  | …       | … |
+Bottom line: SAFE TO STOP  —or—  N items need attention (C2, C4).
+```
+Glyphs: ✅ clean · ⚠️ needs action · ⏭️ n/a this session. Table + one-line verdict; expand each ⚠️ into its exact command directly beneath the table. The bottom line must be consistent with the rows.
+
+## Self-check before you sign off
+Did every surface actually get interpreted (none skipped as "looked fine")? Is the resume-pointer verdict based on the pointer's *current* state vs. what happened this session? Did you judge memory *worthiness*, not just index integrity? Does every ⚠️ carry an exact command? Did you avoid every unapproved mutation and never suggest a blind-add? Is the bottom line a plain verdict consistent with the rows, and did the handoff actually get written?

--- a/.claude/skills/checkpoint/scan.sh
+++ b/.claude/skills/checkpoint/scan.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# checkpoint/scan.sh — READ-ONLY end-of-session sweep for the kvm-pilot project.
+#
+# Prints mechanical facts and MUTATES NOTHING. It never runs `git add`, never
+# writes a file, never runs the (slow) test/lint bar. The agent interprets these
+# facts against the rubric in SKILL.md. Safety property: if this script ever
+# needs to change state, the design is wrong — keep it read-only.
+set -uo pipefail
+
+# --- locate the repo (session CWD is the parent; repo is ./kvm-pilot) ---------
+REPO="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$REPO" ] && [ -d "$PWD/kvm-pilot/.git" ] && REPO="$PWD/kvm-pilot"
+[ -z "$REPO" ] && { echo "FATAL: no git repo found at \$PWD or \$PWD/kvm-pilot"; exit 1; }
+cd "$REPO"
+
+MEM="$HOME/.claude/projects/-Users-dustintrap-Claude-kvm-pilot/memory"
+PROTECTED="main"
+SOT_DOCS=(README.md CHANGELOG.md src/kvm_pilot/mcp/README.md src/kvm_pilot/skill/SKILL.md)
+GREEN_BAR='.venv/bin/ruff check . && .venv/bin/mypy src/kvm_pilot && .venv/bin/pytest -q'
+
+echo "CHECKPOINT SCAN (read-only) — $(date '+%Y-%m-%d %H:%M') "
+echo "REPO: $REPO"
+
+# ============================================================ C1 VCS & tree ===
+echo
+echo "## C1  Version control & working tree"
+BRANCH="$(git branch --show-current 2>/dev/null || echo '(detached)')"
+echo "BRANCH: $BRANCH"
+echo "HEAD: $(git log -1 --format='%h %s' 2>/dev/null)"
+if [ "$BRANCH" = "$PROTECTED" ]; then echo "ON_PROTECTED_BRANCH: yes ($PROTECTED)"; else echo "ON_PROTECTED_BRANCH: no"; fi
+
+DIRTY="$(git status --porcelain 2>/dev/null | grep -vE '^\?\?' || true)"
+echo "UNCOMMITTED: $( [ -n "$DIRTY" ] && echo "$DIRTY" | wc -l | tr -d ' ' || echo 0 ) tracked file(s)"
+[ -n "$DIRTY" ] && echo "$DIRTY" | sed 's/^/  /'
+
+UNTRACKED="$(git status --porcelain --untracked-files=all 2>/dev/null | grep -E '^\?\?' | sed 's/^?? //' || true)"
+echo "UNTRACKED_NOT_IGNORED: $( [ -n "$UNTRACKED" ] && echo "$UNTRACKED" | wc -l | tr -d ' ' || echo 0 )"
+[ -n "$UNTRACKED" ] && echo "$UNTRACKED" | sed 's/^/  /'
+
+UP="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+if [ -n "$UP" ]; then
+  echo "UPSTREAM: $UP"
+  echo "UNPUSHED (ahead): $(git rev-list --count '@{upstream}..HEAD' 2>/dev/null || echo '?') commit(s)"
+  echo "BEHIND: $(git rev-list --count 'HEAD..@{upstream}' 2>/dev/null || echo '?') commit(s)"
+else
+  echo "UPSTREAM: (none — branch not pushed)"
+fi
+
+# Stray debug in the working diff (added lines only). Bare print( is legit in this
+# CLI, so only unambiguous markers are flagged; eyeball library-module prints.
+DBG="$(git diff HEAD 2>/dev/null | grep -nE '^\+' | grep -nE 'breakpoint\(\)|pdb\.set_trace|import i?pdb|console\.log|debugger|\bFIXME\b|\bXXX\b' || true)"
+echo "DEBUG_MARKERS_IN_DIFF: $( [ -n "$DBG" ] && echo "$DBG" | wc -l | tr -d ' ' || echo 0 )"
+[ -n "$DBG" ] && echo "$DBG" | sed 's/^/  /'
+
+# ==================================================== C2 Tracking & release ===
+echo
+echo "## C2  Tracking & the release/resume pointer"
+VER="$(sed -nE 's/^__version__ = "(.*)"/\1/p' src/kvm_pilot/__about__.py 2>/dev/null)"
+LOCAL_TAG="$(git tag --sort=-creatordate 2>/dev/null | head -1)"
+# Releases are cut with `gh release` (tags the REMOTE), so local tags lag — ask gh
+# for the authoritative latest release rather than trusting `git tag`.
+REL="$(gh release list --limit 1 --json tagName -q '.[0].tagName' 2>/dev/null || true)"
+echo "VERSION (__about__.py): ${VER:-?}"
+echo "LATEST_RELEASE (gh, authoritative): ${REL:-'(gh unavailable)'}"
+echo "LOCAL_LATEST_TAG: ${LOCAL_TAG:-none}"
+if [ -n "$REL" ] && [ "$LOCAL_TAG" != "$REL" ]; then
+  echo "TAG_LAG: local tags lag the remote — fix: git fetch --tags"
+fi
+if [ -n "$REL" ] && [ "$REL" = "v${VER}" ]; then
+  echo "RELEASE_STATE: version ${VER} == latest release ${REL} — nothing unreleased"
+elif [ -n "$REL" ]; then
+  echo "RELEASE_STATE: version ${VER} vs latest release ${REL} — differs (unreleased bump or newer tag)"
+fi
+echo "RECENT COMMITS (agent: pick out THIS session's):"
+git log -15 --oneline 2>/dev/null | sed 's/^/  /'
+echo "OPEN_PRS (this branch): $(gh pr list --head "$BRANCH" --json number,title -q '[.[]|"#\(.number) \(.title)"]|join("; ")' 2>/dev/null || echo '(gh unavailable)')"
+
+# ==================================================== C3 Persistent memory ====
+echo
+echo "## C3  Persistent memory"
+echo "MEMORY_DIR: $MEM"
+if [ -d "$MEM" ]; then
+  ORPHAN=""; MISSING=""
+  for f in "$MEM"/*.md; do
+    b="$(basename "$f")"; [ "$b" = "MEMORY.md" ] && continue
+    grep -q "($b)" "$MEM/MEMORY.md" 2>/dev/null || ORPHAN="$ORPHAN $b"
+  done
+  while IFS= read -r link; do
+    [ "$link" = "MEMORY.md" ] && continue
+    [ -f "$MEM/$link" ] || MISSING="$MISSING $link"
+  done < <(grep -oE '\(([a-z0-9-]+\.md)\)' "$MEM/MEMORY.md" 2>/dev/null | tr -d '()')
+  echo "FILES_NOT_IN_INDEX:${ORPHAN:- none}"
+  echo "INDEX_LINKS_MISSING_FILE:${MISSING:- none}"
+  echo "NEWEST_MEMORY: $(ls -t "$MEM"/*.md 2>/dev/null | grep -v MEMORY.md | head -1 | xargs -I{} basename {} 2>/dev/null)"
+else
+  echo "(no memory dir — C3 n/a)"
+fi
+
+# ==================================================== C4 Docs reconciliation ==
+echo
+echo "## C4  Documentation (sources of truth)"
+if grep -qE '^## \[Unreleased\]' CHANGELOG.md 2>/dev/null; then
+  BODY="$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md | grep -vE '^\s*$' || true)"
+  [ -z "$BODY" ] && echo "CHANGELOG_UNRELEASED: EMPTY" || echo "CHANGELOG_UNRELEASED: has content"
+fi
+if [ -n "${VER:-}" ]; then
+  grep -qE "^## \[${VER}\]" CHANGELOG.md 2>/dev/null && echo "CHANGELOG_HAS_${VER}: yes" || echo "CHANGELOG_HAS_${VER}: NO"
+fi
+# Window = since the last LOCAL tag (may be wide if local tags lag; the agent
+# narrows to THIS session's commits from C2). Falls back to last 15 commits.
+WIN="${LOCAL_TAG:-HEAD~15}"; git rev-parse "$WIN" >/dev/null 2>&1 || WIN="HEAD~15"; git rev-parse "$WIN" >/dev/null 2>&1 || WIN="$(git rev-list --max-parents=0 HEAD | tail -1)"
+echo "SOURCE-OF-TRUTH DOCS CHANGED SINCE ${WIN}:"
+git diff --name-only "${WIN}..HEAD" -- "${SOT_DOCS[@]}" docs/ 2>/dev/null | sed 's/^/  /' | head -30 || true
+echo "(a doc NOT changed this session is ⏭️ — do not audit it)"
+echo "WIKI: auto-generated by .github/workflows/wiki-sync.yml — NEVER hand-edit the wiki"
+
+# ==================================================== C5 Loose ends ===========
+echo
+echo "## C5  Loose ends"
+echo "WORKTREES: $(git worktree list 2>/dev/null | wc -l | tr -d ' ') (>1 = stray)"
+git worktree list 2>/dev/null | sed 's/^/  /'
+echo "DOCKER_RUNNING: $(docker ps --format '{{.Names}}' 2>/dev/null | paste -sd, - || echo 'none/na')"
+echo "LOCKS (.claude): $(find "$PWD/.claude" ../.claude -maxdepth 1 -name '*.lock' 2>/dev/null | paste -sd, - || echo none)"
+echo "GREEN_BAR (NOT run — confirm this session's known-good, or run on demand):"
+echo "  $GREEN_BAR"
+echo
+echo "SCAN COMPLETE (nothing was modified)."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.0a8] — 2026-07-06
+
+### Added — MCP act layer: drive the box, not just observe it (2026-07-06, #61, #112)
+- **New MCP tools** `type_text`, `press_key`, `send_shortcut`, `ctrl_alt_delete`,
+  `mouse`, `mount_iso`, `eject` — an agent can now *drive* HID/media over MCP, not
+  only observe. Authorized by **two guarantees**: an operator effect-gate env flag
+  (classified by *effect, not transport*, so Ctrl+Alt+Del and reboot chords need
+  `KVM_PILOT_MCP_ALLOW_POWER`, ordinary HID needs `KVM_PILOT_MCP_ALLOW_HID`, media
+  needs `KVM_PILOT_MCP_ALLOW_MEDIA`) **and** a per-invocation approval — MCP
+  elicitation when the client supports it, else `confirm=true` under a standing
+  policy (the unattended path). Fail-closed `KVM_PILOT_MCP_PROFILES` allowlist.
+  Denials return through the same call path; each result carries a stable
+  `invocation_id` + transport + effect. Effect taxonomy is additive over
+  `DESTRUCTIVE_OPS` (`EffectClass` in `safety.py`); see `mcp/act.py`.
+
+### Added — mouse with a generation-keyed staleness gate (2026-07-06, #124)
+- **`mouse`** — absolute move + optional click (`percent` coords by default,
+  resolution-independent). A click must carry the `observed_frame_ref` from a prior
+  `snapshot`; it is refused if the host rebooted or swapped media since (the frame
+  *generation* changed), so a click can't land on a stale screen. `snapshot` now
+  returns a `frame_ref`.
+
+### Added — keyless `classify_screen` (2026-07-06, #125)
+- `classify_screen` falls back to **caller-side** classification (returns the
+  screenshot + prompt/schema) when the server has no vision key.
+
+### Added — SSH install-time hand-off (2026-07-06, #81)
+- CLI `--ssh-host` / MCP `host=` runtime override (use a target's DHCP IP without
+  editing config); a volatile `ssh-reachable` healthcheck; and a guided
+  `kvm-pilot ssh-bootstrap` command that reads the target IP off an installer
+  console and starts `sshd` (plans by default; the IP probe doubles as a console
+  canary and aborts before any command if it doesn't echo; success requires an
+  `ssh_exec` auth-probe).
+
 ## [0.1.0a7] — 2026-07-04
 
 ### Added — first-run onboarding + agent recovery guidance (2026-07-04, #111)


### PR DESCRIPTION
Two loose ends from the a8 session, swept up by the new checkpoint skill itself:

- **`/checkpoint` dev skill** (`.claude/skills/checkpoint/`) — a read-only end-of-session safety sweep (VCS · tracking/resume · memory · docs · loose ends) that ends in SAFE TO STOP / N-items and always leaves a resume handoff. `scan.sh` mutates nothing; `SKILL.md` is the rubric + hard rules (never blind-add, no auto-mutation except the handoff, stays out of releasability).
- **CHANGELOG `[0.1.0a8]` entry** — a8 shipped to PyPI without its changelog entry (`[Unreleased]` was empty); this is the post-release catch-up.

No package/runtime code changes — docs + `.claude` tooling only, so the a8 green bar (ruff+mypy+pytest, #137 CI) still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)