### PR TITLE
test: close synthetic-testing gaps for boot-control + WoL (#200)

### DIFF
--- a/tests/integration/test_redfish_external.py
+++ b/tests/integration/test_redfish_external.py
@@ -81,3 +81,35 @@ def test_power_transitions_are_reflected_on_get(redfish_emulator_url):
     assert driver.is_powered_on() is True
     driver.power_off_hard()
     assert driver.is_powered_on() is False
+
+
+def test_boot_device_target_round_trips_against_external_reference(redfish_emulator_url):
+    # Independent corroboration our own mock can't give: a real BootSourceOverride
+    # PATCH changes the target, observed via a fresh GET on a DMTF-conformant
+    # service (validates the target write + our normalized<->Redfish mapping).
+    # NOTE: sushy-tools' --fake pins BootSourceOverrideEnabled to "Continuous" (it
+    # does not honor once/disabled), so once-vs-persistent-vs-clear is asserted
+    # against the in-repo emulator + real BMCs, not here.
+    driver = _driver(redfish_emulator_url)
+    for device in ("cd", "hdd", "pxe"):
+        driver.set_boot_device(device)
+        assert driver.get_boot_options()["target"] == device
+
+
+def test_boot_device_rejects_unadvertised_target_against_external(redfish_emulator_url):
+    # Feature-detect against ground truth: sushy advertises [Pxe, Cd, Hdd,
+    # UefiHttp] but NOT Usb, so a usb request must fail fast (CapabilityError),
+    # not send a doomed PATCH the BMC would 400.
+    from kvm_pilot.errors import CapabilityError
+
+    driver = _driver(redfish_emulator_url)
+    assert "usb" not in driver.get_boot_options()["allowable"]
+    with pytest.raises(CapabilityError):
+        driver.set_boot_device("usb")
+
+
+def test_cli_boot_device_show_reports_external_allowable(redfish_emulator_url, capsys):
+    rc = main(_cli(redfish_emulator_url, "boot-device", "--show", "--skip-healthcheck"))
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "pxe" in out["allowable"] and "cd" in out["allowable"]

--- a/tests/redfish_emulator.py
+++ b/tests/redfish_emulator.py
@@ -112,6 +112,12 @@ class RedfishState:
         self.boot_expose_mode = True
         self.boot_patch_rejects_mode = False
         self.boot_patch_status = 200
+        # boot_patch_fail_status: a boot PATCH returns this status for ANY body
+        # (a non-mode failure — 500, or a 400 unrelated to the mode property — so
+        # the driver must NOT swallow it as the mode-retry case). boot_absent: the
+        # ComputerSystem exposes no Boot object at all (a minimal BMC).
+        self.boot_patch_fail_status: int | None = None
+        self.boot_absent = False
         self.patches: list[tuple[str, dict]] = []
 
 
@@ -310,7 +316,7 @@ class _Handler(BaseHTTPRequestHandler):
         }
         if st.boot_expose_mode:
             boot["BootSourceOverrideMode"] = st.boot_override_mode
-        return {
+        doc = {
             "@odata.id": SYS,
             "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
             "Manufacturer": "ACME", "Model": "Server 9000", "SerialNumber": "SN-1",
@@ -327,6 +333,9 @@ class _Handler(BaseHTTPRequestHandler):
             # (Dell shape); the driver must scan both and follow the link.
             "Actions": {"#ComputerSystem.Reset": reset},
         }
+        if st.boot_absent:
+            doc.pop("Boot")
+        return doc
 
     def _chassis(self) -> dict:
         doc = {"@odata.id": CHAS}
@@ -424,6 +433,12 @@ class _Handler(BaseHTTPRequestHandler):
         boot = body.get("Boot")
         if not isinstance(boot, dict):
             self._send({"error": {"message": "unsupported PATCH target"}}, status=400)
+            return
+        if st.boot_patch_fail_status:
+            self._send({"error": {"@Message.ExtendedInfo": [
+                {"MessageId": "Base.1.0.InternalError",
+                 "Message": "the BMC could not apply the boot override"}]}},
+                status=st.boot_patch_fail_status)
             return
         target = boot.get("BootSourceOverrideTarget")
         if target is not None and target not in st.boot_allowable:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -884,7 +884,7 @@ _EFI_FIXTURE = (
 )
 
 
-def _patch_ssh(monkeypatch, calls, *, read_stdout=_EFI_FIXTURE, set_ok=True):
+def _patch_ssh(monkeypatch, calls, *, read_stdout=_EFI_FIXTURE, read_ok=True, set_ok=True):
     from kvm_pilot import ssh as ssh_mod
 
     class FakeCh:
@@ -894,10 +894,12 @@ def _patch_ssh(monkeypatch, calls, *, read_stdout=_EFI_FIXTURE, set_ok=True):
             calls.append(command)
             if "efibootmgr -n" in command:
                 return {"command": command, "returncode": 0 if set_ok else 1,
-                        "stdout": "", "stderr": "" if set_ok else "denied",
+                        "stdout": "", "stderr": "" if set_ok else "Operation not permitted",
                         "ok": set_ok, "dry_run": False}
-            return {"command": command, "returncode": 0, "stdout": read_stdout,
-                    "stderr": "", "ok": True, "dry_run": False}
+            return {"command": command, "returncode": 0 if read_ok else 1,
+                    "stdout": read_stdout if read_ok else "",
+                    "stderr": "" if read_ok else "EFI variables are not supported",
+                    "ok": read_ok, "dry_run": False}
 
     monkeypatch.setattr(ssh_mod.SSHChannel, "from_config", lambda cfg, **kw: FakeCh())
 
@@ -945,3 +947,35 @@ def test_boot_device_via_ssh_persistent_unsupported(monkeypatch, capsys):
                "--host", "10.0.1.16", "--yes"])
     assert rc == 2
     assert "persistent" in capsys.readouterr().err.lower()
+
+
+def test_boot_device_via_ssh_read_failure(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls, read_ok=False)
+    rc = main(["boot-device", "pxe", "--via", "ssh", "--host", "10.0.1.16", "--yes"])
+    assert rc == 1
+    assert not any("efibootmgr -n" in c for c in calls)  # never reached the set
+    assert "efibootmgr read failed" in capsys.readouterr().err
+
+
+def test_boot_device_via_ssh_set_failure(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls, set_ok=False)
+    rc = main(["boot-device", "hdd", "--via", "ssh", "--host", "10.0.1.16", "--yes"])
+    assert rc == 1
+    assert any("efibootmgr -n 0005" in c for c in calls)  # attempted the set
+    assert "set BootNext failed" in capsys.readouterr().err
+
+
+def test_boot_device_via_ssh_bios_unsupported(monkeypatch, capsys):
+    calls: list = []
+    _patch_ssh(monkeypatch, calls)
+    rc = main(["boot-device", "bios", "--via", "ssh", "--host", "10.0.1.16", "--yes"])
+    assert rc == 2  # bios/diag/none aren't efibootmgr device tokens
+    assert not any("efibootmgr -n" in c for c in calls)
+
+
+def test_wake_rejects_bad_mac(capsys):
+    rc = main(["wake", "--mac", "not-a-mac", "--host", "fake", "--yes"])
+    assert rc == 2
+    assert "invalid MAC" in capsys.readouterr().err

--- a/tests/test_redfish_boot.py
+++ b/tests/test_redfish_boot.py
@@ -163,3 +163,38 @@ def test_restricted_allowable_reported_normalized(emu):
     emu.state.boot_allowable = ["None", "Pxe", "Hdd"]
     opts = make(emu).get_boot_options()
     assert opts["allowable"] == ["hdd", "none", "pxe"]
+
+
+# -- error / edge paths ----------------------------------------------------
+
+def test_set_boot_device_async_task_failure_raises(emu):
+    emu.state.boot_patch_status = 202
+    emu.state.task_state = "Exception"          # a failed terminal TaskState
+    with pytest.raises(KVMPilotError):
+        make(emu).set_boot_device("pxe")
+
+
+def test_set_boot_device_non_mode_patch_failure_propagates(emu):
+    # A 500 (or any failure that is NOT the mode-property 400) must propagate,
+    # never be swallowed as the mode-retry case.
+    emu.state.boot_patch_fail_status = 500
+    with pytest.raises(KVMPilotError):
+        make(emu).set_boot_device("cd")
+
+
+def test_set_boot_device_survives_session_expiry(emu):
+    # BMC drops the session mid-flow (DSP0266 idle timeout); the transport
+    # re-authenticates once and the override still applies.
+    emu.state.expire_token_once = True
+    make(emu).set_boot_device("hdd")
+    assert emu.state.boot_override_target == "Hdd"
+
+
+def test_get_boot_options_when_no_boot_object(emu):
+    # A minimal BMC exposing no ComputerSystem.Boot: sane defaults, no mode.
+    emu.state.boot_absent = True
+    opts = make(emu).get_boot_options()
+    assert opts["enabled"] == "Disabled"
+    assert opts["target"] == "none"
+    assert opts["mode_settable"] is False
+    assert opts["allowable"] == []


### PR DESCRIPTION
Follow-up to #203 — closes the remaining simulator-testing gaps before the iLO/iDRAC hardware run (#29).

- **sushy-tools (independent Redfish):** boot-device target round-trip + allowable feature-detect (usb rejected) + CLI `--show`. The cross-check surfaced a real quirk — sushy `--fake` pins `BootSourceOverrideEnabled` to `Continuous` — documented in the test; our once/persistent/clear path stays covered by the in-repo emulator + real BMCs.
- **Redfish error paths** (new emulator knobs `boot_patch_fail_status`, `boot_absent`): async-Task failure raises; a non-mode PATCH 500 propagates (not swallowed as the mode-retry); survives mid-flow session expiry; `get_boot_options` defaults cleanly with no `Boot` object.
- **efibootmgr `--via ssh` failures:** read-fail → exit 1, set-fail → exit 1, bios/diag (non-efibootmgr tokens) → exit 2.
- **wake:** malformed MAC → exit 2.

11 new tests; ruff + mypy clean; full suite (incl. the sushy integration job) green.

Refs #200 #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)