### PR TITLE
Remote boot-control + Wake-on-LAN (epic #200): Redfish BootSourceOverride, efibootmgr BootNext, WoL

### DIFF
--- a/.github/scripts/build_wiki.py
+++ b/.github/scripts/build_wiki.py
@@ -44,6 +44,8 @@ PAGES: list[tuple[str, str, str | None]] = [
     ("docs/decisions.md", "decisions.md", "Design decisions"),
     ("docs/reflexes.md", "reflexes.md", "Reflexes (RFC)"),
     ("docs/redfish.md", "redfish.md", "Redfish reference"),
+    ("docs/hardware-test-plan-ilo-idrac.md", "hardware-test-plan-ilo-idrac.md",
+     "Hardware test plan: iLO / iDRAC"),
     ("docs/firmware-registry.md", "firmware-registry.md", "Firmware registry"),
     ("docs/firmware-update.md", "firmware-update.md", "Remote firmware update"),
     ("docs/unattended-install.md", "unattended-install.md", "Unattended Linux installs"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ on every push to `main` — edit the files here, never the wiki directly).
 - [Configuration](configuration.md) — the config file, every `KVM_PILOT_*` env var, and precedence.
 - [Design decisions](decisions.md) — the "looks wrong but is intentional" record, newest first.
 - [Hardware reliability test plan](test-plan.md) — the reusable full-fleet sweep procedure: exercise every CLI + MCP function across device states, cross-check each result against independent ground truth to catch false reports, and feed the support matrix ([#172](https://github.com/DustinTrap/kvm-pilot/issues/172)).
+- [Hardware test plan: iLO / iDRAC](hardware-test-plan-ilo-idrac.md) — quick-execute runbook to validate the Redfish driver (boot-device + power) against an HPE DL380 G9 (iLO4) and a Dell R710 (iDRAC6, no-Redfish → IPMI) ([#200](https://github.com/DustinTrap/kvm-pilot/issues/200)/[#29](https://github.com/DustinTrap/kvm-pilot/issues/29)).
 - [Reflexes (RFC)](reflexes.md) — the post-GA edge-autonomy playbook runner: act locally on known steps, escalate surprises to the agent ([#117](https://github.com/DustinTrap/kvm-pilot/issues/117)).
 - [Redfish reference](redfish.md) — the BMC driver: hypermedia navigation, auth, and firmware quirks.
 - [Firmware registry](firmware-registry.md) — the firmware-currency check, the community registry data model, and the GitHub-based single-source-of-truth + ingestion design (#80 follow-up).

--- a/docs/hardware-test-plan-ilo-idrac.md
+++ b/docs/hardware-test-plan-ilo-idrac.md
@@ -1,0 +1,189 @@
+# Hardware test plan — HPE DL380 G9 (iLO) + Dell R710 (iDRAC)
+
+A fast, copy-paste runbook to validate the Redfish driver — especially the new
+**boot-device control** (BootSourceOverride, #28/#201) and **power** — against two
+real BMCs. Tracks epic #200; capture findings on #29 (real-BMC validation) and the
+support matrix (#96). Pairs with the synthetic coverage in
+`tests/test_redfish_boot.py` / `tests/redfish_emulator.py`.
+
+> **Read the firmware-era caveat first — it decides which box is testable over Redfish.**
+
+## Firmware reality (important)
+
+| Box | BMC | Redfish? | Path |
+|---|---|---|---|
+| **HPE DL380 G9** | **iLO 4** (fw ≥ 2.30 for DMTF Redfish 1.0; 2.5x+ preferred) | **Yes** (older Redfish — exactly what the driver's feature-detect + quirk handling targets) | `--driver redfish` ✅ |
+| **Dell R710** | **iDRAC 6** (11th-gen; there is no iDRAC7 for R710) | **No** — iDRAC6 predates Redfish (WS-MAN/IPMI/racadm only) | Redfish will 404 at `/redfish/v1`; use **IPMI (#62, not yet built)** |
+
+So tonight: **full Redfish run on the DL380 G9**; on the R710 the goal is to
+**confirm clean detection of "no Redfish"** and record it as the motivating case
+for the IPMI driver (#62). If the R710's iDRAC was flashed to something newer, or
+it's actually a 12th-gen board, re-check — but plan for iDRAC6 = no Redfish.
+
+## Prerequisites
+
+- kvm-pilot installed (`uv run kvm-pilot ...` in the repo, or `pip install`).
+- Network reachability from the runner to each BMC IP (BMCs are on a dedicated
+  mgmt NIC/VLAN — confirm the runner can reach it; the same split-tunnel/L2 gotcha
+  that hid `10.0.1.16` applies).
+- Credentials. **Do not commit them.** Defaults to try: iLO4 `Administrator` /
+  the label password on the server pull-tab; iDRAC `root` / `calvin`.
+- A maintenance window — several steps power-cycle the host.
+
+## Onboarding (config profiles)
+
+Add to `~/.config/kvm-pilot/config.toml` (password via `KVM_PILOT_PASSWD`,
+`--passwd-file <600 file>`, or `--ask-passwd` — never in the file):
+
+```toml
+[hosts.ilo-dl380g9]
+host = "10.0.1.AA"        # iLO IP
+driver = "redfish"
+user = "Administrator"
+verify_ssl = false         # iLO4 ships a self-signed cert; pin with ssl_ca_file if you have it
+
+[hosts.idrac-r710]
+host = "10.0.1.BB"        # iDRAC IP
+driver = "redfish"
+user = "root"
+verify_ssl = false
+```
+
+Then per session: `export KVM_PILOT_PASSWD='...'` (or pass `--ask-passwd`).
+
+---
+
+## Phase A — read-only vetting (safe; run first)
+
+```bash
+P=ilo-dl380g9   # then repeat with P=idrac-r710
+uv run kvm-pilot healthcheck   --profile $P     # intake gate — expect no CRITICAL for a reachable BMC
+uv run kvm-pilot info          --profile $P     # manufacturer/model/BIOS/power_state/redfish_version
+uv run kvm-pilot capabilities  --profile $P     # expect: system_info, power, boot_progress, sensors, logs, virtual_media, boot_config
+uv run kvm-pilot power-state   --profile $P
+uv run kvm-pilot boot-device   --profile $P --show   # current override + ALLOWABLE targets + mode_settable
+uv run kvm-pilot sensors       --profile $P     # temps/fans/power (iLO4/iDRAC expose these)
+uv run kvm-pilot boot-progress --profile $P
+uv run kvm-pilot logs          --profile $P --seek 3600
+```
+
+**Record from `info` / `boot-device --show`:** `redfish_version`, the
+`allowable` boot targets, and `mode_settable` (does the box expose
+`BootSourceOverrideMode`?). These drive the quirks table below.
+
+---
+
+## Phase B — boot-device control (the new feature, #28/#201)
+
+`--show` is read-only; every *set* needs `--yes` (gated) and writes
+BootSourceOverride. Verify each with a follow-up `--show`.
+
+```bash
+P=ilo-dl380g9
+# one-time PXE (default: once + UEFI)
+uv run kvm-pilot boot-device pxe  --profile $P --yes
+uv run kvm-pilot boot-device      --profile $P --show      # expect enabled=Once, target=pxe
+
+# one-time CD/virtual-media, then HDD
+uv run kvm-pilot boot-device cd   --profile $P --yes
+uv run kvm-pilot boot-device hdd  --profile $P --yes
+
+# persistent + legacy variants (exercise both flags)
+uv run kvm-pilot boot-device pxe  --profile $P --persistent --yes   # enabled=Continuous
+uv run kvm-pilot boot-device bios --profile $P --legacy --yes       # BootSourceOverrideMode=Legacy (if settable)
+
+# clear the override
+uv run kvm-pilot boot-device none --profile $P --yes                # enabled=Disabled
+```
+
+**End-to-end confirmation (optional, needs a reboot):** set `pxe` once, then
+`power reset --profile $P --yes`, and confirm on the console/iLO that it PXE-boots
+once and reverts afterward.
+
+**Watch for (and note on #29):**
+- A target in your list that the BMC rejects → the driver should raise a clear
+  `CapabilityError` naming the allowable set (not an opaque 400).
+- iLO4 rejecting `BootSourceOverrideMode` → the driver **auto-retries without it**
+  (log line: "rejected BootSourceOverrideMode; retrying without it"); confirm the
+  target still applied.
+- A `202 Accepted` + Task on the PATCH → the driver polls it to completion.
+
+---
+
+## Phase C — power (destructive; maintenance window)
+
+```bash
+P=ilo-dl380g9
+uv run kvm-pilot power-state  --profile $P
+uv run kvm-pilot power on     --profile $P --yes    # verified against Redfish PowerState
+uv run kvm-pilot power off    --profile $P --yes    # graceful (GracefulShutdown)
+uv run kvm-pilot power reset  --profile $P --yes
+uv run kvm-pilot power-cycle  --profile $P --yes    # off-hard -> on, blocks on PowerState
+```
+Redfish power is **verified** (real PowerState), unlike GL ATX. Note the
+`ResetType`s the box advertises (iLO4 vs iDRAC differ) and any
+`InvalidOperationForSystemState` 400/409 the driver absorbs as success.
+
+## Phase D — virtual media (if the BMC exposes it over Redfish)
+
+```bash
+uv run kvm-pilot media-list --profile ilo-dl380g9
+# uv run kvm-pilot mount <http-url-to.iso> --profile ilo-dl380g9 --yes
+# uv run kvm-pilot eject --profile ilo-dl380g9 --yes
+```
+iLO4 needs an advanced/iLO license for scriptable virtual media — note if it's
+absent. Combine with `boot-device cd` for a full remote-install rehearsal.
+
+## Phase E — Wake-on-LAN (wired NIC; alternative power-on, #199)
+
+For the host's OS NIC (not the BMC): confirm `ethtool <if>` shows `Wake-on: g`,
+note the wired MAC, suspend/shutdown the OS, then from a sender on the same L2:
+```bash
+uv run python -c "from kvm_pilot import wol; wol.send_magic_packet('AA:BB:CC:DD:EE:FF', broadcast='10.0.1.255')"
+```
+(Already hardware-validated on the RHEL host behind KVM .20 — woke in 52 s.)
+
+---
+
+## R710 / iDRAC6 — expected "no Redfish" path
+
+```bash
+uv run kvm-pilot info --profile idrac-r710
+```
+**Expected:** a clean failure resolving `/redfish/v1` (404 / connection reset) —
+iDRAC6 has no Redfish. Record the exact error. This is the motivating case for the
+**IPMI driver (#62)**: `ipmitool -H <idrac> -U root -P calvin chassis power status`
+and `chassis bootdev pxe|cd|disk options=efiboot` would provide power + boot-device
+there. Until #62 lands, the R710 is controlled via IPMI/racadm directly, not kvm-pilot.
+
+---
+
+## Quirks to capture (→ #29 / support matrix #96)
+
+For each box, record:
+- [ ] `RedfishVersion` and BMC firmware version
+- [ ] `capabilities()` set actually served
+- [ ] boot-device `allowable` targets + whether `mode_settable`
+- [ ] Did `BootSourceOverrideMode` apply, get rejected (auto-retry), or absent?
+- [ ] one-time vs persistent both honored? cleared cleanly?
+- [ ] PATCH sync (200/204) vs async (202+Task)?
+- [ ] Power `ResetType`s advertised; any 400/409-absorbed-as-success
+- [ ] Virtual media present/licensed?
+- [ ] Auth: session vs basic; session-cap/idle-timeout behavior
+- [ ] Any field/shape that differs from the emulator (feed it back into `redfish_emulator.py`)
+
+## Results table (fill in)
+
+| Check | DL380 G9 (iLO4) | R710 (iDRAC6) |
+|---|---|---|
+| Reachable / healthcheck | | |
+| info + redfish_version | | |
+| capabilities | | (expect: n/a — no Redfish) |
+| boot-device --show (allowable, mode) | | n/a |
+| set once: pxe / cd / hdd | | n/a |
+| set persistent / legacy | | n/a |
+| clear (none) | | n/a |
+| power on/off/reset/cycle | | (IPMI, #62) |
+| virtual media | | n/a |
+| WoL (host NIC) | | |
+| Notes / quirks | | |

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -361,6 +361,8 @@ def cmd_wake(args) -> int:
 
 
 def cmd_boot_device(args) -> int:
+    if getattr(args, "via", "auto") == "ssh":
+        return _boot_device_via_ssh(args)
     bc = cast("BootConfig", _client(args, Capability.BOOT_CONFIG))
     if args.device is None:
         if not args.show:
@@ -371,6 +373,66 @@ def cmd_boot_device(args) -> int:
         return 0
     result = bc.set_boot_device(args.device, once=not args.persistent, uefi=not args.legacy)
     print(json.dumps(result, indent=2))
+    return 0
+
+
+def _boot_device_via_ssh(args) -> int:
+    """boot-device over the in-band SSH channel via efibootmgr BootNext (#150).
+
+    Single-gate design: the efibootmgr READ is harmless and runs on a
+    pre-consented channel; only the state-changing SET is gated, once, as
+    ``ssh.set_boot_next`` — so the flow never double-prompts through the
+    per-command ``ssh.exec`` gate. efibootmgr needs root, so commands are
+    ``sudo``-prefixed (passwordless sudo or a tty required on the target).
+    """
+    from . import efiboot
+    from .ssh import SSHChannel
+
+    cfg = _resolve_cfg(args)
+    ch = SSHChannel.from_config(cfg, confirm=allow_all, dry_run=False)
+    read = ch.ssh_exec("sudo efibootmgr")
+    if not read["ok"]:
+        print(f"boot-device (ssh): efibootmgr read failed: "
+              f"{read.get('stderr') or read.get('returncode')}", file=sys.stderr)
+        return 1
+    parsed = efiboot.parse_efibootmgr(read["stdout"])
+    if args.device is None:
+        if not args.show:
+            print("boot-device: give a device (pxe|cd|hdd|usb) or --show", file=sys.stderr)
+            return 2
+        print(json.dumps({"via": "ssh", "current": parsed["current"],
+                          "order": parsed["order"], "entries": parsed["entries"]}, indent=2))
+        return 0
+    if args.persistent:
+        print("boot-device (ssh): --persistent isn't supported over SSH yet; "
+              "efibootmgr BootNext is one-time only", file=sys.stderr)
+        return 2
+    try:
+        entry = efiboot.match_boot_entry(parsed["entries"], args.device)
+    except ValueError as exc:
+        print(f"boot-device (ssh): {exc}", file=sys.stderr)
+        return 2
+    if entry is None:
+        print(f"boot-device (ssh): no '{args.device}' boot entry found. Available:",
+              file=sys.stderr)
+        for bid in sorted(parsed["entries"]):
+            print(f"  Boot{bid}: {parsed['entries'][bid]}", file=sys.stderr)
+        return 2
+    confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
+    policy = SafetyPolicy(dry_run=getattr(args, "dry_run", False), confirm=confirm)
+    cmd = f"sudo {efiboot.set_boot_next_command(entry)}"
+    desc = f"Set next boot -> {args.device} (BootNext {entry}) on {ch.target}"
+    if not policy.guard("ssh.set_boot_next", desc):
+        print(json.dumps({"via": "ssh", "dry_run": True, "device": args.device,
+                          "entry": entry, "command": cmd}, indent=2))
+        return 0
+    res = ch.ssh_exec(cmd)
+    if not res["ok"]:
+        print(f"boot-device (ssh): set BootNext failed: "
+              f"{res.get('stderr') or res.get('returncode')}", file=sys.stderr)
+        return 1
+    print(json.dumps({"via": "ssh", "device": args.device, "entry": entry,
+                      "boot_next": entry, "once": True}, indent=2))
     return 0
 
 
@@ -1405,6 +1467,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--persistent", action="store_true",
                    help="Persist across reboots (default: one-time, cleared after next boot)")
     p.add_argument("--legacy", action="store_true", help="Legacy BIOS boot mode (default: UEFI)")
+    p.add_argument("--via", choices=["auto", "redfish", "ssh"], default="auto",
+                   help="Control path: 'redfish'/'auto' = BMC BootSourceOverride; "
+                        "'ssh' = in-band efibootmgr BootNext on the host OS (#150)")
     _add_common(p)
     p.set_defaults(func=cmd_boot_device, _preflight=True)
 

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     # capability-partial (a BMC — strong on structured state, but no keyboard or
     # screen), so capability-specific subcommands gate on supports() before
     # dispatch instead of AttributeError-ing deep in a handler.
-    from .drivers.base import BootProgress, FirmwareUpdate, Logs, Sensors
+    from .drivers.base import BootConfig, BootProgress, FirmwareUpdate, Logs, Sensors
     from .drivers.fake import FakeDriver
     from .drivers.redfish import RedfishDriver
 
@@ -331,6 +331,20 @@ def cmd_snapshot(args) -> int:
     kvm = _rich_client(args, Capability.VIDEO)
     out = kvm.snapshot_save(args.output)
     print(f"Saved {out}")
+    return 0
+
+
+def cmd_boot_device(args) -> int:
+    bc = cast("BootConfig", _client(args, Capability.BOOT_CONFIG))
+    if args.device is None:
+        if not args.show:
+            print("boot-device: give a device (pxe|cd|hdd|usb|bios|diag|none) or --show",
+                  file=sys.stderr)
+            return 2
+        print(json.dumps(bc.get_boot_options(), indent=2))
+        return 0
+    result = bc.set_boot_device(args.device, once=not args.persistent, uefi=not args.legacy)
+    print(json.dumps(result, indent=2))
     return 0
 
 
@@ -1342,6 +1356,22 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("action", choices=["on", "off", "off-hard", "reset"])
     _add_common(p)
     p.set_defaults(func=cmd_power, _preflight=True)
+
+    p = sub.add_parser(
+        "boot-device",
+        help="Set the next-boot device (Redfish BootSourceOverride); --show to read",
+    )
+    p.add_argument(
+        "device", nargs="?",
+        choices=["pxe", "cd", "hdd", "usb", "bios", "diag", "none"],
+        help="Boot device for the next reset (omit with --show; 'none' clears the override)",
+    )
+    p.add_argument("--show", action="store_true", help="Show the current boot override and exit")
+    p.add_argument("--persistent", action="store_true",
+                   help="Persist across reboots (default: one-time, cleared after next boot)")
+    p.add_argument("--legacy", action="store_true", help="Legacy BIOS boot mode (default: UEFI)")
+    _add_common(p)
+    p.set_defaults(func=cmd_boot_device, _preflight=True)
 
     p = sub.add_parser("power-cycle", help="Hard power cycle (off-hard -> on)")
     _add_common(p)

--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -43,7 +43,7 @@ from .drivers import make_driver_from_config
 from .drivers.base import Capability
 from .errors import CapabilityError, KVMPilotError, SafetyError
 from .firmware_registry import UPSTREAM_REPO
-from .safety import allow_all, interactive_confirm
+from .safety import SafetyPolicy, allow_all, interactive_confirm
 
 if TYPE_CHECKING:
     # Drivers the CLI can construct. KVMClient (PiKVM family) and FakeDriver expose
@@ -331,6 +331,32 @@ def cmd_snapshot(args) -> int:
     kvm = _rich_client(args, Capability.VIDEO)
     out = kvm.snapshot_save(args.output)
     print(f"Saved {out}")
+    return 0
+
+
+def cmd_wake(args) -> int:
+    from . import wol
+
+    cfg = _resolve_cfg(args)
+    mac = getattr(args, "mac", None) or cfg.mac
+    if not mac:
+        print("wake: no MAC — pass --mac AA:BB:CC:DD:EE:FF or set 'mac' in the profile",
+              file=sys.stderr)
+        return 2
+    broadcast = getattr(args, "broadcast", None) or cfg.wol_broadcast
+    count = getattr(args, "count", 3)
+    confirm = allow_all if getattr(args, "yes", False) else interactive_confirm
+    policy = SafetyPolicy(dry_run=getattr(args, "dry_run", False), confirm=confirm)
+    desc = f"Wake-on-LAN magic packet -> {mac} (broadcast {broadcast})"
+    if not policy.guard("wol.wake", desc):
+        print(f"wake: DRY-RUN — would send a WoL magic packet to {mac} via {broadcast}")
+        return 0
+    try:
+        wol.send_magic_packet(mac, broadcast=broadcast, count=count)
+    except ValueError as exc:
+        print(f"wake: {exc}", file=sys.stderr)
+        return 2
+    print(f"wake: sent WoL magic packet x{count} to {mac} (broadcast {broadcast})")
     return 0
 
 
@@ -1356,6 +1382,15 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("action", choices=["on", "off", "off-hard", "reset"])
     _add_common(p)
     p.set_defaults(func=cmd_power, _preflight=True)
+
+    p = sub.add_parser(
+        "wake", help="Send a Wake-on-LAN magic packet to power the host on (#199)")
+    p.add_argument("--mac", help="Target NIC MAC (default: the profile's 'mac')")
+    p.add_argument("--broadcast",
+                   help="Broadcast address (default: profile 'wol_broadcast' or 255.255.255.255)")
+    p.add_argument("--count", type=int, default=3, help="Copies of the packet to send (default 3)")
+    _add_common(p)
+    p.set_defaults(func=cmd_wake)
 
     p = sub.add_parser(
         "boot-device",

--- a/src/kvm_pilot/config.py
+++ b/src/kvm_pilot/config.py
@@ -92,6 +92,13 @@ class HostConfig:
     appliance_ssh_port: int = 22
     appliance_ssh_key: str | None = None
 
+    # Wake-on-LAN: the managed HOST's wired NIC MAC (the WoL target — not the
+    # KVM appliance) + the broadcast address the magic packet goes to. Used by
+    # `kvm-pilot wake` / power-on fallback when the KVM has no wired ATX power
+    # channel (the CRITICAL "no out-of-band reset" finding, #199).
+    mac: str | None = None
+    wol_broadcast: str = "255.255.255.255"
+
 
 def _load_file(path: Path) -> dict[str, Any]:
     if not path.exists():
@@ -152,6 +159,8 @@ def resolve_host(
     appliance_ssh_user: str | None = None,
     appliance_ssh_port: int | None = None,
     appliance_ssh_key: str | None = None,
+    mac: str | None = None,
+    wol_broadcast: str | None = None,
     config_path: Path | None = None,
 ) -> HostConfig:
     """Resolve a HostConfig from args > env > file (in that priority)."""
@@ -235,6 +244,9 @@ def resolve_host(
             pick("appliance_ssh_port", appliance_ssh_port, "KVM_PILOT_APPLIANCE_SSH_PORT", 22)),
         appliance_ssh_key=pick(
             "appliance_ssh_key", appliance_ssh_key, "KVM_PILOT_APPLIANCE_SSH_KEY"),
+        mac=pick("mac", mac, "KVM_PILOT_MAC"),
+        wol_broadcast=pick(
+            "wol_broadcast", wol_broadcast, "KVM_PILOT_WOL_BROADCAST", "255.255.255.255"),
     )
 
 

--- a/src/kvm_pilot/drivers/base.py
+++ b/src/kvm_pilot/drivers/base.py
@@ -30,6 +30,7 @@ class Capability(StrEnum):
     HID = "hid"
     VIDEO = "video"
     VIRTUAL_MEDIA = "virtual_media"
+    BOOT_CONFIG = "boot_config"
     GPIO = "gpio"
     EVENTS = "events"
     # Sensing capabilities — cheaper-than-vision signals. A driver that has any
@@ -91,6 +92,22 @@ class VirtualMedia(Protocol):
     def mount_iso(self, source: str, image_name: str | None = None, cdrom: bool = True) -> str: ...
     def msd_connect(self) -> None: ...
     def msd_disconnect(self) -> None: ...
+
+
+@runtime_checkable
+class BootConfig(Protocol):
+    """Choose what the host boots on its next (or every) reset.
+
+    Unifies the Redfish ``Boot.BootSourceOverride*`` path (a BMC) and the in-band
+    ``efibootmgr`` ``BootNext`` path (a running OS over SSH). ``device`` is a
+    normalized token — ``pxe | cd | hdd | usb | bios | diag | none`` — that each
+    implementation maps to its native vocabulary. ``once`` selects a one-time
+    override (cleared after the next boot) vs. a persistent one; ``uefi`` selects
+    UEFI vs. legacy/BIOS boot mode where the target exposes the choice.
+    """
+
+    def get_boot_options(self) -> dict: ...
+    def set_boot_device(self, device: str, *, once: bool = True, uefi: bool = True) -> dict: ...
 
 
 @runtime_checkable
@@ -220,6 +237,7 @@ CAPABILITY_PROTOCOLS: dict[Capability, type] = {
     Capability.HID: HID,
     Capability.VIDEO: Video,
     Capability.VIRTUAL_MEDIA: VirtualMedia,
+    Capability.BOOT_CONFIG: BootConfig,
     Capability.GPIO: GPIO,
     Capability.EVENTS: Events,
     Capability.LOGS: Logs,
@@ -307,6 +325,7 @@ __all__ = [
     "HID",
     "Video",
     "VirtualMedia",
+    "BootConfig",
     "GPIO",
     "Events",
     "Logs",

--- a/src/kvm_pilot/drivers/fake.py
+++ b/src/kvm_pilot/drivers/fake.py
@@ -85,6 +85,10 @@ class FakeDriver(PowerMixin, CapabilityMixin):
         self.keys: list[str] = []
         self.shortcuts: list[str] = []
         self.mounted: list[str] = []
+        # BootConfig (BootSourceOverride) in-memory state.
+        self.boot_enabled = "Disabled"   # Disabled | Once | Continuous
+        self.boot_target = "none"        # normalized token
+        self.boot_mode = "UEFI"          # UEFI | Legacy
 
     def _record(self, name: str, detail: Any = None) -> None:
         self.actions.append((name, detail))
@@ -122,6 +126,32 @@ class FakeDriver(PowerMixin, CapabilityMixin):
     def reset_hard(self, wait: bool = True) -> None:
         if self.safety.guard("atx.reset_hard", f"HARD reset {self.host}"):
             self._record("reset_hard")
+
+    # -- BootConfig (gated) ---------------------------------------------
+
+    _BOOT_TARGETS = ("pxe", "cd", "hdd", "usb", "bios", "diag", "none")
+
+    def get_boot_options(self) -> dict:
+        return {
+            "enabled": self.boot_enabled,
+            "once": self.boot_enabled == "Once",
+            "persistent": self.boot_enabled == "Continuous",
+            "target": self.boot_target,
+            "mode": self.boot_mode,
+            "mode_settable": True,
+            "allowable": sorted(self._BOOT_TARGETS),
+        }
+
+    def set_boot_device(self, device: str, *, once: bool = True, uefi: bool = True) -> dict:
+        key = str(device).strip().lower()
+        if key not in self._BOOT_TARGETS:
+            raise ValueError(f"unknown boot device {device!r}")
+        if self.safety.guard("redfish.set_boot_device", f"Set next boot -> {key} on {self.host}"):
+            self.boot_enabled = "Disabled" if key == "none" else ("Once" if once else "Continuous")
+            self.boot_target = key
+            self.boot_mode = "UEFI" if uefi else "Legacy"
+            self._record("set_boot_device", key)
+        return self.get_boot_options()
 
     # -- HID -------------------------------------------------------------
 

--- a/src/kvm_pilot/drivers/redfish/driver.py
+++ b/src/kvm_pilot/drivers/redfish/driver.py
@@ -152,6 +152,20 @@ def _log_within_lookback(created: object, cutoff: float | None) -> bool:
     return ts >= cutoff
 
 
+# Normalized boot-device token -> Redfish BootSourceOverrideTarget (DSP0268).
+# Aliases (dvd/disk/setup/diags) fold onto the canonical tokens.
+_BOOT_TARGET_MAP = {
+    "pxe": "Pxe", "cd": "Cd", "dvd": "Cd", "hdd": "Hdd", "disk": "Hdd",
+    "usb": "Usb", "bios": "BiosSetup", "setup": "BiosSetup",
+    "diag": "Diags", "diags": "Diags", "none": "None",
+}
+# Redfish target -> normalized token, for reporting.
+_BOOT_TARGET_REVERSE = {
+    "Pxe": "pxe", "Cd": "cd", "Hdd": "hdd", "Usb": "usb",
+    "BiosSetup": "bios", "Diags": "diag", "None": "none",
+}
+
+
 class RedfishDriver(PowerMixin, CapabilityMixin):
     """A Redfish BMC driver. See module docstring for the capability scope."""
 
@@ -616,6 +630,98 @@ class RedfishDriver(PowerMixin, CapabilityMixin):
             # as off would tell a wait loop the host is down mid-transition.
             return PHASE_POWER_OFF if sysd.get("PowerState") == "Off" else PHASE_UNKNOWN
         return _BOOT_PROGRESS_MAP.get(str(last), PHASE_UNKNOWN)
+
+    # -- BootConfig (BootSourceOverride) ---------------------------------
+
+    def _boot(self) -> dict:
+        """The current ``ComputerSystem.Boot`` object, re-read fresh.
+
+        The override is operator-set config that may have changed out-of-band, so
+        it is never cached. Resolving it also populates ``_system_uri`` for PATCH.
+        """
+        return self._system_fresh().get("Boot") or {}
+
+    def get_boot_options(self) -> dict:
+        """Report the current boot override (normalized + raw)."""
+        boot = self._boot()
+        enabled = boot.get("BootSourceOverrideEnabled", "Disabled")
+        raw_target = boot.get("BootSourceOverrideTarget", "None")
+        allowable_raw = boot.get("BootSourceOverrideTarget@Redfish.AllowableValues") or []
+        return {
+            "enabled": enabled,               # Disabled | Once | Continuous
+            "once": enabled == "Once",
+            "persistent": enabled == "Continuous",
+            "target": _BOOT_TARGET_REVERSE.get(
+                raw_target, raw_target.lower() if isinstance(raw_target, str) else raw_target
+            ),
+            "target_raw": raw_target,
+            "mode": boot.get("BootSourceOverrideMode"),   # UEFI | Legacy | None (not exposed)
+            "mode_settable": "BootSourceOverrideMode" in boot,
+            "allowable": sorted(
+                {_BOOT_TARGET_REVERSE.get(t, t.lower()) for t in allowable_raw if isinstance(t, str)}
+            ),
+            "allowable_raw": list(allowable_raw),
+        }
+
+    def set_boot_device(self, device: str, *, once: bool = True, uefi: bool = True) -> dict:
+        """Set the next-boot (``once``) or persistent boot device via BootSourceOverride.
+
+        ``device`` is a normalized token (``pxe|cd|hdd|usb|bios|diag|none``);
+        ``none`` clears the override. Feature-detects the BMC's advertised targets
+        and its support for ``BootSourceOverrideMode`` (older iLO4/iDRAC7 omit it),
+        so a target the box rejects fails fast with a clear error instead of an
+        opaque 400. Returns the resulting :meth:`get_boot_options`.
+        """
+        key = str(device).strip().lower()
+        if key not in _BOOT_TARGET_MAP:
+            choices = sorted({"pxe", "cd", "hdd", "usb", "bios", "diag", "none"})
+            raise KVMPilotError(f"unknown boot device {device!r}; choose one of {choices}")
+        target = _BOOT_TARGET_MAP[key]
+        boot = self._boot()
+        allowable = boot.get("BootSourceOverrideTarget@Redfish.AllowableValues")
+        # "None" always clears; other targets must be advertised (if the BMC says).
+        if target != "None" and allowable and target not in allowable:
+            raise CapabilityError(
+                f"{self.host} does not allow boot target {target!r}; advertises {list(allowable)}"
+            )
+        enabled = "Disabled" if target == "None" else ("Once" if once else "Continuous")
+        patch: dict[str, Any] = {
+            "Boot": {
+                "BootSourceOverrideEnabled": enabled,
+                "BootSourceOverrideTarget": target,
+            }
+        }
+        # Set mode only where the target exposes it — PATCHing a mode the BMC
+        # doesn't model 400s or is silently dropped (iLO4/iDRAC7).
+        mode_exposed = "BootSourceOverrideMode" in boot
+        if mode_exposed and target != "None":
+            patch["Boot"]["BootSourceOverrideMode"] = "UEFI" if uefi else "Legacy"
+
+        desc = (
+            f"Set next boot -> {key} ({'once' if once else 'persistent'}"
+            f"{', UEFI' if mode_exposed and uefi else ''}) on {self.host} [{self._system_uri}]"
+        )
+        if not self.safety.guard("redfish.set_boot_device", desc):
+            return self.get_boot_options()  # dry-run: gated and skipped
+
+        assert self._system_uri is not None
+        try:
+            resp = self._http.request("PATCH", self._system_uri, json_body=patch)
+        except KVMPilotError as exc:
+            # Some BMCs reject the mode property specifically (PropertyNotWritable
+            # / 400). Retry once without it — the override target still applies.
+            if (
+                mode_exposed
+                and exc.status_code == 400
+                and "BootSourceOverrideMode" in patch["Boot"]
+            ):
+                logger.info("%s rejected BootSourceOverrideMode; retrying without it", self.host)
+                del patch["Boot"]["BootSourceOverrideMode"]
+                resp = self._http.request("PATCH", self._system_uri, json_body=patch)
+            else:
+                raise
+        self._handle_async(resp)
+        return self.get_boot_options()
 
     # -- Logs ------------------------------------------------------------
 

--- a/src/kvm_pilot/efiboot.py
+++ b/src/kvm_pilot/efiboot.py
@@ -1,0 +1,94 @@
+"""Parse ``efibootmgr`` output and pick a boot entry for a normalized device.
+
+The in-band counterpart to the Redfish BootSourceOverride path (#150/#201): on a
+host with a running OS (reached over the SSH channel), ``efibootmgr`` lists the
+UEFI boot entries and ``efibootmgr -n <id>`` sets a one-time ``BootNext``. This
+module is the pure, hardware-free core — parsing and device-to-entry matching —
+so it is unit-tested against captured fixtures; the SSH execution + gating live in
+the CLI (``boot-device --via ssh``).
+"""
+
+from __future__ import annotations
+
+import re
+
+_BOOT_LINE = re.compile(r"^Boot([0-9A-Fa-f]{4})(\*?)\s+(.*)$")
+
+# Normalized device token -> ordered label/path regexes (first hit wins). Matched
+# against the whole entry text (label + any device path from ``-v``), so signals
+# in the path — NVMe, MAC/IPv4, USB() — count too. Order encodes preference
+# (e.g. IPv4 PXE before IPv6; the OS loader before a raw disk).
+_MATCH_PATTERNS: dict[str, list[str]] = {
+    "pxe": [r"ipv4.*network|network.*ipv4|\bpxe\b", r"\bnetwork\b|ipv6"],
+    "usb": [r"\busb\b(?!.*network)"],  # a USB volume, not "USB NETWORK BOOT" (PXE-over-USB-NIC)
+    "cd": [r"\bcd\b|\bdvd\b|cd/dvd|cdrom|optical"],
+    "hdd": [
+        r"windows boot manager|\bredhat\b|ubuntu|fedora|debian|grub|rhel|opensuse",
+        r"nvme|\bsata\b|\bssd\b|\bhdd\b|hard drive|\bata\b|\bscsi\b",
+    ],
+}
+
+VALID_DEVICES = ("pxe", "cd", "hdd", "usb")
+
+
+def parse_efibootmgr(output: str) -> dict:
+    """Parse ``efibootmgr`` (plain or ``-v``) output.
+
+    Returns ``{current, order, timeout, entries, active}`` where ``entries`` maps
+    a 4-hex-digit id (uppercased) to its text, ``active`` maps id -> bool (the
+    ``*`` flag), ``order`` is the BootOrder id list, ``current`` is BootCurrent.
+    """
+    current: str | None = None
+    order: list[str] = []
+    timeout: int | None = None
+    entries: dict[str, str] = {}
+    active: dict[str, bool] = {}
+    for raw in output.splitlines():
+        line = raw.rstrip()
+        if line.startswith("BootCurrent:"):
+            current = line.split(":", 1)[1].strip().upper() or None
+        elif line.startswith("BootOrder:"):
+            order = [x.strip().upper() for x in line.split(":", 1)[1].split(",") if x.strip()]
+        elif line.startswith("Timeout:"):
+            m = re.search(r"\d+", line)
+            timeout = int(m.group()) if m else None
+        else:
+            m = _BOOT_LINE.match(line)
+            if m:
+                bid = m.group(1).upper()
+                entries[bid] = m.group(3).strip()
+                active[bid] = m.group(2) == "*"
+    return {
+        "current": current,
+        "order": order,
+        "timeout": timeout,
+        "entries": entries,
+        "active": active,
+    }
+
+
+def match_boot_entry(entries: dict[str, str], device: str) -> str | None:
+    """Return the boot-entry id best matching a normalized ``device``, or None.
+
+    Deterministic: patterns are tried in preference order, and within a pattern
+    entries are scanned in id order. ``None`` means the box has no such entry (the
+    caller should surface the available entries so an operator can pick explicitly).
+    """
+    key = device.strip().lower()
+    patterns = _MATCH_PATTERNS.get(key)
+    if patterns is None:
+        raise ValueError(f"unknown boot device {device!r}; choose one of {list(VALID_DEVICES)}")
+    for pattern in patterns:
+        rx = re.compile(pattern, re.IGNORECASE)
+        for bid in sorted(entries):
+            if rx.search(entries[bid]):
+                return bid
+    return None
+
+
+def set_boot_next_command(entry_id: str) -> str:
+    """The command that sets a one-time BootNext to ``entry_id`` (validated hex)."""
+    bid = entry_id.strip().upper()
+    if not re.fullmatch(r"[0-9A-F]{4}", bid):
+        raise ValueError(f"invalid boot entry id {entry_id!r} (want 4 hex digits)")
+    return f"efibootmgr -n {bid}"

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -86,7 +86,15 @@ if TYPE_CHECKING:
     # ``_driver(capability=…)`` guarantees the driver supports the capability at
     # runtime; narrow to the owning protocol for the capability-specific calls
     # (mirrors the ``cast`` pattern in cli.py).
-    from kvm_pilot.drivers.base import HID, Logs, Power, SystemInfo, Video, VirtualMedia
+    from kvm_pilot.drivers.base import (
+        HID,
+        BootConfig,
+        Logs,
+        Power,
+        SystemInfo,
+        Video,
+        VirtualMedia,
+    )
 
 mcp = FastMCP("kvm-pilot")
 _log = logging.getLogger("kvm_pilot.mcp")
@@ -797,6 +805,56 @@ def power(
             **_provenance(cfg), "requested": action,
             "verified": verified, "observed": observed, "note": note,
             "detail": f"power {action}: requested on host '{cfg.host}' ({cfg.driver})",
+        }
+
+
+@mcp.tool(annotations=_READ)
+def boot_options(profile: str | None = None) -> dict:
+    """Show the host's current boot override (Redfish BootSourceOverride) — read-only.
+
+    Reports ``enabled`` (Disabled/Once/Continuous), the normalized ``target``, the
+    ``mode`` (UEFI/Legacy, or null if the BMC doesn't expose it), and the
+    ``allowable`` targets the BMC advertises — so an actuator knows what
+    ``set_boot_device`` values this box will accept before trying one.
+    """
+    with _driver(profile, confirm=deny_all, capability=Capability.BOOT_CONFIG) as (cfg, kvm):
+        return {**_provenance(cfg), "boot": cast("BootConfig", kvm).get_boot_options()}
+
+
+@mcp.tool(annotations=_DESTRUCTIVE)
+def set_boot_device(
+    device: Literal["pxe", "cd", "hdd", "usb", "bios", "diag", "none"],
+    once: bool = True,
+    uefi: bool = True,
+    confirm: bool = False,
+    profile: str | None = None,
+) -> dict:
+    """Set the next-boot (or persistent) boot device via BootSourceOverride. CONFIG MUTATION.
+
+    Disabled unless the operator enabled config mutations in the server's own
+    environment (see the co-located README.md). ``confirm=true`` is required.
+    ``none`` clears the override; ``once=false`` makes it persistent; ``uefi=false``
+    selects legacy BIOS mode where the target exposes it. A target the BMC doesn't
+    advertise fails fast (call ``boot_options`` first to see ``allowable``).
+    """
+    if not _env_flag("KVM_PILOT_MCP_ALLOW_CONFIG"):
+        # As with power: the gate is opened by the human operator out of band, so
+        # no copy-pasteable variable is surfaced to the agent.
+        raise ToolError(
+            "boot-device control is disabled on this server. Only the human operator "
+            "can enable it, by setting the config-mutation enable environment variable "
+            "(documented in the server's README.md) in the MCP server's own environment "
+            "before starting it. It cannot be enabled from within an agent session."
+        )
+    if not confirm:
+        raise ToolError(f"set_boot_device {device!r} was not confirmed")
+    with _driver(
+        profile, confirm=allow_all, capability=Capability.BOOT_CONFIG, enforce_health=True
+    ) as (cfg, kvm):
+        result = cast("BootConfig", kvm).set_boot_device(device, once=once, uefi=uefi)
+        return {
+            **_provenance(cfg), "requested": device, "once": once, "uefi": uefi,
+            "dry_run": _dry_run(), "boot": result,
         }
 
 

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -858,6 +858,47 @@ def set_boot_device(
         }
 
 
+@mcp.tool(annotations=_DESTRUCTIVE)
+def wake(
+    mac: str | None = None,
+    broadcast: str | None = None,
+    count: int = 3,
+    confirm: bool = False,
+    profile: str | None = None,
+) -> dict:
+    """Send a Wake-on-LAN magic packet to power the host on. POWER (soft).
+
+    Disabled unless the operator enabled power control (the power-enable env var,
+    see the co-located README.md) in the server's own environment. ``confirm=true``
+    is required. ``mac`` defaults to the profile's ``mac``; ``broadcast`` to its
+    ``wol_broadcast``. No KVM driver is contacted — WoL is a broadcast sent from
+    the server's own host onto the target's L2 segment.
+    """
+    if not _env_flag("KVM_PILOT_MCP_ALLOW_POWER"):
+        raise ToolError(
+            "power control is disabled on this server. Only the human operator can "
+            "enable it, by setting the power-enable environment variable (documented "
+            "in the server's README.md) in the MCP server's own environment before "
+            "starting it. It cannot be enabled from within an agent session."
+        )
+    if not confirm:
+        raise ToolError("wake was not confirmed")
+    cfg = resolve_host(profile or os.environ.get("KVM_PILOT_PROFILE"))
+    target = mac or cfg.mac
+    if not target:
+        raise ToolError("no MAC — pass mac=, or set 'mac' in the host profile")
+    bc = broadcast or cfg.wol_broadcast
+    from kvm_pilot import wol
+
+    if _dry_run():
+        return {**_provenance(cfg), "requested_mac": target, "broadcast": bc, "dry_run": True}
+    wol.send_magic_packet(target, broadcast=bc, count=count)
+    return {
+        **_provenance(cfg), "requested_mac": target, "broadcast": bc,
+        "count": count, "dry_run": False,
+    }
+
+
 # -- HID act tools (issue #61): see act.py for the two-guarantee model --------
 
 

--- a/src/kvm_pilot/safety.py
+++ b/src/kvm_pilot/safety.py
@@ -38,6 +38,9 @@ DESTRUCTIVE_OPS: set[str] = {
     "atx.reset_hard",
     "atx.power_on",  # included: powering a box on is a state change worth gating
     "atx.click",
+    # Wake-on-LAN: sending a magic packet powers a sleeping/off host ON — a state
+    # change, gated like any power-on (the WoL fallback when there's no ATX, #199).
+    "wol.wake",
     "msd.set_params",
     "msd.connect",
     "msd.disconnect",
@@ -120,6 +123,7 @@ class EffectClass(StrEnum):
 OP_EFFECT: dict[str, EffectClass] = {
     # ATX / power
     "atx.power_on": EffectClass.POWER_SOFT,
+    "wol.wake": EffectClass.POWER_SOFT,   # WoL magic packet powers a host on
     "atx.power_off": EffectClass.POWER_SOFT,
     "atx.power_off_hard": EffectClass.POWER_HARD,
     "atx.reset_hard": EffectClass.POWER_HARD,

--- a/src/kvm_pilot/safety.py
+++ b/src/kvm_pilot/safety.py
@@ -57,6 +57,11 @@ DESTRUCTIVE_OPS: set[str] = {
     "redfish.reset_hard",
     "redfish.virtual_media_insert",
     "redfish.virtual_media_eject",
+    # Changing the boot device (Redfish BootSourceOverride, or an in-band
+    # efibootmgr BootNext) alters what the host boots on its next reset — a
+    # pre-reboot state change worth gating, though not itself a power action.
+    "redfish.set_boot_device",
+    "ssh.set_boot_next",
     # HID input changes target state too: keystrokes and clicks land on a live
     # console (rm -rf is one type_text away). Mouse *moves* stay ungated.
     "hid.ctrl_alt_delete",
@@ -138,6 +143,11 @@ OP_EFFECT: dict[str, EffectClass] = {
     "redfish.reset_hard": EffectClass.POWER_HARD,
     "redfish.virtual_media_insert": EffectClass.MEDIA,
     "redfish.virtual_media_eject": EffectClass.MEDIA,
+    # Boot-device override (Redfish BootSourceOverride / in-band efibootmgr
+    # BootNext): changes what the host boots next reset — a config mutation, not
+    # a power/media action, so an actuator can't launder it as either.
+    "redfish.set_boot_device": EffectClass.CONFIG_MUTATION,
+    "ssh.set_boot_next": EffectClass.CONFIG_MUTATION,
     # HID input
     "hid.type_text": EffectClass.HID_INPUT,
     "hid.press_key": EffectClass.HID_INPUT,

--- a/src/kvm_pilot/wol.py
+++ b/src/kvm_pilot/wol.py
@@ -1,0 +1,93 @@
+"""Wake-on-LAN: build/send magic packets and parse ``ethtool`` WoL state.
+
+WoL is the power-*on* path for targets whose KVM appliance has no wired ATX or
+GPIO power channel — the CRITICAL "no out-of-band reset" healthcheck finding
+(#199). A magic packet is ``6x 0xFF`` followed by the target MAC repeated 16
+times (102 bytes); broadcast over UDP, a NIC armed for WoL (``ethtool`` shows
+``Wake-on: g``) powers the host on when it sees the packet.
+
+This module is intentionally dependency-free and side-effect-light so the packet
+construction and ``ethtool`` parsing are unit-testable without hardware; the one
+socket call is isolated in :func:`send_magic_packet`.
+"""
+
+from __future__ import annotations
+
+import socket
+
+# UDP discard port; 7 (echo) and 0 are also seen in the wild. The payload, not
+# the port, is what a NIC matches on, so any works — 9 is the de-facto default.
+DEFAULT_WOL_PORT = 9
+_MAGIC_PREFIX = b"\xff" * 6
+_PACKET_LEN = 6 + 6 * 16  # 102
+
+
+def normalize_mac(mac: str) -> bytes:
+    """Parse a MAC in colon/dash/dot/bare-hex form into 6 raw bytes.
+
+    Accepts ``5c:60:ba:bb:cf:63``, ``5C-60-BA-BB-CF-63``, ``5c60.babb.cf63``
+    (Cisco), or ``5c60babbcf63`` (case/space-insensitive). Raises ``ValueError``
+    on anything that is not exactly six hex octets.
+    """
+    if not isinstance(mac, str):
+        raise ValueError(f"MAC must be a string, got {type(mac).__name__}")
+    cleaned = mac.strip().lower().replace(":", "").replace("-", "").replace(".", "")
+    if len(cleaned) != 12 or any(c not in "0123456789abcdef" for c in cleaned):
+        raise ValueError(f"invalid MAC address: {mac!r}")
+    return bytes.fromhex(cleaned)
+
+
+def build_magic_packet(mac: str) -> bytes:
+    """Return the 102-byte Wake-on-LAN magic packet for ``mac``."""
+    return _MAGIC_PREFIX + normalize_mac(mac) * 16
+
+
+def send_magic_packet(
+    mac: str,
+    *,
+    broadcast: str = "255.255.255.255",
+    port: int = DEFAULT_WOL_PORT,
+    count: int = 1,
+    interface_ip: str | None = None,
+) -> bytes:
+    """Broadcast a WoL magic packet for ``mac``; return the packet sent.
+
+    ``broadcast`` should be the target segment's broadcast address (e.g.
+    ``10.0.1.255``) so the frame reaches the sleeping NIC's L2. ``interface_ip``
+    binds the send to a specific local NIC on a multi-homed sender. ``count``
+    sends the packet more than once (WoL is fire-and-forget; a couple of copies
+    hedges against loss).
+    """
+    if count < 1:
+        raise ValueError("count must be >= 1")
+    packet = build_magic_packet(mac)
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        if interface_ip:
+            sock.bind((interface_ip, 0))
+        for _ in range(count):
+            sock.sendto(packet, (broadcast, port))
+    return packet
+
+
+def parse_ethtool_wol(ethtool_output: str) -> dict:
+    """Parse ``ethtool <iface>`` output for WoL capability and current state.
+
+    Returns ``{'supported': str, 'current': str, 'supports_magic': bool,
+    'magic_enabled': bool}``. ethtool's letter codes: ``g`` = wake on
+    MagicPacket, ``d`` = disabled (see ``man ethtool``).
+    """
+    supported = ""
+    current = ""
+    for line in ethtool_output.splitlines():
+        s = line.strip()
+        if s.startswith("Supports Wake-on:"):
+            supported = s.split(":", 1)[1].strip()
+        elif s.startswith("Wake-on:"):
+            current = s.split(":", 1)[1].strip()
+    return {
+        "supported": supported,
+        "current": current,
+        "supports_magic": "g" in supported,
+        "magic_enabled": "g" in current,
+    }

--- a/tests/redfish_emulator.py
+++ b/tests/redfish_emulator.py
@@ -100,6 +100,19 @@ class RedfishState:
         # If True, ServiceRoot advertises $expand and the Sensors collection
         # serves its members inline for a ?$expand request (one GET, no fan-out).
         self.sensors_expandable = False
+        # ComputerSystem.Boot (BootSourceOverride) state + quirk knobs.
+        self.boot_override_enabled = "Disabled"   # Disabled | Once | Continuous
+        self.boot_override_target = "None"        # None|Pxe|Cd|Hdd|Usb|BiosSetup|Diags
+        self.boot_override_mode = "UEFI"          # UEFI | Legacy
+        self.boot_allowable = ["None", "Pxe", "Cd", "Hdd", "Usb", "BiosSetup", "Diags"]
+        # boot_expose_mode=False models older iLO4/iDRAC7 with no
+        # BootSourceOverrideMode field; boot_patch_rejects_mode models a BMC that
+        # 400s a PATCH that includes a mode it won't accept (driver must retry
+        # without it). boot_patch_status: 200 (return resource) | 204 | 202 async.
+        self.boot_expose_mode = True
+        self.boot_patch_rejects_mode = False
+        self.boot_patch_status = 200
+        self.patches: list[tuple[str, dict]] = []
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -290,6 +303,13 @@ class _Handler(BaseHTTPRequestHandler):
     def _computer_system(self) -> dict:
         st = self._state
         reset: dict = {"target": RESET, "ResetType@Redfish.AllowableValues": st.reset_allowable}
+        boot: dict = {
+            "BootSourceOverrideEnabled": st.boot_override_enabled,
+            "BootSourceOverrideTarget": st.boot_override_target,
+            "BootSourceOverrideTarget@Redfish.AllowableValues": st.boot_allowable,
+        }
+        if st.boot_expose_mode:
+            boot["BootSourceOverrideMode"] = st.boot_override_mode
         return {
             "@odata.id": SYS,
             "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
@@ -298,6 +318,7 @@ class _Handler(BaseHTTPRequestHandler):
             "PowerState": st.power_state,
             "Status": {"Health": "OK", "State": "Enabled"},
             "BootProgress": {"LastState": st.boot_progress},
+            "Boot": boot,
             # DSP0268 associations — the driver resolves chassis/manager from
             # these, not by indexing the global collections.
             "Links": {"Chassis": [{"@odata.id": CHAS}], "ManagedBy": [{"@odata.id": MGR}]},
@@ -389,6 +410,47 @@ class _Handler(BaseHTTPRequestHandler):
             return
         # A real BMC 404s an unknown action target (a typo'd @odata.id/target).
         self._send({"error": {"message": "not found"}}, status=404)
+
+    def do_PATCH(self) -> None:
+        if self._pre():
+            return
+        path = self._path()
+        body = self._read_body()
+        st = self._state
+        st.patches.append((path, body))
+        if path != SYS:
+            self._send({"error": {"message": "not found"}}, status=404)
+            return
+        boot = body.get("Boot")
+        if not isinstance(boot, dict):
+            self._send({"error": {"message": "unsupported PATCH target"}}, status=400)
+            return
+        target = boot.get("BootSourceOverrideTarget")
+        if target is not None and target not in st.boot_allowable:
+            self._send({"error": {"@Message.ExtendedInfo": [
+                {"MessageId": "Base.1.0.PropertyValueNotInList",
+                 "Message": f"{target} is not one of the allowable values",
+                 "MessageArgs": [str(target), "BootSourceOverrideTarget"]}]}}, status=400)
+            return
+        if "BootSourceOverrideMode" in boot and st.boot_patch_rejects_mode:
+            self._send({"error": {"@Message.ExtendedInfo": [
+                {"MessageId": "Base.1.0.PropertyNotWritable",
+                 "Message": "BootSourceOverrideMode is not writable on this system",
+                 "MessageArgs": ["BootSourceOverrideMode"]}]}}, status=400)
+            return
+        # Apply the write.
+        if "BootSourceOverrideEnabled" in boot:
+            st.boot_override_enabled = boot["BootSourceOverrideEnabled"]
+        if target is not None:
+            st.boot_override_target = target
+        if "BootSourceOverrideMode" in boot and st.boot_expose_mode:
+            st.boot_override_mode = boot["BootSourceOverrideMode"]
+        if st.boot_patch_status == 202:
+            self._send(None, status=202, headers={"Location": TASK})
+        elif st.boot_patch_status == 204:
+            self._send(None, status=204)
+        else:
+            self._send(self._computer_system(), status=200)
 
     def do_DELETE(self) -> None:
         if self._pre():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -871,3 +871,77 @@ def test_wake_requires_mac(capsys):
     rc = main(["wake", "--host", "fake"])
     assert rc == 2
     assert "no MAC" in capsys.readouterr().err
+
+
+# -- boot-device --via ssh (efibootmgr BootNext, #150) ----------------------
+
+_EFI_FIXTURE = (
+    "BootCurrent: 0005\nBootOrder: 0005,0001,0003,0004\n"
+    "Boot0001* SAMSUNG NVMe\tNVMe(0x1)\n"
+    "Boot0003* IPV4 Network Intel I219-LM\tMAC(5c60babbcf63)/IPv4\n"
+    "Boot0004* USB\tUSB(0x1)\n"
+    "Boot0005* redhat\tHD(1)/shimx64.efi\n"
+)
+
+
+def _patch_ssh(monkeypatch, calls, *, read_stdout=_EFI_FIXTURE, set_ok=True):
+    from kvm_pilot import ssh as ssh_mod
+
+    class FakeCh:
+        target = "dtrapani@10.0.1.16"
+
+        def ssh_exec(self, command, **kw):
+            calls.append(command)
+            if "efibootmgr -n" in command:
+                return {"command": command, "returncode": 0 if set_ok else 1,
+                        "stdout": "", "stderr": "" if set_ok else "denied",
+                        "ok": set_ok, "dry_run": False}
+            return {"command": command, "returncode": 0, "stdout": read_stdout,
+                    "stderr": "", "ok": True, "dry_run": False}
+
+    monkeypatch.setattr(ssh_mod.SSHChannel, "from_config", lambda cfg, **kw: FakeCh())
+
+
+def test_boot_device_via_ssh_sets_bootnext_pxe(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls)
+    rc = main(["boot-device", "pxe", "--via", "ssh", "--host", "10.0.1.16", "--yes"])
+    assert rc == 0
+    assert any("efibootmgr -n 0003" in c for c in calls)   # IPV4 network entry
+    assert '"entry": "0003"' in capsys.readouterr().out
+
+
+def test_boot_device_via_ssh_show(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls)
+    rc = main(["boot-device", "--via", "ssh", "--show", "--host", "10.0.1.16"])
+    assert rc == 0
+    assert not any("efibootmgr -n" in c for c in calls)     # read-only, no set
+    assert '"current": "0005"' in capsys.readouterr().out
+
+
+def test_boot_device_via_ssh_no_match_lists_entries(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls)  # fixture has no CD entry
+    rc = main(["boot-device", "cd", "--via", "ssh", "--host", "10.0.1.16", "--yes"])
+    assert rc == 2
+    assert not any("efibootmgr -n" in c for c in calls)
+    assert "no 'cd' boot entry" in capsys.readouterr().err
+
+
+def test_boot_device_via_ssh_dry_run(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls)
+    rc = main(["boot-device", "hdd", "--via", "ssh", "--host", "10.0.1.16", "--dry-run"])
+    assert rc == 0
+    assert not any("efibootmgr -n" in c for c in calls)     # dry-run: no set issued
+    assert '"dry_run": true' in capsys.readouterr().out
+
+
+def test_boot_device_via_ssh_persistent_unsupported(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls)
+    rc = main(["boot-device", "pxe", "--via", "ssh", "--persistent",
+               "--host", "10.0.1.16", "--yes"])
+    assert rc == 2
+    assert "persistent" in capsys.readouterr().err.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -829,3 +829,45 @@ def test_firmware_update_plan_steers_to_web_console(monkeypatch, capsys):
     assert cli_mod.main(["firmware-update", "--host", "h"]) == 0
     out = capsys.readouterr().out
     assert "web console" in out
+
+
+def test_wake_sends_magic_packet(monkeypatch, capsys):
+    import kvm_pilot.wol as wol_mod
+    sent = {}
+    monkeypatch.setattr(
+        wol_mod, "send_magic_packet",
+        lambda mac, **kw: sent.update(mac=mac, **kw) or b"",
+    )
+    rc = main(["wake", "--mac", "5c:60:ba:bb:cf:63", "--host", "fake", "--yes"])
+    assert rc == 0
+    assert sent["mac"] == "5c:60:ba:bb:cf:63"
+    assert sent["broadcast"] == "255.255.255.255"
+    assert "sent WoL" in capsys.readouterr().out
+
+
+def test_wake_broadcast_flag(monkeypatch):
+    import kvm_pilot.wol as wol_mod
+    sent = {}
+    monkeypatch.setattr(
+        wol_mod, "send_magic_packet",
+        lambda mac, **kw: sent.update(mac=mac, **kw) or b"",
+    )
+    rc = main(["wake", "--mac", "aa:bb:cc:dd:ee:ff", "--broadcast", "10.0.1.255",
+               "--host", "fake", "--yes"])
+    assert rc == 0
+    assert sent["broadcast"] == "10.0.1.255"
+
+
+def test_wake_dry_run_does_not_send(monkeypatch):
+    import kvm_pilot.wol as wol_mod
+    called = []
+    monkeypatch.setattr(wol_mod, "send_magic_packet", lambda *a, **k: called.append(1))
+    rc = main(["wake", "--mac", "5c:60:ba:bb:cf:63", "--host", "fake", "--dry-run"])
+    assert rc == 0
+    assert called == []
+
+
+def test_wake_requires_mac(capsys):
+    rc = main(["wake", "--host", "fake"])
+    assert rc == 2
+    assert "no MAC" in capsys.readouterr().err

--- a/tests/test_cli_redfish.py
+++ b/tests/test_cli_redfish.py
@@ -114,3 +114,40 @@ def test_cli_boot_progress_reports_phase(emu, capsys):
     rc = main(_argv(emu, "boot-progress"))
     assert rc == 0
     assert "os_running" in capsys.readouterr().out
+
+
+# -- boot-device (BootSourceOverride) via the CLI --------------------------
+
+def _boot_patches(emu) -> list[dict]:
+    from redfish_emulator import SYS
+    return [b["Boot"] for p, b in emu.state.patches if p == SYS and "Boot" in b]
+
+
+def test_cli_boot_device_pxe_once(emu, capsys):
+    rc = main(_argv(emu, "boot-device", "pxe", "--yes"))
+    assert rc == 0
+    assert emu.state.boot_override_enabled == "Once"
+    assert emu.state.boot_override_target == "Pxe"
+    assert '"target": "pxe"' in capsys.readouterr().out
+
+
+def test_cli_boot_device_persistent_cd(emu):
+    rc = main(_argv(emu, "boot-device", "cd", "--persistent", "--yes"))
+    assert rc == 0
+    assert emu.state.boot_override_enabled == "Continuous"
+    assert emu.state.boot_override_target == "Cd"
+
+
+def test_cli_boot_device_none_clears(emu):
+    emu.state.boot_override_enabled = "Once"
+    emu.state.boot_override_target = "Pxe"
+    rc = main(_argv(emu, "boot-device", "none", "--yes"))
+    assert rc == 0
+    assert emu.state.boot_override_enabled == "Disabled"
+
+
+def test_cli_boot_device_show_is_read_only(emu, capsys):
+    rc = main(_argv(emu, "boot-device", "--show", "--yes"))
+    assert rc == 0
+    assert _boot_patches(emu) == []          # read-only: no PATCH
+    assert '"enabled": "Disabled"' in capsys.readouterr().out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -207,3 +207,31 @@ def test_default_config_path_ends_with_kvm_pilot_config(monkeypatch):
     monkeypatch.delenv("KVM_PILOT_CONFIG", raising=False)
     p = cfg._default_config_path()
     assert p.name == "config.toml" and p.parent.name == "kvm-pilot"
+
+
+def test_wol_mac_and_broadcast_precedence(monkeypatch, tmp_path):
+    none = tmp_path / "none.toml"
+    # default
+    cfg = resolve_host(host="h", config_path=none)
+    assert cfg.mac is None
+    assert cfg.wol_broadcast == "255.255.255.255"
+    # arg wins
+    cfg = resolve_host(host="h", mac="5c:60:ba:bb:cf:63",
+                       wol_broadcast="10.0.1.255", config_path=none)
+    assert cfg.mac == "5c:60:ba:bb:cf:63"
+    assert cfg.wol_broadcast == "10.0.1.255"
+    # env
+    monkeypatch.setenv("KVM_PILOT_MAC", "aa:bb:cc:dd:ee:ff")
+    assert resolve_host(host="h", config_path=none).mac == "aa:bb:cc:dd:ee:ff"
+
+
+def test_wol_mac_from_profile(tmp_path):
+    cfg_file = tmp_path / "c.toml"
+    cfg_file.write_text(
+        '[hosts.box]\nhost = "10.0.1.16"\n'
+        'mac = "5c:60:ba:bb:cf:63"\nwol_broadcast = "10.0.1.255"\n'
+    )
+    cfg = resolve_host(profile="box", config_path=cfg_file)
+    assert cfg.host == "10.0.1.16"
+    assert cfg.mac == "5c:60:ba:bb:cf:63"
+    assert cfg.wol_broadcast == "10.0.1.255"

--- a/tests/test_efiboot.py
+++ b/tests/test_efiboot.py
@@ -1,0 +1,106 @@
+"""Tests for efibootmgr parsing + device matching (#150/#22).
+
+Pure/hardware-free. REAL_FIXTURE is captured from the .16 homelab host
+(Dell wired NIC I219-LM, Samsung NVMe, redhat shim); SYNTH_FIXTURE adds a CD/DVD
+and a Windows Boot Manager to cover matches the real box lacks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kvm_pilot import efiboot
+
+# Real `efibootmgr` output from 10.0.1.16 (trimmed device paths kept — they carry
+# the NVMe/MAC/IPv4/USB signals the matcher can use).
+REAL_FIXTURE = """\
+BootCurrent: 0005
+Timeout: 0 seconds
+BootOrder: 0005,0001,0004,0002,0003,0006,0007
+Boot0001* SAMSUNG MZVL2256HCHQ-00BH1-S63XNX0T339238\tPciRoot(0x0)/Pci(0x1b,0x0)/Pci(0x0,0x0)/NVMe(0x1,00-25-38-B3-21-C6-70-70)
+Boot0002* IPV6 Network - Intel(R) Ethernet Connection (17) I219-LM\tPciRoot(0x0)/Pci(0x1f,0x6)/MAC(5c60babbcf63,0)/IPv6([::])
+Boot0003* IPV4 Network - Intel(R) Ethernet Connection (17) I219-LM\tPciRoot(0x0)/Pci(0x1f,0x6)/MAC(5c60babbcf63,0)/IPv4(0.0.0.0)
+Boot0004* USB\tPciRoot(0x0)/Pci(0x14,0x0)
+Boot0005* redhat\tHD(1,GPT,ad2dec7d-34e4-4de5-8952-29bfea127409)/File(\\EFI\\redhat\\shimx64.efi)
+Boot0006  USB NETWORK BOOT\tPciRoot(0x0)/Pci(0x0,0x0)/IPv4(0.0.0.0,DHCP)
+Boot0007  USB NETWORK BOOT\tPciRoot(0x0)/Pci(0x0,0x0)/IPv6([::])
+"""
+
+SYNTH_FIXTURE = """\
+BootCurrent: 0000
+BootOrder: 0000,0001,0002,0003
+Boot0000* Windows Boot Manager\tHD(1,GPT,abc)/File(\\EFI\\Microsoft\\Boot\\bootmgfw.efi)
+Boot0001* UEFI: SanDisk Cruzer USB\tUSB(0x1)
+Boot0002* UEFI: HL-DT-ST DVD-ROM\tCD/DVD
+Boot0003* UEFI: PXE IPv4 Intel\tMAC(001122334455)/IPv4
+"""
+
+
+class TestParse:
+    def test_headers_and_entries(self):
+        r = efiboot.parse_efibootmgr(REAL_FIXTURE)
+        assert r["current"] == "0005"
+        assert r["timeout"] == 0
+        assert r["order"] == ["0005", "0001", "0004", "0002", "0003", "0006", "0007"]
+        assert set(r["entries"]) == {"0001", "0002", "0003", "0004", "0005", "0006", "0007"}
+        assert r["entries"]["0005"].startswith("redhat")
+
+    def test_active_flag(self):
+        r = efiboot.parse_efibootmgr(REAL_FIXTURE)
+        assert r["active"]["0005"] is True     # Boot0005*
+        assert r["active"]["0006"] is False    # Boot0006 (no star)
+
+    def test_empty_output(self):
+        r = efiboot.parse_efibootmgr("")
+        assert r == {"current": None, "order": [], "timeout": None, "entries": {}, "active": {}}
+
+
+class TestMatchReal:
+    @pytest.fixture()
+    def entries(self):
+        return efiboot.parse_efibootmgr(REAL_FIXTURE)["entries"]
+
+    def test_pxe_prefers_ipv4(self, entries):
+        assert efiboot.match_boot_entry(entries, "pxe") == "0003"  # IPV4 Network, not IPV6
+
+    def test_usb_excludes_usb_network_boot(self, entries):
+        assert efiboot.match_boot_entry(entries, "usb") == "0004"  # "USB", not "USB NETWORK BOOT"
+
+    def test_hdd_prefers_os_loader(self, entries):
+        assert efiboot.match_boot_entry(entries, "hdd") == "0005"  # redhat shim
+
+    def test_cd_absent_returns_none(self, entries):
+        assert efiboot.match_boot_entry(entries, "cd") is None
+
+
+class TestMatchSynth:
+    @pytest.fixture()
+    def entries(self):
+        return efiboot.parse_efibootmgr(SYNTH_FIXTURE)["entries"]
+
+    def test_cd_matches_dvd(self, entries):
+        assert efiboot.match_boot_entry(entries, "cd") == "0002"
+
+    def test_hdd_matches_windows_boot_manager(self, entries):
+        assert efiboot.match_boot_entry(entries, "hdd") == "0000"
+
+    def test_usb_matches_removable(self, entries):
+        assert efiboot.match_boot_entry(entries, "usb") == "0001"
+
+    def test_pxe_matches(self, entries):
+        assert efiboot.match_boot_entry(entries, "pxe") == "0003"
+
+
+class TestMisc:
+    def test_unknown_device_raises(self):
+        with pytest.raises(ValueError):
+            efiboot.match_boot_entry({}, "floppy")
+
+    def test_set_boot_next_command(self):
+        assert efiboot.set_boot_next_command("0003") == "efibootmgr -n 0003"
+
+    def test_set_boot_next_command_normalizes_and_validates(self):
+        assert efiboot.set_boot_next_command("00a3") == "efibootmgr -n 00A3"
+        for bad in ("", "5", "zzzz", "00000"):
+            with pytest.raises(ValueError):
+                efiboot.set_boot_next_command(bad)

--- a/tests/test_fake_driver.py
+++ b/tests/test_fake_driver.py
@@ -23,6 +23,7 @@ def test_capabilities_match_pikvm_plus_boot_progress():
         Capability.EVENTS,
         Capability.LOGS,
         Capability.BOOT_PROGRESS,  # FakeDriver is the first BootProgress implementer
+        Capability.BOOT_CONFIG,
     }
     assert caps == expected
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -55,6 +55,7 @@ EXPECTED_ANNOTATIONS = {
     "appliance_status": READ,
     "access_paths": READ,
     "power": DESTRUCTIVE,
+    "wake": DESTRUCTIVE,
     "set_boot_device": DESTRUCTIVE,
     "type_text": DESTRUCTIVE,
     "press_key": DESTRUCTIVE,
@@ -1444,3 +1445,43 @@ def test_boot_options_is_read_only(config_file):
     result = run_session(server_env(config_file), interact)
     assert result.isError is False
     assert '"enabled": "Disabled"' in result.content[0].text
+
+
+# -- wake / Wake-on-LAN (#199) — power gate + confirm + dry-run ---------------
+
+def test_wake_errors_without_power_gate(config_file):
+    async def interact(session):
+        return await session.call_tool("wake", {"mac": "aa:bb:cc:dd:ee:ff", "confirm": True})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is True
+    assert "operator" in result.content[0].text
+
+
+def test_wake_requires_confirm(config_file):
+    async def interact(session):
+        return await session.call_tool("wake", {"mac": "aa:bb:cc:dd:ee:ff"})
+
+    result = run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1"), interact)
+    assert result.isError is True
+    assert "not confirmed" in result.content[0].text
+
+
+def test_wake_requires_mac(config_file):
+    async def interact(session):
+        return await session.call_tool("wake", {"confirm": True})
+
+    result = run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1"), interact)
+    assert result.isError is True
+    assert "no MAC" in result.content[0].text
+
+
+def test_wake_dry_run_reports_without_sending(config_file):
+    async def interact(session):
+        return await session.call_tool("wake", {"mac": "aa:bb:cc:dd:ee:ff", "confirm": True})
+
+    env = server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1", KVM_PILOT_MCP_DRY_RUN="1")
+    result = run_session(env, interact)
+    assert result.isError is False
+    text = result.content[0].text
+    assert '"dry_run": true' in text and "aa:bb:cc:dd:ee:ff" in text

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -44,6 +44,7 @@ EXPECTED_ANNOTATIONS = {
     "capabilities": READ,
     "support_matrix": READ,
     "power_state": READ,
+    "boot_options": READ,
     "logs": READ,
     "snapshot": READ,
     "classify_screen": READ_VISION,
@@ -54,6 +55,7 @@ EXPECTED_ANNOTATIONS = {
     "appliance_status": READ,
     "access_paths": READ,
     "power": DESTRUCTIVE,
+    "set_boot_device": DESTRUCTIVE,
     "type_text": DESTRUCTIVE,
     "press_key": DESTRUCTIVE,
     "send_shortcut": DESTRUCTIVE,
@@ -1399,3 +1401,46 @@ def test_act_result_carries_receipt_and_real_expiry(config_file):
     assert parsed["approved"] is True
     assert parsed["receipt"]["state"] == "consumed"
     assert parsed["approval"]["expires"] is not None
+
+
+# -- boot-device (BootSourceOverride, #201) — effect gate + confirm + execute --
+
+def test_set_boot_device_errors_without_config_gate(config_file):
+    async def interact(session):
+        return await session.call_tool("set_boot_device", {"device": "pxe", "confirm": True})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is True
+    text = result.content[0].text
+    assert "operator" in text
+    assert "KVM_PILOT_MCP_ALLOW_CONFIG" not in text  # no copy-pasteable incantation
+
+
+def test_set_boot_device_requires_confirm(config_file):
+    async def interact(session):
+        return await session.call_tool("set_boot_device", {"device": "pxe"})
+
+    env = server_env(config_file, KVM_PILOT_MCP_ALLOW_CONFIG="1")
+    result = run_session(env, interact)
+    assert result.isError is True
+    assert "not confirmed" in result.content[0].text
+
+
+def test_set_boot_device_executes_on_fake(config_file):
+    async def interact(session):
+        return await session.call_tool("set_boot_device", {"device": "pxe", "confirm": True})
+
+    env = server_env(config_file, KVM_PILOT_MCP_ALLOW_CONFIG="1")
+    result = run_session(env, interact)
+    assert result.isError is False
+    text = result.content[0].text
+    assert '"target": "pxe"' in text and '"enabled": "Once"' in text
+
+
+def test_boot_options_is_read_only(config_file):
+    async def interact(session):
+        return await session.call_tool("boot_options", {})
+
+    result = run_session(server_env(config_file), interact)
+    assert result.isError is False
+    assert '"enabled": "Disabled"' in result.content[0].text

--- a/tests/test_redfish_boot.py
+++ b/tests/test_redfish_boot.py
@@ -1,0 +1,165 @@
+"""RedfishDriver boot-device control (BootSourceOverride) — #28/#201.
+
+Exercised over the real transport against the fake BMC (redfish_emulator), incl.
+iLO4/iDRAC7-era quirks: no BootSourceOverrideMode field, a BMC that rejects the
+mode property, async (202) PATCH, and restricted AllowableValues.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kvm_pilot.drivers import RedfishDriver
+from kvm_pilot.drivers.base import BootConfig, Capability
+from kvm_pilot.errors import CapabilityError, KVMPilotError, SafetyError
+from kvm_pilot.safety import deny_all
+from redfish_emulator import SYS
+
+
+def make(emu, **kw) -> RedfishDriver:
+    return RedfishDriver("127.0.0.1", "admin", "secret", port=emu.port, scheme="http", **kw)
+
+
+def _boot_patches(emu) -> list[dict]:
+    return [body["Boot"] for path, body in emu.state.patches if path == SYS and "Boot" in body]
+
+
+# -- capability + protocol -------------------------------------------------
+
+def test_driver_satisfies_boot_config_capability(emu):
+    d = make(emu)
+    assert isinstance(d, BootConfig)
+    assert Capability.BOOT_CONFIG in d.capabilities()
+
+
+# -- reporting -------------------------------------------------------------
+
+def test_get_boot_options_default_disabled(emu):
+    opts = make(emu).get_boot_options()
+    assert opts["enabled"] == "Disabled"
+    assert opts["once"] is False and opts["persistent"] is False
+    assert opts["target"] == "none"
+    assert opts["mode"] == "UEFI"
+    assert opts["mode_settable"] is True
+    # normalized allowable, sorted
+    assert opts["allowable"] == sorted(["none", "pxe", "cd", "hdd", "usb", "bios", "diag"])
+
+
+# -- set: one-time / persistent / clear -----------------------------------
+
+def test_set_pxe_once_patches_and_reports(emu):
+    opts = make(emu).set_boot_device("pxe", once=True)
+    patch = _boot_patches(emu)[-1]
+    assert patch == {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideMode": "UEFI",
+    }
+    assert emu.state.boot_override_enabled == "Once"
+    assert emu.state.boot_override_target == "Pxe"
+    assert opts["once"] is True and opts["target"] == "pxe"
+
+
+def test_set_cd_persistent(emu):
+    make(emu).set_boot_device("cd", once=False)
+    patch = _boot_patches(emu)[-1]
+    assert patch["BootSourceOverrideEnabled"] == "Continuous"
+    assert patch["BootSourceOverrideTarget"] == "Cd"
+    assert emu.state.boot_override_enabled == "Continuous"
+
+
+def test_set_none_clears_override(emu):
+    emu.state.boot_override_enabled = "Once"
+    emu.state.boot_override_target = "Pxe"
+    make(emu).set_boot_device("none")
+    patch = _boot_patches(emu)[-1]
+    assert patch["BootSourceOverrideEnabled"] == "Disabled"
+    assert patch["BootSourceOverrideTarget"] == "None"
+    # clearing never sends a mode
+    assert "BootSourceOverrideMode" not in patch
+    assert emu.state.boot_override_enabled == "Disabled"
+
+
+def test_legacy_mode(emu):
+    make(emu).set_boot_device("hdd", uefi=False)
+    assert _boot_patches(emu)[-1]["BootSourceOverrideMode"] == "Legacy"
+    assert emu.state.boot_override_mode == "Legacy"
+
+
+@pytest.mark.parametrize(
+    "token,expected",
+    [("dvd", "Cd"), ("disk", "Hdd"), ("setup", "BiosSetup"), ("BIOS", "BiosSetup"),
+     ("Pxe", "Pxe"), ("diag", "Diags")],
+)
+def test_device_token_aliases(emu, token, expected):
+    make(emu).set_boot_device(token)
+    assert _boot_patches(emu)[-1]["BootSourceOverrideTarget"] == expected
+
+
+# -- validation ------------------------------------------------------------
+
+def test_unknown_device_raises(emu):
+    with pytest.raises(KVMPilotError):
+        make(emu).set_boot_device("floppy")
+    assert _boot_patches(emu) == []  # never PATCHed
+
+
+def test_target_not_in_allowable_raises_capability_error(emu):
+    # A restricted BMC (no PXE) must fail fast, not send an opaque 400.
+    emu.state.boot_allowable = ["None", "Hdd", "BiosSetup"]
+    with pytest.raises(CapabilityError):
+        make(emu).set_boot_device("pxe")
+    assert _boot_patches(emu) == []
+
+
+# -- safety gating ---------------------------------------------------------
+
+def test_dry_run_does_not_patch(emu):
+    opts = make(emu, dry_run=True).set_boot_device("pxe")
+    assert _boot_patches(emu) == []            # gated, no write
+    assert emu.state.boot_override_enabled == "Disabled"
+    assert opts["target"] == "none"            # reports unchanged state
+
+
+def test_denied_confirm_raises_and_does_not_patch(emu):
+    with pytest.raises(SafetyError):
+        make(emu, confirm=deny_all).set_boot_device("pxe")
+    assert _boot_patches(emu) == []
+
+
+# -- iLO4 / iDRAC7 quirks --------------------------------------------------
+
+def test_no_mode_field_omits_mode(emu):
+    # Older iLO4/iDRAC7: ComputerSystem.Boot has no BootSourceOverrideMode.
+    emu.state.boot_expose_mode = False
+    opts = make(emu).set_boot_device("pxe")
+    patch = _boot_patches(emu)[-1]
+    assert "BootSourceOverrideMode" not in patch      # never sent
+    assert patch["BootSourceOverrideTarget"] == "Pxe"
+    assert opts["mode_settable"] is False
+
+
+def test_mode_rejected_retries_without_mode(emu):
+    # A BMC that 400s a PATCH containing BootSourceOverrideMode: the driver must
+    # retry once without it and still apply the target.
+    emu.state.boot_patch_rejects_mode = True
+    make(emu).set_boot_device("cd")
+    patches = _boot_patches(emu)
+    assert len(patches) == 2                          # first with mode, retry without
+    assert "BootSourceOverrideMode" in patches[0]
+    assert "BootSourceOverrideMode" not in patches[1]
+    assert emu.state.boot_override_target == "Cd"     # applied on retry
+
+
+def test_async_patch_is_awaited(emu):
+    # BMC returns 202 + Task for the PATCH; driver polls it to completion.
+    emu.state.boot_patch_status = 202
+    make(emu).set_boot_device("usb")
+    assert emu.state.boot_override_target == "Usb"
+    assert ("GET", "/redfish/v1/TaskService/Tasks/1") in emu.state.calls
+
+
+def test_restricted_allowable_reported_normalized(emu):
+    emu.state.boot_allowable = ["None", "Pxe", "Hdd"]
+    opts = make(emu).get_boot_options()
+    assert opts["allowable"] == ["hdd", "none", "pxe"]

--- a/tests/test_redfish_driver.py
+++ b/tests/test_redfish_driver.py
@@ -41,6 +41,7 @@ def test_capabilities_are_the_bmc_complementary_set(emu):
     assert caps == {
         Capability.SYSTEM_INFO, Capability.POWER, Capability.BOOT_PROGRESS,
         Capability.SENSORS, Capability.LOGS, Capability.VIRTUAL_MEDIA,
+        Capability.BOOT_CONFIG,
     }
     # A BMC has no keyboard/mouse/screenshot/relay — these must be absent.
     for absent in (Capability.HID, Capability.VIDEO, Capability.GPIO,

--- a/tests/test_wol.py
+++ b/tests/test_wol.py
@@ -1,0 +1,151 @@
+"""Tests for Wake-on-LAN (#199).
+
+Packet construction and ethtool parsing are pure/unit-tested; the single socket
+call is exercised with a fake socket. The ethtool fixture is real output
+captured from the .20 homelab host's wired NIC (eno1, Intel I219-LM).
+"""
+
+import socket
+
+import pytest
+
+from kvm_pilot import wol
+
+MAC = "5c:60:ba:bb:cf:63"          # real .20-host wired NIC
+MAC_RAW = bytes.fromhex("5c60babbcf63")
+
+
+class TestNormalizeMac:
+    def test_colon_form(self):
+        assert wol.normalize_mac(MAC) == MAC_RAW
+
+    def test_dash_bare_dot_forms_all_equal(self):
+        assert wol.normalize_mac("5C-60-BA-BB-CF-63") == MAC_RAW
+        assert wol.normalize_mac("5c60babbcf63") == MAC_RAW
+        assert wol.normalize_mac("5c60.babb.cf63") == MAC_RAW  # Cisco dotted
+
+    def test_case_and_whitespace_insensitive(self):
+        assert wol.normalize_mac("  5C:60:BA:BB:CF:63 ") == MAC_RAW
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "5c:60:ba:bb:cf", "5c:60:ba:bb:cf:63:00", "zz:60:ba:bb:cf:63", "notamac"],
+    )
+    def test_invalid_raises(self, bad):
+        with pytest.raises(ValueError):
+            wol.normalize_mac(bad)
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError):
+            wol.normalize_mac(b"\x5c\x60\xba\xbb\xcf\x63")  # type: ignore[arg-type]
+
+
+class TestMagicPacket:
+    def test_length_prefix_and_repeat(self):
+        pkt = wol.build_magic_packet(MAC)
+        assert len(pkt) == 102
+        assert pkt[:6] == b"\xff" * 6
+        body = pkt[6:]
+        assert body == MAC_RAW * 16
+        # every 6-byte block after the prefix is the MAC
+        assert all(body[i : i + 6] == MAC_RAW for i in range(0, 96, 6))
+
+
+class _FakeSock:
+    def __init__(self, log):
+        self._log = log
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def setsockopt(self, level, opt, val):
+        self._log.append(("opt", level, opt, val))
+
+    def bind(self, addr):
+        self._log.append(("bind", addr))
+
+    def sendto(self, data, addr):
+        self._log.append(("sendto", data, addr))
+
+
+class TestSend:
+    def test_broadcasts_packet_count_times(self, monkeypatch):
+        log: list = []
+        monkeypatch.setattr(wol.socket, "socket", lambda *a, **k: _FakeSock(log))
+        pkt = wol.send_magic_packet(MAC, broadcast="10.0.1.255", port=9, count=2)
+        sends = [e for e in log if e[0] == "sendto"]
+        assert len(sends) == 2
+        assert sends[0][1] == pkt
+        assert sends[0][2] == ("10.0.1.255", 9)
+
+    def test_enables_so_broadcast(self, monkeypatch):
+        log: list = []
+        monkeypatch.setattr(wol.socket, "socket", lambda *a, **k: _FakeSock(log))
+        wol.send_magic_packet(MAC)
+        assert any(
+            e[0] == "opt" and e[2] == socket.SO_BROADCAST and e[3] == 1 for e in log
+        )
+
+    def test_binds_interface_ip_when_given(self, monkeypatch):
+        log: list = []
+        monkeypatch.setattr(wol.socket, "socket", lambda *a, **k: _FakeSock(log))
+        wol.send_magic_packet(MAC, interface_ip="10.0.1.50")
+        assert ("bind", ("10.0.1.50", 0)) in log
+
+    def test_no_bind_without_interface_ip(self, monkeypatch):
+        log: list = []
+        monkeypatch.setattr(wol.socket, "socket", lambda *a, **k: _FakeSock(log))
+        wol.send_magic_packet(MAC)
+        assert not any(e[0] == "bind" for e in log)
+
+    def test_invalid_count_raises(self):
+        with pytest.raises(ValueError):
+            wol.send_magic_packet(MAC, count=0)
+
+    def test_bad_mac_raises_before_socket(self, monkeypatch):
+        # A malformed MAC must fail without ever opening a socket.
+        monkeypatch.setattr(
+            wol.socket, "socket", lambda *a, **k: pytest.fail("socket opened")
+        )
+        with pytest.raises(ValueError):
+            wol.send_magic_packet("nope")
+
+
+class TestParseEthtoolWol:
+    # Real capture from the .20 host wired NIC (eno1) during the SNO build-out.
+    REAL_FIXTURE = (
+        "Settings for eno1:\n"
+        "\tSupported ports: [ TP ]\n"
+        "\tSupports Wake-on: pumbg\n"
+        "\tWake-on: g\n"
+        "\tLink detected: no\n"
+    )
+
+    def test_real_fixture_magic_supported_and_enabled(self):
+        r = wol.parse_ethtool_wol(self.REAL_FIXTURE)
+        assert r["supported"] == "pumbg"
+        assert r["current"] == "g"
+        assert r["supports_magic"] is True
+        assert r["magic_enabled"] is True
+
+    def test_disabled_state(self):
+        r = wol.parse_ethtool_wol("\tSupports Wake-on: pumbg\n\tWake-on: d\n")
+        assert r["supports_magic"] is True
+        assert r["magic_enabled"] is False
+
+    def test_no_wol_support(self):
+        r = wol.parse_ethtool_wol("\tSupports Wake-on: d\n\tWake-on: d\n")
+        assert r["supports_magic"] is False
+        assert r["magic_enabled"] is False
+
+    def test_empty_output(self):
+        r = wol.parse_ethtool_wol("")
+        assert r == {
+            "supported": "",
+            "current": "",
+            "supports_magic": False,
+            "magic_enabled": False,
+        }


### PR DESCRIPTION
Builds out the top interface-economics enhancements from the SNO build-out report (epic #200). All TDD; WoL hardware-validated.

## What's in it
- **WoL (#199):** `wol.py` (magic-packet + ethtool parser) — **woke a real host in 52s**; `HostConfig.mac`/`wol_broadcast`; `kvm-pilot wake` CLI + MCP `wake` tool (gated `wol.wake`/POWER_SOFT).
- **Redfish boot-device (#28/#201):** new `BOOT_CONFIG` capability + `BootConfig` protocol; `RedfishDriver.get_boot_options`/`set_boot_device` (BootSourceOverride, one-time/persistent, UEFI/legacy, feature-detect + auto-retry without mode for iLO4/iDRAC7); `boot-device` CLI + `boot_options`/`set_boot_device` MCP tools; fake driver BootConfig.
- **efibootmgr BootNext over SSH (#150):** `efiboot.py` parser + device matcher; `boot-device --via {auto,redfish,ssh}` with a single-gate design (`ssh.set_boot_next`).
- **Emulator + safety:** redfish_emulator grows a `Boot` object + `do_PATCH` + iLO4/iDRAC7 quirk knobs; `redfish.set_boot_device`/`ssh.set_boot_next`/`wol.wake` added to `DESTRUCTIVE_OPS` + `OP_EFFECT`.
- **Docs:** `docs/hardware-test-plan-ilo-idrac.md` — quick-execute DL380 G9 (iLO4) / R710 (iDRAC6→no-Redfish→IPMI #62) runbook.

## Tests
~65 new tests (wol, redfish boot, efiboot, CLI, MCP, config); full suite + ruff green locally. Real fixtures from the .16 host baked in.

Closes #199 #150. Advances #28 #201 #200. Real-BMC validation to follow on #29 (iLO/iDRAC tonight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)