### PR TITLE
test: cross-check IpmiDriver against OpenIPMI ipmi_sim (#62)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -535,6 +535,38 @@ fleet-wide fault. Several non-obvious choices came out of measuring it live:
   run's volatile findings would report every live warning as a false
   "regression" after each upgrade.
 
+## IPMI driver cross-checked against OpenIPMI `ipmi_sim` (#62 / #28)
+
+Like the Redfish driver against sushy-tools, the IPMI driver
+(`tests/test_ipmi.py`, fake-ipmitool) is corroborated against a reference BMC we
+didn't write — OpenIPMI's `ipmi_sim` — in `tests/integration/test_ipmi_external.py`
+(marked `integration`, env-gated via the `ipmi_bmc` fixture; run live on the
+homelab OpenShift VM against Fedora's stock `/etc/ipmi/ipmisim1.emu`, since macOS
+has no ipmi_sim build). Independence is the point: the sim answers as *MontaVista*
+(mfr `0x1291`, fw `9.08`), not the Dell shapes our fixtures were captured from, so
+a `mc info`/chassis-status parser overfit to Dell would surface here. It didn't —
+6/6 green.
+
+- **Assert only what the reference sim models; document the rest.** Stock
+  `ipmi_sim` has known gaps (characterised live), so the integration test asserts
+  execution + parsing + feature-detect, not full state round-trips (which the
+  fake-ipmitool unit tests and real iLO/iDRAC hardware, #29, cover):
+  - **Power never toggles.** `chassis power on/off` is accepted but the reported
+    state is stuck at "off" — the sim binds chassis power to an external QEMU VM
+    (`startcmd`, `startnow false`) that isn't running. Consequently the
+    state-dependent verbs `reset`/`soft` are *rejected* ("Invalid data field") on
+    an off chassis, so only `power_off_hard`/`power_on` are exercised live.
+  - **No device SDRs** (`no-device-sdrs`, empty SDR repo) → `read_sensors()`
+    returns `count == 0`, so the test asserts the shape is readable, not a count.
+  - **Boot parameter 5 GET is unimplemented** → `get_boot_options()` degrades to
+    `target=None`/`enabled='Unknown'` yet still reports the static `allowable`
+    set and `mode_settable`, which is what the test checks (plus fast client-side
+    rejection of `usb`, which has no IPMI bootdev selector).
+- **The cosmetic "Unable to Get Channel Cipher Suites" line is not an error.**
+  `ipmi_sim` doesn't answer Get-Channel-Cipher-Suites, but the RMCP+ session still
+  establishes on the default cipher, so the driver's commands succeed. Tests parse
+  the real output lines and ignore that warning.
+
 ## Process
 
 Most structural choices came from adversarial review passes (find → verify →

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -84,3 +84,28 @@ def redfish_emulator_url() -> str:
             proc.wait(timeout=10)
         except subprocess.TimeoutExpired:
             proc.kill()
+
+
+@pytest.fixture(scope="session")
+def ipmi_bmc():
+    """Connection params for an external IPMI BMC (OpenIPMI ``ipmi_sim`` or real).
+
+    Env-driven (mirrors ``redfish_emulator_url``): point at an already-running
+    ``ipmi_sim`` (or a real BMC) via ``KVM_PILOT_IPMI_HOST`` [+ ``_PORT`` /
+    ``_USER`` / ``_PASSWD`` / ``_CIPHER``]. Skips when unset so the default suite
+    stays hermetic (macOS has no ipmi_sim build).
+    """
+    host = os.environ.get("KVM_PILOT_IPMI_HOST")
+    if not host:
+        pytest.skip(
+            "external IPMI BMC unavailable: set KVM_PILOT_IPMI_HOST (+ _PORT/_USER/"
+            "_PASSWD/_CIPHER) to an ipmi_sim or real BMC"
+        )
+    cipher = os.environ.get("KVM_PILOT_IPMI_CIPHER")
+    return {
+        "host": host,
+        "port": int(os.environ.get("KVM_PILOT_IPMI_PORT", "623")),
+        "user": os.environ.get("KVM_PILOT_IPMI_USER", "admin"),
+        "passwd": os.environ.get("KVM_PILOT_IPMI_PASSWD", "password"),
+        "cipher": int(cipher) if cipher else None,
+    }

--- a/tests/integration/test_ipmi_external.py
+++ b/tests/integration/test_ipmi_external.py
@@ -1,0 +1,104 @@
+"""IpmiDriver against an independent IPMI simulator (OpenIPMI ``ipmi_sim``) — #62/#28.
+
+Marked ``integration`` and skipped unless an ``ipmi_sim`` BMC is available (see
+conftest ``ipmi_bmc``). The point, as with the sushy-tools Redfish tests, is
+*independence*: driving a reference implementation we didn't write (a different
+vendor identity — MontaVista, not the Dell shapes our fake-ipmitool fixtures were
+captured from) so a spec assumption shared by our driver and our own mocks can't
+hide a bug. Runs on Linux (CI / the homelab OpenShift VM); macOS has no ipmi_sim.
+
+Reference-sim limits, characterised live against Fedora's stock
+``/etc/ipmi/ipmisim1.emu`` (documented so assertions stay honest, exactly like the
+sushy ``--fake`` "Continuous" note in ``test_redfish_external.py``):
+
+* **Power does not toggle.** ``chassis power on/off`` is accepted ("Chassis Power
+  Control: Up/On") but the reported state never changes — ipmi_sim binds chassis
+  power to an external QEMU VM (``startcmd``, ``startnow false``) that isn't
+  running. So we assert the power verbs *execute* against a live BMC, not a flip.
+  And because the modelled state is stuck at "off", the state-dependent verbs
+  ``reset``/``soft`` are rejected ("Invalid data field") — you can't reset a
+  powered-off chassis — so only ``power_off_hard``/``power_on`` are exercised live.
+* **No device SDRs.** The MC is ``no-device-sdrs`` with no SDR repository records,
+  so ``sdr elist`` is empty → ``read_sensors()["count"]`` is 0.
+* **Boot parameter 5 GET is unimplemented** ("Invalid data field in request"), so
+  ``get_boot_options()`` degrades to ``target=None``/``enabled='Unknown'`` while
+  still feature-detecting the static ``allowable`` set.
+
+State round-trips (power flip, boot target read-back, populated sensors) are
+covered by the fake-ipmitool unit tests (``tests/test_ipmi.py``) and by real
+iLO/iDRAC hardware (#29); here we prove the wire protocol and parsers against an
+independent BMC.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kvm_pilot.drivers.base import BootConfig, Logs, Power, Sensors, SystemInfo
+from kvm_pilot.drivers.ipmi import IpmiDriver
+from kvm_pilot.errors import KVMPilotError
+from kvm_pilot.safety import allow_all
+
+pytestmark = pytest.mark.integration
+
+
+def _driver(bmc: dict) -> IpmiDriver:
+    return IpmiDriver(
+        bmc["host"], bmc["user"], bmc["passwd"],
+        port=bmc["port"], cipher=bmc.get("cipher"), confirm=allow_all,
+    )
+
+
+def test_capabilities_match_the_ipmi_set(ipmi_bmc):
+    # Structural capability set, corroborated against a live BMC session.
+    d = _driver(ipmi_bmc)
+    assert isinstance(d, Power | SystemInfo | Sensors | Logs | BootConfig)
+
+
+def test_info_talks_to_ipmi_sim(ipmi_bmc):
+    info = _driver(ipmi_bmc).get_info()
+    # An independent, non-Dell BMC answered through IpmiDriver -> ipmitool ->
+    # RMCP+/lanplus, and our `mc info` parser read a real identity back.
+    assert info["power_state"] in ("on", "off")
+    assert info["manufacturer"] is not None or info["bmc_version"] is not None
+
+
+def test_power_verbs_execute_against_live_bmc(ipmi_bmc):
+    # Each verb frames a real `chassis power <verb>` the BMC accepts (no non-zero
+    # exit). We do NOT assert a state flip: stock ipmi_sim doesn't model chassis
+    # power (see module docstring). reset/soft are state-dependent and rejected
+    # while the modelled state is off, so only off/on are exercised here; all four
+    # verbs' framing is covered by the fake-ipmitool unit tests + real hardware.
+    d = _driver(ipmi_bmc)
+    d.power_off_hard()
+    d.power_on()
+    assert isinstance(d.is_powered_on(), bool)
+
+
+def test_boot_device_commands_execute_and_feature_detect(ipmi_bmc):
+    # set_boot_device frames a real `chassis bootdev` the BMC accepts; get_boot_options
+    # degrades gracefully where the sim omits boot-param-5 GET, yet still reports the
+    # static IPMI allowable set + that mode is settable.
+    d = _driver(ipmi_bmc)
+    d.set_boot_device("pxe", once=True)
+    d.set_boot_device("hdd", once=False)
+    opts = d.get_boot_options()
+    assert "pxe" in opts["allowable"] and "hdd" in opts["allowable"]
+    assert opts["mode_settable"] is True
+
+
+def test_usb_boot_rejected_before_send(ipmi_bmc):
+    # Client-side feature-detect proven against a live BMC: IPMI has no usb bootdev
+    # selector, so a usb request fails fast rather than sending a doomed command.
+    d = _driver(ipmi_bmc)
+    assert "usb" not in d.get_boot_options()["allowable"]
+    with pytest.raises(KVMPilotError):
+        d.set_boot_device("usb")
+
+
+def test_sensors_and_sel_readable(ipmi_bmc):
+    d = _driver(ipmi_bmc)
+    sensors = d.read_sensors()
+    assert isinstance(sensors["count"], int)   # 0 on stock ipmi_sim (no device SDRs)
+    assert isinstance(sensors["sensors"], list)
+    assert isinstance(d.get_logs(), str)        # SEL, may be empty


### PR DESCRIPTION
## What

Adds an **independent-reference cross-check** for the IPMI driver (#62), mirroring the sushy-tools Redfish integration test:

- `tests/integration/test_ipmi_external.py` — drives `IpmiDriver` against OpenIPMI's `ipmi_sim` (a BMC implementation we didn't write).
- `tests/integration/conftest.py` — env-gated `ipmi_bmc` fixture (`KVM_PILOT_IPMI_HOST` [+ `_PORT`/`_USER`/`_PASSWD`/`_CIPHER`]); **skips** when unset so the default suite stays hermetic (macOS has no `ipmi_sim` build).
- `docs/decisions.md` — records the reference-sim limits and why the assertions are scoped the way they are.

## Why

Our unit tests (`tests/test_ipmi.py`) drive the driver against a **fake `ipmitool`** with captured **Dell** output shapes. A spec assumption shared by the driver and those fixtures could hide a bug. `ipmi_sim` answers as **MontaVista** (mfr `0x1291`, fw `9.08`) over real RMCP+/lanplus, so the `mc info`/chassis-status parsers are exercised against an independent identity.

## Verified live

Ran on the homelab **OpenShift VM** (Fedora, `OpenIPMI-lanserv`) against the stock `/etc/ipmi/ipmisim1.emu` — the exact hardware-free path this repo's CI / a Linux dev box would use:

```
test_capabilities_match_the_ipmi_set PASSED
test_info_talks_to_ipmi_sim PASSED
test_power_verbs_execute_against_live_bmc PASSED
test_boot_device_commands_execute_and_feature_detect PASSED
test_usb_boot_rejected_before_send PASSED
test_sensors_and_sel_readable PASSED
6 passed in 14.93s
```

## Scope of assertions (honest, like the sushy `--fake` "Continuous" note)

Stock `ipmi_sim` doesn't model everything, so the test asserts **execution + parsing + feature-detect**, not full state round-trips (those stay covered by the fake-`ipmitool` unit tests and real iLO/iDRAC hardware, #29):

- **Power never toggles** — `chassis power on/off` is accepted but state is stuck "off" (power is bound to an absent QEMU VM), so `reset`/`soft` are rejected on an off chassis; only `power_off_hard`/`power_on` are exercised live.
- **No device SDRs** → `read_sensors()` count is 0 (shape asserted, not a count).
- **Boot-param-5 GET unimplemented** → `get_boot_options()` degrades to `target=None`/`enabled='Unknown'` but still feature-detects `allowable` + `mode_settable`.

Closes the "ipmi_sim live smoke + integration test" follow-up from #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
