### PR TITLE
power on: Wake-on-LAN fallback when ATX isn't wired (#199)

### DIFF
--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -438,8 +438,33 @@ def _boot_device_via_ssh(args) -> int:
 
 def cmd_power(args) -> int:
     kvm = _client(args, Capability.POWER)
+    if args.action == "on":
+        try:
+            kvm.power_on()
+        except CapabilityError as exc:
+            # No wired ATX/GPIO power path (common on GL units: ATX enabled=false):
+            # fall back to a Wake-on-LAN magic packet if the profile carries the
+            # host's MAC. WoL reaches the NIC directly, bypassing the KVM's
+            # missing power channel — the #199 out-of-band power-on path.
+            cfg = _resolve_cfg(args)
+            if not cfg.mac:
+                raise CapabilityError(
+                    f"{exc} Set 'mac' in the host profile (or run `kvm-pilot wake`) "
+                    "to enable a Wake-on-LAN power-on fallback."
+                ) from exc
+            from . import wol
+            # The power-on was already consented (the driver's atx.power_on gate
+            # passed before it raised), so don't re-prompt — just log the fallback.
+            SafetyPolicy(confirm=allow_all).guard(
+                "wol.wake", f"WoL power-on fallback -> {cfg.mac} on {cfg.host}")
+            wol.send_magic_packet(cfg.mac, broadcast=cfg.wol_broadcast, count=3)
+            print(f"power on: ATX unavailable on {cfg.host}; sent Wake-on-LAN to "
+                  f"{cfg.mac} (broadcast {cfg.wol_broadcast}) as the out-of-band "
+                  "power-on path")
+            return 0
+        print("power on: requested")
+        return 0
     action = {
-        "on": kvm.power_on,
         "off": kvm.power_off,
         "off-hard": kvm.power_off_hard,
         "reset": kvm.reset_hard,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -979,3 +979,59 @@ def test_wake_rejects_bad_mac(capsys):
     rc = main(["wake", "--mac", "not-a-mac", "--host", "fake", "--yes"])
     assert rc == 2
     assert "invalid MAC" in capsys.readouterr().err
+
+
+# -- power on -> Wake-on-LAN fallback when ATX isn't wired (#199) ------------
+
+def _fake_power_on_raises_no_atx(self, wait=True):
+    from kvm_pilot.errors import CapabilityError
+    raise CapabilityError("Power control is unavailable: ATX reports enabled=false")
+
+
+def test_power_on_falls_back_to_wol_when_atx_unavailable(monkeypatch, capsys):
+    from kvm_pilot import wol as wol_mod
+    from kvm_pilot.drivers.fake import FakeDriver
+    monkeypatch.setattr(FakeDriver, "power_on", _fake_power_on_raises_no_atx)
+    monkeypatch.setenv("KVM_PILOT_MAC", "5c:60:ba:bb:cf:63")
+    sent = {}
+    monkeypatch.setattr(wol_mod, "send_magic_packet",
+                        lambda mac, **kw: sent.update(mac=mac, **kw) or b"")
+    rc = main(["power", "on", "--driver", "fake", "--yes"])
+    assert rc == 0
+    assert sent["mac"] == "5c:60:ba:bb:cf:63"
+    assert "Wake-on-LAN" in capsys.readouterr().out
+
+
+def test_power_on_no_atx_no_mac_raises_with_hint(monkeypatch, capsys):
+    from kvm_pilot import wol as wol_mod
+    from kvm_pilot.drivers.fake import FakeDriver
+    monkeypatch.setattr(FakeDriver, "power_on", _fake_power_on_raises_no_atx)
+    monkeypatch.delenv("KVM_PILOT_MAC", raising=False)
+    called = []
+    monkeypatch.setattr(wol_mod, "send_magic_packet", lambda *a, **k: called.append(1))
+    rc = main(["power", "on", "--driver", "fake", "--yes"])
+    assert rc == 1                        # CapabilityError -> exit 1
+    assert called == []                   # no WoL without a MAC
+    assert "Wake-on-LAN" in capsys.readouterr().err  # the actionable hint
+
+
+def test_power_on_no_fallback_when_atx_works(monkeypatch):
+    from kvm_pilot import wol as wol_mod
+    called = []
+    monkeypatch.setattr(wol_mod, "send_magic_packet", lambda *a, **k: called.append(1))
+    monkeypatch.setenv("KVM_PILOT_MAC", "5c:60:ba:bb:cf:63")
+    rc = main(["power", "on", "--driver", "fake", "--yes"])  # fake power_on succeeds
+    assert rc == 0
+    assert called == []                   # fallback only fires on CapabilityError
+
+
+def test_power_off_never_falls_back_to_wol(monkeypatch):
+    # WoL can only power ON — off/reset must not trigger the fallback even if
+    # power_off were to raise.
+    from kvm_pilot import wol as wol_mod
+    called = []
+    monkeypatch.setattr(wol_mod, "send_magic_packet", lambda *a, **k: called.append(1))
+    monkeypatch.setenv("KVM_PILOT_MAC", "5c:60:ba:bb:cf:63")
+    rc = main(["power", "off", "--driver", "fake", "--yes"])
+    assert rc == 0
+    assert called == []


### PR DESCRIPTION
Feature 2 from the #200 build-out review. On a KVM with no wired ATX/GPIO power path (GL units report `ATX enabled=false`), the driver's `power_on()` raises `CapabilityError`. `kvm-pilot power on` now catches that and, if the host profile carries a `mac`, sends a Wake-on-LAN magic packet as the out-of-band power-on path (WoL reaches the NIC directly, bypassing the missing power channel).

- No `mac` configured → the error gains an actionable hint (set `mac`, or use `kvm-pilot wake`).
- Only `on` falls back — WoL can't power off/reset.
- The power-on was already consented (the driver's `atx.power_on` gate passed before it raised), so the fallback logs `wol.wake` without re-prompting.

Builds on the shipped `wake` command + `wol.py` core (hardware-validated). 4 new tests; ruff + mypy + full suite green.

Refs #199 #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)