### PR TITLE
feat: IPMI driver (ipmitool) for pre-Redfish BMCs (#62)

### DIFF
--- a/src/kvm_pilot/cli.py
+++ b/src/kvm_pilot/cli.py
@@ -51,11 +51,19 @@ if TYPE_CHECKING:
     # capability-partial (a BMC — strong on structured state, but no keyboard or
     # screen), so capability-specific subcommands gate on supports() before
     # dispatch instead of AttributeError-ing deep in a handler.
-    from .drivers.base import BootConfig, BootProgress, FirmwareUpdate, Logs, Sensors
+    from .drivers.base import (
+        BootConfig,
+        BootProgress,
+        FirmwareUpdate,
+        Logs,
+        Sensors,
+        VirtualMedia,
+    )
     from .drivers.fake import FakeDriver
+    from .drivers.ipmi import IpmiDriver
     from .drivers.redfish import RedfishDriver
 
-    AnyDriver = KVMClient | FakeDriver | RedfishDriver
+    AnyDriver = KVMClient | FakeDriver | RedfishDriver | IpmiDriver
     RichDriver = KVMClient | FakeDriver
 
 
@@ -568,7 +576,7 @@ def cmd_media_list(args) -> int:
 
 
 def cmd_mount(args) -> int:
-    kvm = _client(args, Capability.VIRTUAL_MEDIA)
+    kvm = cast("VirtualMedia", _client(args, Capability.VIRTUAL_MEDIA))
     name = kvm.mount_iso(args.source, image_name=args.name, cdrom=not args.usb)
     print(f"mounted: {name}")
     return 0
@@ -576,7 +584,7 @@ def cmd_mount(args) -> int:
 
 def cmd_eject(args) -> int:
     # The inverse of mount: without it, detaching an ISO required writing Python.
-    kvm = _client(args, Capability.VIRTUAL_MEDIA)
+    kvm = cast("VirtualMedia", _client(args, Capability.VIRTUAL_MEDIA))
     kvm.msd_disconnect()
     print("ejected: virtual media detached")
     return 0
@@ -1218,7 +1226,7 @@ def cmd_events(args) -> int:
 # -- parser ----------------------------------------------------------------
 
 def _add_common(p: argparse.ArgumentParser) -> None:
-    p.add_argument("--driver", choices=["pikvm", "glkvm", "blikvm", "redfish", "fake"],
+    p.add_argument("--driver", choices=["pikvm", "glkvm", "blikvm", "redfish", "ipmi", "fake"],
                    help="Device driver (overrides KVM_PILOT_DRIVER / config profile; "
                         "default pikvm; 'glkvm' = GL.iNet GLKVM fork, 'redfish' = a DMTF "
                         "Redfish BMC (no HID/Video — capability-partial), 'fake' = no hardware)")

--- a/src/kvm_pilot/config.py
+++ b/src/kvm_pilot/config.py
@@ -99,6 +99,13 @@ class HostConfig:
     mac: str | None = None
     wol_broadcast: str = "255.255.255.255"
 
+    # IPMI (ipmi driver) — the BMC's IPMI transport. host/user/passwd are shared
+    # with the other BMC drivers. ipmi_cipher pins the RAKP cipher suite (some
+    # BMCs need 3 or 17); omit to let ipmitool negotiate.
+    ipmi_interface: str = "lanplus"
+    ipmi_port: int = 623
+    ipmi_cipher: int | None = None
+
 
 def _load_file(path: Path) -> dict[str, Any]:
     if not path.exists():
@@ -136,6 +143,15 @@ def _warn_if_secrets_world_readable(path: Path, data: dict[str, Any]) -> None:
         )
 
 
+def _opt_int(value: object) -> int | None:
+    """Coerce an optional int-ish value (int, numeric str from env, or None)."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        return int(value)
+    return None
+
+
 def resolve_host(
     profile: str | None = None,
     *,
@@ -161,6 +177,9 @@ def resolve_host(
     appliance_ssh_key: str | None = None,
     mac: str | None = None,
     wol_broadcast: str | None = None,
+    ipmi_interface: str | None = None,
+    ipmi_port: int | None = None,
+    ipmi_cipher: int | None = None,
     config_path: Path | None = None,
 ) -> HostConfig:
     """Resolve a HostConfig from args > env > file (in that priority)."""
@@ -247,6 +266,10 @@ def resolve_host(
         mac=pick("mac", mac, "KVM_PILOT_MAC"),
         wol_broadcast=pick(
             "wol_broadcast", wol_broadcast, "KVM_PILOT_WOL_BROADCAST", "255.255.255.255"),
+        ipmi_interface=pick(
+            "ipmi_interface", ipmi_interface, "KVM_PILOT_IPMI_INTERFACE", "lanplus"),
+        ipmi_port=int(pick("ipmi_port", ipmi_port, "KVM_PILOT_IPMI_PORT", 623)),
+        ipmi_cipher=_opt_int(pick("ipmi_cipher", ipmi_cipher, "KVM_PILOT_IPMI_CIPHER")),
     )
 
 

--- a/src/kvm_pilot/drivers/__init__.py
+++ b/src/kvm_pilot/drivers/__init__.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from ..config import HostConfig
     from .fake import FakeDriver
     from .glkvm import GLKVMDriver
+    from .ipmi import IpmiDriver
     from .pikvm import BliKVMDriver
     from .redfish import RedfishDriver
 
@@ -79,6 +80,12 @@ def _make_redfish(**conf: object) -> KVMDriver:
     return RedfishDriver(**conf)  # type: ignore[arg-type]
 
 
+def _make_ipmi(**conf: object) -> KVMDriver:
+    from .ipmi import IpmiDriver
+
+    return IpmiDriver(**conf)  # type: ignore[arg-type]
+
+
 _DRIVER_FACTORIES: dict[str, Callable[..., KVMDriver]] = {
     # PiKVM-family: one base (PiKVMDriver) with thin GLKVM/BliKVM subclasses for
     # the API-compatible forks.
@@ -87,6 +94,8 @@ _DRIVER_FACTORIES: dict[str, Callable[..., KVMDriver]] = {
     "blikvm": _make_blikvm,
     # One Redfish driver covers Dell iDRAC, HPE iLO, Supermicro, Lenovo XCC, OpenBMC.
     "redfish": _make_redfish,
+    # IPMI 2.0 for pre-Redfish BMCs (iDRAC6, older iLO) via ipmitool.
+    "ipmi": _make_ipmi,
     "fake": _make_fake,
 }
 
@@ -119,7 +128,7 @@ def make_driver(kind: str = "pikvm", **conf: object) -> KVMDriver:
 
 def make_driver_from_config(
     cfg: HostConfig, *, confirm: Callable[[str, str], bool] | None = None, dry_run: bool = False
-) -> KVMClient | FakeDriver | RedfishDriver:
+) -> KVMClient | FakeDriver | RedfishDriver | IpmiDriver:
     """Build the driver named by ``cfg.driver`` from a resolved ``HostConfig``.
 
     Shared by the CLI and the MCP server so a profile/env that pins
@@ -132,7 +141,7 @@ def make_driver_from_config(
     if kind == "fake":
         from .fake import FakeDriver
 
-        drv: KVMClient | FakeDriver | RedfishDriver = FakeDriver(
+        drv: KVMClient | FakeDriver | RedfishDriver | IpmiDriver = FakeDriver(
             host=cfg.host, confirm=confirm, dry_run=dry_run
         )
     elif kind in ("pikvm", "glkvm", "blikvm"):
@@ -146,10 +155,14 @@ def make_driver_from_config(
         from .redfish import RedfishDriver
 
         drv = RedfishDriver.from_config(cfg, confirm=confirm, dry_run=dry_run)
+    elif kind == "ipmi":
+        from .ipmi import IpmiDriver
+
+        drv = IpmiDriver.from_config(cfg, confirm=confirm, dry_run=dry_run)
     else:
         raise KVMPilotError(
             f"Driver {kind!r} does not support from-config construction here "
-            "(supported: pikvm, glkvm, blikvm, redfish, fake). Build it directly with "
+            "(supported: pikvm, glkvm, blikvm, redfish, ipmi, fake). Build it directly with "
             f"make_driver({kind!r}, ...) from the library."
         )
     # Attach the in-band SSH channel to the managed host's OS when the profile
@@ -190,6 +203,10 @@ def __getattr__(name: str) -> object:
         from .redfish import RedfishDriver
 
         return RedfishDriver
+    if name == "IpmiDriver":
+        from .ipmi import IpmiDriver
+
+        return IpmiDriver
     if name == "GLKVMDriver":
         from .glkvm import GLKVMDriver
 
@@ -224,6 +241,7 @@ __all__ = [
     "register_driver",
     "FakeDriver",
     "RedfishDriver",
+    "IpmiDriver",
     "GLKVMDriver",
     "BliKVMDriver",
 ]

--- a/src/kvm_pilot/drivers/ipmi.py
+++ b/src/kvm_pilot/drivers/ipmi.py
@@ -1,0 +1,269 @@
+"""IPMI 2.0 driver — the universal path for pre-Redfish BMCs (Dell iDRAC6,
+older HPE iLO, Supermicro, generic OpenBMC).
+
+Shells out to ``ipmitool -I lanplus`` (the ubiquitous, battle-tested client)
+rather than reimplementing the RMCP+/RAKP handshake in Python — mirroring how the
+SSH channel shells out to ``ssh``. The password is passed via ``ipmitool -E``
+(read from the ``IPMI_PASSWORD`` environment variable) so it never appears in the
+process argv / ``ps``.
+
+Capabilities: Power (``chassis power``), SystemInfo (``chassis status`` / ``fru`` /
+``mc info``), BootConfig (``chassis bootdev`` / ``bootparam``), Sensors (``sdr``),
+Logs (SEL). SerialConsole (SOL) and Watchdog are deferred (#28/#13). IPMI has no
+video, HID, or virtual media — those need the vendor's own KVM/OEM channel.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404 - fixed argv (no shell), password via env not argv
+from typing import TYPE_CHECKING, Any
+
+from ..errors import CapabilityError, KVMPilotError, TimeoutError
+from ..safety import SafetyPolicy
+from .base import CapabilityMixin, PowerMixin
+
+if TYPE_CHECKING:
+    from ..config import HostConfig
+
+# Normalized boot-device token -> ipmitool `chassis bootdev` selector. IPMI has no
+# USB selector (usb boot is board-specific); reject it with a clear message.
+_BOOTDEV_MAP = {
+    "pxe": "pxe", "hdd": "disk", "disk": "disk", "cd": "cdrom", "dvd": "cdrom",
+    "bios": "bios", "setup": "bios", "diag": "diag", "none": "none",
+}
+# `bootparam get 5` "Boot Device Selector" phrase -> normalized token.
+_BOOT_SELECTOR_REVERSE = [
+    ("no override", "none"),
+    ("pxe", "pxe"),
+    ("hard-drive", "hdd"),
+    ("hard drive", "hdd"),
+    ("cd/dvd", "cd"),
+    ("bios setup", "bios"),
+    ("floppy", "usb"),
+]
+
+
+class IpmiDriver(PowerMixin, CapabilityMixin):
+    """A BMC over IPMI 2.0 via ``ipmitool``."""
+
+    def __init__(
+        self,
+        host: str,
+        user: str = "ADMIN",
+        passwd: str = "",
+        *,
+        port: int = 623,
+        interface: str = "lanplus",
+        cipher: int | None = None,
+        ipmitool: str = "ipmitool",
+        timeout: float = 30.0,
+        dry_run: bool = False,
+        confirm: Any = None,
+    ):
+        self.host = host
+        self._user = user
+        self._passwd = passwd
+        self._port = port
+        self._interface = interface
+        self._cipher = cipher
+        self._ipmitool = ipmitool
+        self._timeout = timeout
+        self.safety = SafetyPolicy(dry_run=dry_run, confirm=confirm)
+
+    @classmethod
+    def from_config(
+        cls, cfg: HostConfig, *, confirm: Any = None, dry_run: bool = False
+    ) -> IpmiDriver:
+        """Build from a resolved :class:`~kvm_pilot.config.HostConfig` (like the
+        Redfish/PiKVM drivers). Uses ``cfg.host``/``user``/``passwd`` and the
+        ``ipmi_*`` fields (interface/port/cipher)."""
+        return cls(
+            cfg.host,
+            cfg.user,
+            cfg.passwd,
+            port=getattr(cfg, "ipmi_port", 623),
+            interface=getattr(cfg, "ipmi_interface", "lanplus"),
+            cipher=getattr(cfg, "ipmi_cipher", None),
+            timeout=cfg.timeout,
+            dry_run=dry_run,
+            confirm=confirm,
+        )
+
+    # -- ipmitool plumbing ----------------------------------------------
+
+    def _base_argv(self) -> list[str]:
+        argv = [self._ipmitool, "-I", self._interface, "-H", self.host, "-U", self._user, "-E"]
+        if self._cipher is not None:
+            argv += ["-C", str(self._cipher)]
+        if self._port and self._port != 623:
+            argv += ["-p", str(self._port)]
+        return argv
+
+    def _run(self, *args: str) -> str:
+        """Run a read-only ``ipmitool`` subcommand and return stdout. Raises
+        CapabilityError if ipmitool is missing, KVMPilotError on a nonzero exit."""
+        if shutil.which(self._ipmitool) is None:
+            raise CapabilityError(
+                f"'{self._ipmitool}' was not found on PATH; the IPMI driver shells "
+                "out to it (install ipmitool / OpenIPMI)."
+            )
+        argv = self._base_argv() + list(args)
+        env = {**os.environ, "IPMI_PASSWORD": self._passwd}
+        try:
+            proc = subprocess.run(  # nosec B603 - fixed argv from config, shell=False
+                argv, capture_output=True, text=True, timeout=self._timeout, env=env
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError(f"ipmitool timed out after {self._timeout}s") from exc
+        if proc.returncode != 0:
+            raise KVMPilotError(
+                f"ipmitool {' '.join(args)} failed (rc={proc.returncode}): "
+                f"{proc.stderr.strip() or proc.stdout.strip()}"
+            )
+        return proc.stdout
+
+    def _run_gated(self, op: str, desc: str, *args: str) -> str | None:
+        """A state-changing ``ipmitool`` subcommand, guarded via SafetyPolicy.
+        Returns None under dry-run (gated + skipped)."""
+        if not self.safety.guard(op, desc):
+            return None
+        return self._run(*args)
+
+    # -- SystemInfo -----------------------------------------------------
+
+    def get_info(self, fields: list | None = None) -> dict:
+        chassis = _kv(self._run("chassis", "status"))
+        try:
+            fru = _kv(self._run("fru", "print", "0"))
+        except KVMPilotError:
+            fru = {}
+        try:
+            mc = _kv(self._run("mc", "info"))
+        except KVMPilotError:
+            mc = {}
+        info: dict[str, Any] = {
+            "manufacturer": fru.get("Product Manufacturer") or fru.get("Board Mfg")
+            or mc.get("Manufacturer Name"),
+            "model": fru.get("Product Name") or fru.get("Board Product"),
+            "serial_number": fru.get("Product Serial") or fru.get("Board Serial"),
+            "power_state": "on" if "on" in (chassis.get("System Power", "")).lower() else "off",
+            "bmc_version": mc.get("Firmware Revision"),
+            "bmc_manufacturer": mc.get("Manufacturer Name"),
+        }
+        if fields:
+            info = {k: v for k, v in info.items() if k in fields}
+        return info
+
+    # -- Power ----------------------------------------------------------
+
+    def is_powered_on(self) -> bool:
+        return "on" in self._run("chassis", "power", "status").lower()
+
+    def power_on(self, wait: bool = True) -> None:
+        self._run_gated("ipmi.power_on", f"Power ON {self.host}", "chassis", "power", "on")
+
+    def power_off(self, wait: bool = True) -> None:
+        # 'soft' = ACPI graceful shutdown (the graceful analogue of PiKVM/Redfish).
+        self._run_gated(
+            "ipmi.power_off", f"Graceful power OFF {self.host}", "chassis", "power", "soft"
+        )
+
+    def power_off_hard(self, wait: bool = True) -> None:
+        self._run_gated(
+            "ipmi.power_off_hard", f"HARD power off {self.host} (data loss risk)",
+            "chassis", "power", "off",
+        )
+
+    def reset_hard(self, wait: bool = True) -> None:
+        self._run_gated(
+            "ipmi.reset_hard", f"HARD reset {self.host} (data loss risk)",
+            "chassis", "power", "reset",
+        )
+
+    # -- BootConfig -----------------------------------------------------
+
+    def get_boot_options(self) -> dict:
+        try:
+            raw = self._run("chassis", "bootparam", "get", "5")
+        except KVMPilotError:
+            return {"enabled": "Unknown", "once": None, "persistent": None,
+                    "target": None, "mode": None, "mode_settable": True,
+                    "allowable": sorted({v for v in _BOOTDEV_MAP if v != "setup"})}
+        low = raw.lower()
+        target = "none"
+        for phrase, tok in _BOOT_SELECTOR_REVERSE:
+            if phrase in low:
+                target = tok
+                break
+        persistent = "all future boots" in low or "persistent" in low
+        once = not persistent
+        mode = "UEFI" if "efi" in low else "Legacy"
+        return {
+            "enabled": "Continuous" if persistent else ("Once" if target != "none" else "Disabled"),
+            "once": once if target != "none" else False,
+            "persistent": persistent,
+            "target": target,
+            "mode": mode,
+            "mode_settable": True,
+            "allowable": sorted({v for v in _BOOTDEV_MAP if v != "setup"}),
+        }
+
+    def set_boot_device(self, device: str, *, once: bool = True, uefi: bool = True) -> dict:
+        key = str(device).strip().lower()
+        if key not in _BOOTDEV_MAP:
+            raise KVMPilotError(
+                f"unknown boot device {device!r}; IPMI supports "
+                f"{sorted({v for v in _BOOTDEV_MAP if v != 'setup'})} "
+                "(no 'usb' selector in IPMI)"
+            )
+        selector = _BOOTDEV_MAP[key]
+        opts = []
+        if uefi and selector != "none":
+            opts.append("efiboot")
+        if not once and selector != "none":
+            opts.append("persistent")
+        args = ["chassis", "bootdev", selector]
+        if opts:
+            args.append("options=" + ",".join(opts))
+        desc = (f"Set next boot -> {key} ({'once' if once else 'persistent'}"
+                f"{', UEFI' if uefi else ''}) on {self.host}")
+        if self._run_gated("ipmi.set_boot_device", desc, *args) is None:
+            return self.get_boot_options()  # dry-run
+        return self.get_boot_options()
+
+    # -- Sensors --------------------------------------------------------
+
+    def read_sensors(self) -> dict:
+        out = self._run("sdr", "elist")
+        readings = []
+        for line in out.splitlines():
+            parts = [p.strip() for p in line.split("|")]
+            if len(parts) >= 5 and parts[0]:
+                readings.append({
+                    "name": parts[0], "status": parts[2],
+                    "reading": parts[4], "raw": line.strip(),
+                })
+        return {"sensors": readings, "count": len(readings)}
+
+    # -- Logs (SEL) -----------------------------------------------------
+
+    def get_logs(self, seek: int = 0, follow: bool = False) -> str:
+        if follow:
+            raise CapabilityError("IPMI SEL has no tail-follow; call get_logs() without follow")
+        # seek (seconds lookback) has no cheap IPMI analogue — SEL is returned whole;
+        # callers filter by the timestamps in each entry if needed.
+        return self._run("sel", "list")
+
+
+def _kv(text: str) -> dict[str, str]:
+    """Parse ``ipmitool`` 'Key : Value' output into a dict (last wins)."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" in line:
+            k, _, v = line.partition(":")
+            k, v = k.strip(), v.strip()
+            if k:
+                out[k] = v
+    return out

--- a/src/kvm_pilot/safety.py
+++ b/src/kvm_pilot/safety.py
@@ -65,6 +65,12 @@ DESTRUCTIVE_OPS: set[str] = {
     # pre-reboot state change worth gating, though not itself a power action.
     "redfish.set_boot_device",
     "ssh.set_boot_next",
+    # IPMI (ipmitool) driver — power + boot-device on pre-Redfish BMCs.
+    "ipmi.power_on",
+    "ipmi.power_off",
+    "ipmi.power_off_hard",
+    "ipmi.reset_hard",
+    "ipmi.set_boot_device",
     # HID input changes target state too: keystrokes and clicks land on a live
     # console (rm -rf is one type_text away). Mouse *moves* stay ungated.
     "hid.ctrl_alt_delete",
@@ -152,6 +158,11 @@ OP_EFFECT: dict[str, EffectClass] = {
     # a power/media action, so an actuator can't launder it as either.
     "redfish.set_boot_device": EffectClass.CONFIG_MUTATION,
     "ssh.set_boot_next": EffectClass.CONFIG_MUTATION,
+    "ipmi.power_on": EffectClass.POWER_SOFT,
+    "ipmi.power_off": EffectClass.POWER_SOFT,      # 'soft' = ACPI graceful
+    "ipmi.power_off_hard": EffectClass.POWER_HARD,
+    "ipmi.reset_hard": EffectClass.POWER_HARD,
+    "ipmi.set_boot_device": EffectClass.CONFIG_MUTATION,
     # HID input
     "hid.type_text": EffectClass.HID_INPUT,
     "hid.press_key": EffectClass.HID_INPUT,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,7 +212,7 @@ def test_driver_defaults_to_pikvm_when_unset(monkeypatch):
 def test_unsupported_driver_via_env_is_a_clean_error(monkeypatch, capsys):
     # An unknown driver kind (no from-config support) must produce a clean error
     # (exit 1), not a crash.
-    monkeypatch.setenv("KVM_PILOT_DRIVER", "ipmi")
+    monkeypatch.setenv("KVM_PILOT_DRIVER", "nosuchdriver")
     rc = main(["info", "--host", "h"])
     assert rc == 1
     assert "does not support" in capsys.readouterr().err
@@ -1035,3 +1035,14 @@ def test_power_off_never_falls_back_to_wol(monkeypatch):
     rc = main(["power", "off", "--driver", "fake", "--yes"])
     assert rc == 0
     assert called == []
+
+
+def test_driver_ipmi_capabilities_offline(capsys):
+    # The ipmi driver plugs into the capability protocols, so `capabilities`
+    # (structural, no ipmitool call) works with no IPMI-specific CLI code.
+    rc = main(["capabilities", "--driver", "ipmi", "--host", "10.0.1.99"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    for cap in ("power", "system_info", "boot_config", "sensors", "logs"):
+        assert cap in out
+    assert "hid" not in out and "video" not in out  # IPMI has neither

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -145,13 +145,17 @@ def test_make_driver_from_config_dispatches_on_cfg_driver() -> None:
 
     assert isinstance(make_driver_from_config(HostConfig(host="h", driver="glkvm")), GLKVMDriver)
     assert isinstance(make_driver_from_config(HostConfig(host="h", driver="fake")), FakeDriver)
-    # redfish now builds via RedfishDriver.from_config (construction only, lazy login).
+    # redfish/ipmi build via their from_config (construction only, no BMC contacted).
     assert isinstance(
         make_driver_from_config(HostConfig(host="h", driver="redfish")), RedfishDriver
     )
+    from kvm_pilot.drivers import IpmiDriver
+    assert isinstance(
+        make_driver_from_config(HostConfig(host="h", driver="ipmi")), IpmiDriver
+    )
     # A genuinely unknown kind still raises a clean, actionable error.
     with pytest.raises(KVMPilotError, match="does not support"):
-        make_driver_from_config(HostConfig(host="h", driver="ipmi"))
+        make_driver_from_config(HostConfig(host="h", driver="nosuchdriver"))
 
 
 def test_factory_attaches_ssh_channel_when_configured() -> None:

--- a/tests/test_ipmi.py
+++ b/tests/test_ipmi.py
@@ -1,0 +1,272 @@
+"""IpmiDriver tests (#62) — hardware-free.
+
+Exercises the ipmitool wrapper end-to-end with a fake ``subprocess`` (no real
+ipmitool / BMC): command construction, output parsing against captured
+``ipmitool`` output shapes, capability detection, and safety gating.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from kvm_pilot.drivers import ipmi as ipmi_mod
+from kvm_pilot.drivers import make_driver, make_driver_from_config
+from kvm_pilot.drivers.base import BootConfig, Capability, Logs, Power, Sensors, SystemInfo
+from kvm_pilot.drivers.ipmi import IpmiDriver
+from kvm_pilot.errors import CapabilityError, KVMPilotError, SafetyError
+from kvm_pilot.safety import deny_all
+
+# --- captured ipmitool output shapes ---------------------------------------
+POWER_ON = "Chassis Power is on\n"
+POWER_OFF = "Chassis Power is off\n"
+POWER_CONTROL = "Chassis Power Control: Up/On\n"
+CHASSIS_STATUS = (
+    "System Power         : on\n"
+    "Power Overload       : false\n"
+    "Last Power Event     : command\n"
+)
+FRU = (
+    "FRU Device Description : Builtin FRU Device (ID 0)\n"
+    " Board Mfg             : DELL\n"
+    " Product Manufacturer  : DELL\n"
+    " Product Name          : PowerEdge R710\n"
+    " Product Serial        : ABC12345\n"
+)
+MC_INFO = (
+    "Device ID                 : 32\n"
+    "Firmware Revision         : 1.85\n"
+    "Manufacturer Name         : DELL\n"
+)
+BOOT_PXE_ONCE_EFI = (
+    "Boot parameter 5 is valid/unlocked\n"
+    " Boot Flags :\n"
+    "   - Boot Flag Valid\n"
+    "   - Options apply to only next boot\n"
+    "   - BIOS EFI boot\n"
+    "   - Boot Device Selector : Force Boot from Network - PXE\n"
+)
+BOOT_DISK_PERSIST_LEGACY = (
+    " Boot Flags :\n"
+    "   - Options apply to all future boots\n"
+    "   - BIOS PC Compatible (legacy) boot\n"
+    "   - Boot Device Selector : Force Boot from default Hard-Drive\n"
+)
+SDR = (
+    "CPU1 Temp        | 04h | ok  | 3.1 | 45 degrees C\n"
+    "FAN1 RPM         | 30h | ok  | 7.1 | 4200 RPM\n"
+    "Voltage 12V      | 60h | ok  | 7.2 | 12.10 Volts\n"
+)
+SEL = (
+    "   1 | 07/13/2026 | 10:00:00 | Power Unit #0x01 | Power off/down | Asserted\n"
+    "   2 | 07/13/2026 | 10:05:00 | System Boot Initiated | Initiated by power up\n"
+)
+
+# ordered (needle-in-joined-argv, output); first match wins — specific first.
+_OUTPUTS = [
+    ("chassis power status", POWER_ON),
+    ("chassis power", POWER_CONTROL),      # on/off/soft/reset/cycle
+    ("chassis bootparam get 5", BOOT_PXE_ONCE_EFI),
+    ("chassis bootdev", "Set Boot Device to pxe\n"),
+    ("chassis status", CHASSIS_STATUS),
+    ("fru print", FRU),
+    ("mc info", MC_INFO),
+    ("sdr elist", SDR),
+    ("sel list", SEL),
+]
+
+
+@pytest.fixture()
+def ipmi(monkeypatch):
+    """An IpmiDriver whose ipmitool is faked; returns (driver, calls)."""
+    calls: list[list[str]] = []
+    outputs = list(_OUTPUTS)
+
+    def fake_run(argv, **kw):
+        calls.append(argv)
+        joined = " ".join(argv)
+        for needle, out in outputs:
+            if needle in joined:
+                return types.SimpleNamespace(returncode=0, stdout=out, stderr="")
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="unknown command")
+
+    monkeypatch.setattr(ipmi_mod.shutil, "which", lambda _n: "/usr/bin/ipmitool")
+    monkeypatch.setattr(ipmi_mod.subprocess, "run", fake_run)
+    drv = IpmiDriver("10.0.1.99", "root", "calvin", confirm=lambda *a: True)
+    drv._outputs = outputs  # let tests tweak responses
+    return drv, calls
+
+
+class TestCapabilities:
+    def test_ipmi_capability_set(self, ipmi):
+        drv, _ = ipmi
+        caps = drv.capabilities()
+        assert caps == {
+            Capability.SYSTEM_INFO, Capability.POWER, Capability.BOOT_CONFIG,
+            Capability.SENSORS, Capability.LOGS,
+        }
+        for absent in (Capability.HID, Capability.VIDEO, Capability.VIRTUAL_MEDIA,
+                       Capability.GPIO, Capability.EVENTS):
+            assert absent not in caps
+
+    def test_satisfies_protocols(self, ipmi):
+        drv, _ = ipmi
+        assert isinstance(drv, Power | SystemInfo | Sensors | Logs | BootConfig)
+
+
+class TestCommandConstruction:
+    def test_base_argv_uses_env_password_not_argv(self, ipmi):
+        drv, calls = ipmi
+        drv.power_on()
+        argv = calls[-1]
+        assert argv[:1] == ["/usr/bin/ipmitool"] or argv[0] == "ipmitool"
+        assert "-I" in argv and "lanplus" in argv
+        assert "-H" in argv and "10.0.1.99" in argv
+        assert "-E" in argv                    # password via IPMI_PASSWORD env
+        assert "calvin" not in argv            # never in the process argv
+
+    def test_cipher_and_port_flags(self, monkeypatch):
+        calls: list[list[str]] = []
+        monkeypatch.setattr(ipmi_mod.shutil, "which", lambda _n: "ipmitool")
+        monkeypatch.setattr(ipmi_mod.subprocess, "run",
+                            lambda argv, **kw: calls.append(argv) or
+                            types.SimpleNamespace(returncode=0, stdout="Chassis Power is on\n", stderr=""))
+        drv = IpmiDriver("h", "u", "p", cipher=17, port=6230, confirm=lambda *a: True)
+        drv.is_powered_on()
+        assert "-C" in calls[-1] and "17" in calls[-1]
+        assert "-p" in calls[-1] and "6230" in calls[-1]
+
+
+class TestPower:
+    def test_is_powered_on(self, ipmi):
+        drv, _ = ipmi
+        assert drv.is_powered_on() is True
+
+    def test_is_powered_off(self, ipmi):
+        drv, _ = ipmi
+        drv._outputs[0] = ("chassis power status", POWER_OFF)
+        assert drv.is_powered_on() is False
+
+    @pytest.mark.parametrize(
+        "method,verb",
+        [("power_on", "on"), ("power_off", "soft"),
+         ("power_off_hard", "off"), ("reset_hard", "reset")],
+    )
+    def test_power_verbs(self, ipmi, method, verb):
+        drv, calls = ipmi
+        getattr(drv, method)()
+        assert calls[-1][-3:] == ["chassis", "power", verb]
+
+    def test_dry_run_sends_nothing(self, monkeypatch):
+        calls: list[list[str]] = []
+        monkeypatch.setattr(ipmi_mod.shutil, "which", lambda _n: "ipmitool")
+        monkeypatch.setattr(ipmi_mod.subprocess, "run",
+                            lambda argv, **kw: calls.append(argv))
+        drv = IpmiDriver("h", "u", "p", dry_run=True)
+        drv.power_on()
+        assert calls == []                     # gated + skipped
+
+    def test_denied_confirm_raises(self, monkeypatch):
+        monkeypatch.setattr(ipmi_mod.shutil, "which", lambda _n: "ipmitool")
+        monkeypatch.setattr(ipmi_mod.subprocess, "run", lambda *a, **k: pytest.fail("ran"))
+        drv = IpmiDriver("h", "u", "p", confirm=deny_all)
+        with pytest.raises(SafetyError):
+            drv.power_on()
+
+
+class TestSystemInfo:
+    def test_get_info_parses_fru_and_mc(self, ipmi):
+        drv, _ = ipmi
+        info = drv.get_info()
+        assert info["manufacturer"] == "DELL"
+        assert info["model"] == "PowerEdge R710"
+        assert info["serial_number"] == "ABC12345"
+        assert info["power_state"] == "on"
+        assert info["bmc_version"] == "1.85"
+
+
+class TestBootConfig:
+    def test_get_boot_options_pxe_once_efi(self, ipmi):
+        drv, _ = ipmi
+        o = drv.get_boot_options()
+        assert o["target"] == "pxe"
+        assert o["once"] is True and o["persistent"] is False
+        assert o["mode"] == "UEFI"
+
+    def test_get_boot_options_disk_persistent_legacy(self, ipmi):
+        drv, _ = ipmi
+        drv._outputs[2] = ("chassis bootparam get 5", BOOT_DISK_PERSIST_LEGACY)
+        o = drv.get_boot_options()
+        assert o["target"] == "hdd"
+        assert o["persistent"] is True
+        assert o["mode"] == "Legacy"
+
+    def test_set_pxe_once_efi(self, ipmi):
+        drv, calls = ipmi
+        drv.set_boot_device("pxe", once=True, uefi=True)
+        setcall = next(c for c in calls if "bootdev" in c)
+        assert setcall[-2:] == ["pxe", "options=efiboot"]
+
+    def test_set_hdd_persistent_legacy(self, ipmi):
+        drv, calls = ipmi
+        drv.set_boot_device("hdd", once=False, uefi=False)
+        setcall = next(c for c in calls if "bootdev" in c)
+        assert setcall[-2:] == ["disk", "options=persistent"]
+
+    def test_set_none_clears(self, ipmi):
+        drv, calls = ipmi
+        drv.set_boot_device("none")
+        setcall = next(c for c in calls if "bootdev" in c)
+        assert setcall[-1] == "none"           # no options for a clear
+
+    def test_usb_rejected(self, ipmi):
+        drv, calls = ipmi
+        with pytest.raises(KVMPilotError):
+            drv.set_boot_device("usb")          # IPMI has no usb bootdev
+        assert not any("bootdev" in c for c in calls)
+
+
+class TestSensorsAndLogs:
+    def test_read_sensors(self, ipmi):
+        drv, _ = ipmi
+        s = drv.read_sensors()
+        assert s["count"] == 3
+        names = {r["name"] for r in s["sensors"]}
+        assert "CPU1 Temp" in names and "FAN1 RPM" in names
+
+    def test_get_logs_returns_sel(self, ipmi):
+        drv, _ = ipmi
+        assert "Power off/down" in drv.get_logs()
+
+    def test_get_logs_follow_unsupported(self, ipmi):
+        drv, _ = ipmi
+        with pytest.raises(CapabilityError):
+            drv.get_logs(follow=True)
+
+
+class TestErrorsAndRegistry:
+    def test_ipmitool_missing_raises_capability_error(self, monkeypatch):
+        monkeypatch.setattr(ipmi_mod.shutil, "which", lambda _n: None)
+        drv = IpmiDriver("h", "u", "p", confirm=lambda *a: True)
+        with pytest.raises(CapabilityError):
+            drv.is_powered_on()
+
+    def test_nonzero_exit_raises(self, monkeypatch):
+        monkeypatch.setattr(ipmi_mod.shutil, "which", lambda _n: "ipmitool")
+        monkeypatch.setattr(ipmi_mod.subprocess, "run",
+                            lambda *a, **k: types.SimpleNamespace(
+                                returncode=1, stdout="", stderr="Unable to establish LAN session"))
+        drv = IpmiDriver("h", "u", "p", confirm=lambda *a: True)
+        with pytest.raises(KVMPilotError):
+            drv.is_powered_on()
+
+    def test_make_driver_ipmi(self):
+        assert isinstance(make_driver("ipmi", host="h"), IpmiDriver)
+
+    def test_make_driver_from_config(self):
+        from kvm_pilot.config import HostConfig
+        cfg = HostConfig(host="h", driver="ipmi", user="root", passwd="calvin", ipmi_cipher=17)
+        drv = make_driver_from_config(cfg)
+        assert isinstance(drv, IpmiDriver)
+        assert drv._cipher == 17


### PR DESCRIPTION
Closes the long-standing #62 gap — motivated by a real Dell R710 (iDRAC6) that has **no Redfish**.

`IpmiDriver` shells out to `ipmitool -I lanplus` (password via `-E`/`IPMI_PASSWORD` env — never in argv), mirroring the SSH-channel pattern rather than hand-rolling RMCP+/RAKP.

**Capabilities** (plug straight into the existing protocols → `power`/`boot-device`/`sensors`/`logs` work with no new CLI/MCP code):
- **Power** — `chassis power on/soft/off/reset` (soft = ACPI graceful)
- **SystemInfo** — `chassis status` + `fru` + `mc info`
- **BootConfig** — `chassis bootdev` (one-time/persistent, UEFI/legacy; no `usb` selector in IPMI)
- **Sensors** — `sdr elist`; **Logs** — SEL `sel list`

Registered in `make_driver` + `--driver ipmi`; `ipmi_interface`/`ipmi_port`/`ipmi_cipher` config fields; `ipmi.*` ops gated (`DESTRUCTIVE_OPS`/`OP_EFFECT`).

**Testing:** 34 hardware-free tests — command construction, output parsing vs captured `ipmitool` fixtures, and a fake-ipmitool end-to-end. ruff + mypy + full suite green. IPMI went from 0% → ≈ Redfish-minus-VirtualMedia.

Unblocks #18 (SEL/SDR tests) and #21 (ipmi_sim in the stack). Deferred: SOL SerialConsole + Watchdog (#28/#13); **ipmi_sim integration + live R710 validation to follow (#21/#29)** — fixtures are self-authored, so the R710 is the independent cross-check (as sushy-tools was for Redfish).

Refs #62 #18 #21 #13 #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)