### PR TITLE
deps: support both MCP SDK majors (mcp>=1.10,<3) — supersedes #240

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,11 @@ jobs:
           pip install -e ".[dev,totp,ws]"
           pip install "${{ matrix.mcp-version }}"   # pin the major under test
           python -c "import importlib.metadata as m; print('mcp', m.version('mcp'))"
+      - name: Mypy (types against this major)
+        # The `test` job type-checks against the newest allowed mcp only. The SDK
+        # renames are visible to mypy (annotation kwargs resolve to one major's
+        # field names), so an untyped-checked major is where that drift lands.
+        run: mypy src/kvm_pilot
       - name: Pytest (MCP surfaces)
         run: pytest tests/test_mcp_server.py tests/test_mcp_sdk_shim.py tests/test_act.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
     # leaks pre-releases into the transitive dep resolution). The `test`/`security`
     # jobs use editable installs *without* `--pre`, so they can't catch a dependency
     # that only breaks under a real `--pre` resolve — e.g. #110, where `--pre` pulled
-    # the mcp 2.x beta and the bundled server failed to import out of the box.
+    # the (then unsupported) mcp 2.x beta and the bundled server failed to import out
+    # of the box. Both mcp majors are supported now (#241) — see the mcp-majors job,
+    # which pins each one explicitly; this job keeps covering whatever `--pre` picks.
     # Asserts the shipped MCP server + skill + console scripts actually work.
     runs-on: ubuntu-latest
     steps:
@@ -93,6 +95,36 @@ jobs:
           test -x /tmp/smoke/bin/kvm-pilot        # CLI console script
           test -x /tmp/smoke/bin/kvm-pilot-mcp    # MCP server console script
           /tmp/smoke/bin/kvm-pilot --version
+
+  mcp-majors:
+    # `mcp>=1.10,<3` spans two SDK majors that are NOT source-compatible: 2.x moved
+    # `mcp.server.fastmcp` -> `mcp.server.mcpserver` and renamed the model fields to
+    # snake_case (#241). The `test` job only ever resolves the newest allowed mcp, so
+    # it cannot catch a change that breaks the *older* major — and the shim exists
+    # precisely to keep both working. Pin each end of the range and run the MCP suite
+    # against it. If supporting 1.x stops being worth this job, raise the floor in
+    # pyproject and delete the leg — don't let it silently rot.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mcp-version: ["mcp>=1.10,<2", "mcp>=2,<3"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install with ${{ matrix.mcp-version }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,totp,ws]"
+          pip install "${{ matrix.mcp-version }}"   # pin the major under test
+          python -c "import importlib.metadata as m; print('mcp', m.version('mcp'))"
+      - name: Pytest (MCP surfaces)
+        run: pytest tests/test_mcp_server.py tests/test_mcp_sdk_shim.py tests/test_act.py
 
   redfish-integration:
     # Validates `--driver redfish` end-to-end against an external, DMTF-conformant

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,18 +97,20 @@ jobs:
           /tmp/smoke/bin/kvm-pilot --version
 
   mcp-majors:
-    # `mcp>=1.10,<3` spans two SDK majors that are NOT source-compatible: 2.x moved
+    # `mcp>=1.17,<3` spans two SDK majors that are NOT source-compatible: 2.x moved
     # `mcp.server.fastmcp` -> `mcp.server.mcpserver` and renamed the model fields to
     # snake_case (#241). The `test` job only ever resolves the newest allowed mcp, so
     # it cannot catch a change that breaks the *older* major — and the shim exists
-    # precisely to keep both working. Pin each end of the range and run the MCP suite
-    # against it. If supporting 1.x stops being worth this job, raise the floor in
-    # pyproject and delete the leg — don't let it silently rot.
+    # precisely to keep both working. Run the MCP suite against three points:
+    # the exact declared floor (a range would resolve the newest 1.x and never
+    # exercise the bound we publish — the old `>=1.10` claim was false for months),
+    # newest 1.x, and 2.x. If supporting 1.x stops being worth this job, raise the
+    # floor in pyproject and drop the legs — don't let it silently rot.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        mcp-version: ["mcp>=1.10,<2", "mcp>=2,<3"]
+        mcp-version: ["mcp==1.17.0", "mcp>=1.17,<2", "mcp>=2,<3"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - **Support for both MCP SDK majors** (#241) — the dependency widens from
-  `mcp>=1.10,<2` to `mcp>=1.10,<3`, so `pip install kvm-pilot` works whether the
+  `mcp>=1.10,<2` to `mcp>=1.17,<3`, so `pip install kvm-pilot` works whether the
   resolver picks mcp 1.x or the now-stable 2.x. The two majors are **not**
   source-compatible (2.x moved `mcp.server.fastmcp` → `mcp.server.mcpserver`,
   `FastMCP` → `MCPServer`, and renamed the SDK's model fields to snake_case —
@@ -24,6 +24,12 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `KVM_PILOT_MCP_READ_ONLY=1` aborted the server at startup with an
   `AttributeError` instead of serving the least-privilege tool set (#196). The
   hint is now read major-agnostically. No effect on mcp 1.x installs.
+- **The published mcp lower bound was never true** (#241) — `>=1.10` was declared
+  but unexercised: below 1.14 the bundled server does not import at all (FastMCP
+  could not resolve its `Context` annotations), and 1.14–1.16 lack
+  `FastMCP.remove_tool`, which read-only mode (#196) calls. The floor is now the
+  measured one, `>=1.17`, and the `mcp-majors` CI leg pins that exact version so
+  the bound is tested rather than asserted.
 
 ## [0.1.0b11] — 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Support for both MCP SDK majors** (#241) — the dependency widens from
+  `mcp>=1.10,<2` to `mcp>=1.10,<3`, so `pip install kvm-pilot` works whether the
+  resolver picks mcp 1.x or the now-stable 2.x. The two majors are **not**
+  source-compatible (2.x moved `mcp.server.fastmcp` → `mcp.server.mcpserver`,
+  `FastMCP` → `MCPServer`, and renamed the SDK's model fields to snake_case —
+  the wire protocol is unchanged), so every SDK symbol is now imported through
+  one shim, `kvm_pilot/mcp/_sdk.py`. A guard test fails the build if any shipped
+  module imports `mcp.server.*` directly — that is what silently reintroduced
+  #110 — and a new `mcp-majors` CI leg runs the MCP suite pinned to each end of
+  the supported range, which the normal `test` job (always newest) cannot catch.
+
+### Fixed
+- **Read-only launch mode crashed on mcp 2.x** (#241) — `_apply_read_only_mode()`
+  read the `readOnlyHint` annotation by its 1.x field name, so under mcp 2.x
+  `KVM_PILOT_MCP_READ_ONLY=1` aborted the server at startup with an
+  `AttributeError` instead of serving the least-privilege tool set (#196). The
+  hint is now read major-agnostically. No effect on mcp 1.x installs.
+
 ## [0.1.0b11] — 2026-07-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,12 @@ Optimize for the next person reading this, not for cleverness.
   `CONTRIBUTING.md`, `SECURITY.md`. `src/kvm_pilot/skill/SKILL.md` (bundled Claude
   skill, shipped as package data) and `src/kvm_pilot/mcp/README.md` stay next to
   their code but are mirrored into the docs too.
-- `src/kvm_pilot/mcp/` — the bundled FastMCP stdio server (`server.py`, entry point
+- `src/kvm_pilot/mcp/` — the bundled MCP stdio server (`server.py`, entry point
   `kvm-pilot-mcp`); `src/kvm_pilot/skill/SKILL.md` — the bundled Claude skill. Both
-  ship in the wheel (see the batteries-included rule above).
+  ship in the wheel (see the batteries-included rule above). The server supports
+  **both mcp SDK majors** (`mcp>=1.10,<3`), which are not source-compatible: import
+  every SDK symbol from `kvm_pilot/mcp/_sdk.py`, never from `mcp.server.*` directly
+  (#241) — `tests/test_mcp_sdk_shim.py` fails the build if you do.
 - The GitHub wiki is auto-generated from `docs/` by `.github/workflows/wiki-sync.yml`
   (via `.github/scripts/build_wiki.py`) — edit the docs, never the wiki. `PAGES`
   in that script is the **single navigation manifest** (#221): it defines each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,11 @@ classifiers = [
 # to `mcp.server.mcpserver` (MCPServer/Image) — the breakage behind the old `<2` cap
 # (#110) — so the server imports the SDK through `kvm_pilot.mcp._sdk`, which resolves
 # either major. Keep the `<3` cap: a future major may move things again.
-dependencies = ["mcp>=1.10,<3", "websocket-client>=1.9.0"]
+# The floor is 1.17, measured, not guessed: below 1.14 the server does not import at
+# all (FastMCP couldn't resolve our `Context` annotations), and 1.14-1.16 lack
+# `FastMCP.remove_tool`, which read-only mode needs (#196). The old `>=1.10` claim was
+# never true. The mcp-majors CI leg pins this exact floor so it can't silently rot.
+dependencies = ["mcp>=1.17,<3", "websocket-client>=1.9.0"]
 
 [project.optional-dependencies]
 totp = ["pyotp>=2.10.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,11 @@ classifiers = [
 #   - websocket-client: GL's video encoder is on-demand and a headless `snapshot`
 #     must register a stream client over kvmd's WS to start it + keep it warm
 #     (#142) — snapshot/classify/watch would otherwise 503 on an idle GL unit.
-# Cap mcp below 2.0: mcp 2.x relocated `mcp.server.fastmcp` (FastMCP/Image), which
-# the server imports; the cap also stops `pip install --pre kvm-pilot` from pulling
-# the mcp 2.x beta into a fresh env (#110).
-dependencies = ["mcp>=1.10,<2", "websocket-client>=1.9.0"]
+# mcp spans both SDK majors (#241). 2.x renamed `mcp.server.fastmcp` (FastMCP/Image)
+# to `mcp.server.mcpserver` (MCPServer/Image) — the breakage behind the old `<2` cap
+# (#110) — so the server imports the SDK through `kvm_pilot.mcp._sdk`, which resolves
+# either major. Keep the `<3` cap: a future major may move things again.
+dependencies = ["mcp>=1.10,<3", "websocket-client>=1.9.0"]
 
 [project.optional-dependencies]
 totp = ["pyotp>=2.10.0"]

--- a/src/kvm_pilot/mcp/_sdk.py
+++ b/src/kvm_pilot/mcp/_sdk.py
@@ -1,0 +1,74 @@
+"""One import site for the MCP SDK, across both SDK majors (#241, was #110).
+
+mcp 2.x renamed the server class ``FastMCP`` to ``MCPServer`` and moved the
+``mcp.server.fastmcp`` package to ``mcp.server.mcpserver``. That move is why the
+dependency was pinned ``mcp<2``: a fresh ``pip install --pre kvm-pilot`` pulled
+the 2.x beta and the bundled server failed to import (#110).
+
+Everything kvm-pilot actually uses kept its name and signature across the move —
+the ``tool``/``resource`` decorators, ``Context`` (``elicit``, ``session``,
+``report_progress``), ``Image(data=, format=)``, ``ToolError``, and the
+``mcp.types`` models — so a single shim covers both majors and lets the
+dependency widen to ``mcp>=1.10,<3``. Import the SDK from here, never directly:
+a stray ``from mcp.server.fastmcp import ...`` elsewhere silently reintroduces
+#110 on mcp 2.x. ``tests/test_mcp_sdk_shim.py`` guards that.
+"""
+
+from __future__ import annotations
+
+from mcp.types import ToolAnnotations  # unmoved across majors; only the fields renamed
+
+try:  # mcp 2.x
+    from mcp.server.mcpserver import Context, Image, MCPServer
+    from mcp.server.mcpserver.exceptions import ToolError
+
+    SDK_MAJOR = 2
+except ModuleNotFoundError:  # mcp 1.x — FastMCP under its original name/path
+    # no-redef: mypy sees both branches define these; only one ever executes, and
+    # which one type-checks cleanly depends on the mcp installed in the checking env.
+    from mcp.server.fastmcp import Context, Image  # type: ignore[no-redef]
+    from mcp.server.fastmcp import FastMCP as MCPServer  # type: ignore[no-redef]
+    from mcp.server.fastmcp.exceptions import ToolError  # type: ignore[no-redef]
+
+    SDK_MAJOR = 1
+
+# mcp 2.x also renamed the SDK's *model* fields to snake_case (`readOnlyHint` ->
+# `read_only_hint`) while the protocol keys stayed camelCase. The two helpers below
+# are the only places that care, so neither major's field names leak into the server.
+_READ_ONLY_HINT = "read_only_hint" if SDK_MAJOR == 2 else "readOnlyHint"
+
+
+def tool_annotations(
+    *, read_only: bool, destructive: bool, idempotent: bool, open_world: bool
+) -> ToolAnnotations:
+    """Build a `ToolAnnotations` from the four hints, keyed by their wire names.
+
+    Validated from a dict rather than passed as keywords on purpose: the wire keys
+    are camelCase on both majors, but they are only *field* names on 1.x — keyword
+    construction type-checks against whichever mcp is installed and fails on the
+    other. `model_validate` accepts the wire key as a field name (1.x) or an alias
+    (2.x), so one call site is correct and type-clean under both."""
+    return ToolAnnotations.model_validate(
+        {
+            "readOnlyHint": read_only,
+            "destructiveHint": destructive,
+            "idempotentHint": idempotent,
+            "openWorldHint": open_world,
+        }
+    )
+
+
+def read_only_hint(annotations: object | None) -> bool | None:
+    """A tool's declared ``readOnlyHint``, or None if it declares no annotations."""
+    return None if annotations is None else getattr(annotations, _READ_ONLY_HINT, None)
+
+
+__all__ = [
+    "SDK_MAJOR",
+    "Context",
+    "Image",
+    "MCPServer",
+    "ToolError",
+    "read_only_hint",
+    "tool_annotations",
+]

--- a/src/kvm_pilot/mcp/act.py
+++ b/src/kvm_pilot/mcp/act.py
@@ -43,11 +43,10 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
 
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ClientCapabilities, ElicitationCapability
 from pydantic import BaseModel
 
+from kvm_pilot.mcp._sdk import Context, ToolError
 from kvm_pilot.safety import EffectClass
 
 # --------------------------------------------------------------------------- #

--- a/src/kvm_pilot/mcp/server.py
+++ b/src/kvm_pilot/mcp/server.py
@@ -58,9 +58,6 @@ from importlib.resources import files
 from typing import TYPE_CHECKING, Literal, cast
 
 import anyio
-from mcp.server.fastmcp import Context, FastMCP, Image
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
 
 from kvm_pilot import resolve_host
 from kvm_pilot.calibrate import (
@@ -80,6 +77,14 @@ from kvm_pilot.errors import (
 from kvm_pilot.errors import TimeoutError as KVMTimeoutError
 from kvm_pilot.health import RECOVERY_ORDER
 from kvm_pilot.mcp import act
+from kvm_pilot.mcp._sdk import (
+    Context,
+    Image,
+    MCPServer,
+    ToolError,
+    read_only_hint,
+    tool_annotations,
+)
 from kvm_pilot.safety import EffectClass, allow_all, deny_all, shortcut_effect
 from kvm_pilot.vision import (
     ALL_PHASES,
@@ -105,7 +110,7 @@ if TYPE_CHECKING:
         VirtualMedia,
     )
 
-mcp = FastMCP("kvm-pilot")
+mcp = MCPServer("kvm-pilot")
 _log = logging.getLogger("kvm_pilot.mcp")
 
 # Tool annotations (#195): every tool declares all four hints explicitly,
@@ -132,23 +137,23 @@ _log = logging.getLogger("kvm_pilot.mcp")
 #                    The _REMOTE variant may leave the operator's network
 #                    (mount by URL; filing a GitHub issue — which dedupes
 #                    against existing issues, hence idempotent).
-_READ = ToolAnnotations(
-    readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+_READ = tool_annotations(
+    read_only=True, destructive=False, idempotent=True, open_world=False
 )
-_READ_VISION = ToolAnnotations(
-    readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True
+_READ_VISION = tool_annotations(
+    read_only=True, destructive=False, idempotent=True, open_world=True
 )
-_READ_VISION_WAIT = ToolAnnotations(
-    readOnlyHint=True, destructiveHint=False, idempotentHint=False, openWorldHint=True
+_READ_VISION_WAIT = tool_annotations(
+    read_only=True, destructive=False, idempotent=False, open_world=True
 )
-_DESTRUCTIVE = ToolAnnotations(
-    readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False
+_DESTRUCTIVE = tool_annotations(
+    read_only=False, destructive=True, idempotent=False, open_world=False
 )
-_REVERSIBLE_WRITE = ToolAnnotations(
-    readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+_REVERSIBLE_WRITE = tool_annotations(
+    read_only=False, destructive=False, idempotent=True, open_world=False
 )
-_REVERSIBLE_WRITE_REMOTE = ToolAnnotations(
-    readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
+_REVERSIBLE_WRITE_REMOTE = tool_annotations(
+    read_only=False, destructive=False, idempotent=True, open_world=True
 )
 
 _POWER_ACTIONS = {
@@ -197,8 +202,8 @@ def _apply_read_only_mode() -> None:
     if not _read_only_mode():
         return
     for tool in list(mcp._tool_manager.list_tools()):
-        ann = tool.annotations
-        if ann is None or ann.readOnlyHint is not True or tool.name in _READ_ONLY_MODE_EXCLUDED:
+        hint = read_only_hint(tool.annotations)
+        if hint is not True or tool.name in _READ_ONLY_MODE_EXCLUDED:
             mcp.remove_tool(tool.name)
 
 

--- a/tests/test_act.py
+++ b/tests/test_act.py
@@ -14,9 +14,8 @@ import pytest
 
 pytest.importorskip("mcp")
 
-from mcp.server.fastmcp.exceptions import ToolError  # noqa: E402
-
 from kvm_pilot.mcp import act  # noqa: E402
+from kvm_pilot.mcp._sdk import ToolError  # noqa: E402
 from kvm_pilot.safety import EffectClass  # noqa: E402
 
 _ENV = (

--- a/tests/test_mcp_sdk_shim.py
+++ b/tests/test_mcp_sdk_shim.py
@@ -1,0 +1,63 @@
+"""Guards on the MCP SDK import shim (#241, regression guard for #110).
+
+`pip install --pre kvm-pilot` once pulled the mcp 2.x beta into a fresh env and
+the bundled server failed to import, because mcp 2.x moved
+`mcp.server.fastmcp` (FastMCP/Image) to `mcp.server.mcpserver` (MCPServer/Image).
+The dependency now spans both majors (`mcp>=1.10,<3`) and every SDK symbol is
+imported through `kvm_pilot.mcp._sdk`.
+
+That only holds while nothing imports the SDK's server package directly, so the
+first test below is the real guard: a stray `from mcp.server.fastmcp import ...`
+anywhere in the shipped package breaks on mcp 2.x exactly the way #110 did, and
+the equivalent 2.x-only import breaks on mcp 1.x.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from kvm_pilot.mcp import _sdk
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "kvm_pilot"
+_SHIM = _SRC / "mcp" / "_sdk.py"
+
+# Either major's server package, imported anywhere but the shim, pins us to that
+# major. `mcp.types` is deliberately absent: those models kept their path across
+# the move, so importing them directly is fine.
+_DIRECT_SDK_IMPORT = re.compile(r"^\s*(?:from|import)\s+mcp\.server\.(fastmcp|mcpserver)\b", re.M)
+
+
+def test_shipped_package_imports_the_sdk_only_through_the_shim():
+    """No module but `_sdk` may touch mcp's server package (#110 regression)."""
+    offenders = {
+        path.relative_to(_SRC).as_posix()
+        for path in _SRC.rglob("*.py")
+        if path != _SHIM and _DIRECT_SDK_IMPORT.search(path.read_text())
+    }
+    assert not offenders, (
+        f"{sorted(offenders)} import mcp's server package directly; import from "
+        "kvm_pilot.mcp._sdk instead so both mcp 1.x and 2.x keep working (#241)."
+    )
+
+
+def test_shim_exports_every_symbol_the_server_uses():
+    """The shim is the whole SDK surface — each export must resolve on this major."""
+    for name in ("Context", "Image", "MCPServer", "ToolError"):
+        assert getattr(_sdk, name, None) is not None, f"_sdk.{name} did not resolve"
+    assert _sdk.SDK_MAJOR in (1, 2)
+
+
+def test_shim_resolves_the_major_actually_installed():
+    """SDK_MAJOR must describe the installed mcp, not the branch that imported."""
+    import mcp.server
+
+    has_v2 = hasattr(mcp.server, "mcpserver")
+    assert _sdk.SDK_MAJOR == (2 if has_v2 else 1)
+
+
+def test_server_module_builds_its_app_from_the_shim():
+    """The live server object is the shim's class on whichever major is installed."""
+    from kvm_pilot.mcp import server
+
+    assert isinstance(server.mcp, _sdk.MCPServer)

--- a/tests/test_mcp_sdk_shim.py
+++ b/tests/test_mcp_sdk_shim.py
@@ -14,7 +14,7 @@ the equivalent 2.x-only import breaks on mcp 1.x.
 
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 from kvm_pilot.mcp import _sdk
@@ -22,10 +22,31 @@ from kvm_pilot.mcp import _sdk
 _SRC = Path(__file__).resolve().parents[1] / "src" / "kvm_pilot"
 _SHIM = _SRC / "mcp" / "_sdk.py"
 
-# Either major's server package, imported anywhere but the shim, pins us to that
-# major. `mcp.types` is deliberately absent: those models kept their path across
-# the move, so importing them directly is fine.
-_DIRECT_SDK_IMPORT = re.compile(r"^\s*(?:from|import)\s+mcp\.server\.(fastmcp|mcpserver)\b", re.M)
+
+def _imports_mcp_server(source: str) -> bool:
+    """Does this module import anything out of mcp's server package?
+
+    Parsed rather than pattern-matched: the package is reachable as
+    `import mcp.server.fastmcp`, `from mcp.server.mcpserver import X` *and*
+    `from mcp.server import fastmcp`, and a regex that misses the last form
+    would let exactly the #110 breakage back in. `mcp.types` is deliberately not
+    covered — those models kept their path across the move, so importing them
+    directly is fine.
+    """
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            names = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            # A relative import (level > 0) can't reach the mcp package.
+            if node.level:
+                continue
+            module = node.module or ""
+            names = [module] + [f"{module}.{alias.name}" for alias in node.names]
+        else:
+            continue
+        if any(n == "mcp.server" or n.startswith("mcp.server.") for n in names):
+            return True
+    return False
 
 
 def test_shipped_package_imports_the_sdk_only_through_the_shim():
@@ -33,12 +54,39 @@ def test_shipped_package_imports_the_sdk_only_through_the_shim():
     offenders = {
         path.relative_to(_SRC).as_posix()
         for path in _SRC.rglob("*.py")
-        if path != _SHIM and _DIRECT_SDK_IMPORT.search(path.read_text())
+        if path != _SHIM and _imports_mcp_server(path.read_text())
     }
     assert not offenders, (
         f"{sorted(offenders)} import mcp's server package directly; import from "
         "kvm_pilot.mcp._sdk instead so both mcp 1.x and 2.x keep working (#241)."
     )
+
+
+def test_the_guard_catches_every_way_of_reaching_mcp_server():
+    """The guard above is only worth having if it sees all the import spellings.
+
+    `from mcp.server import fastmcp` is the one a line-based check misses, and it
+    breaks on mcp 2.x exactly like the others."""
+    caught = [
+        "import mcp.server.fastmcp",
+        "import mcp.server.mcpserver as sdk",
+        "from mcp.server.fastmcp import FastMCP",
+        "from mcp.server.mcpserver.exceptions import ToolError",
+        "from mcp.server import fastmcp",
+        "from mcp.server import mcpserver",
+        "def f():\n    from mcp.server.fastmcp import Context",  # function-local too
+    ]
+    for source in caught:
+        assert _imports_mcp_server(source), f"guard missed: {source!r}"
+
+    allowed = [
+        "from mcp.types import ToolAnnotations",  # unmoved across majors
+        "import mcp",
+        "from kvm_pilot.mcp._sdk import MCPServer",
+        "from . import server",  # relative: can't reach the mcp package
+    ]
+    for source in allowed:
+        assert not _imports_mcp_server(source), f"guard over-reached: {source!r}"
 
 
 def test_shim_exports_every_symbol_the_server_uses():

--- a/tests/test_mcp_sdk_shim.py
+++ b/tests/test_mcp_sdk_shim.py
@@ -97,10 +97,14 @@ def test_shim_exports_every_symbol_the_server_uses():
 
 
 def test_shim_resolves_the_major_actually_installed():
-    """SDK_MAJOR must describe the installed mcp, not the branch that imported."""
-    import mcp.server
+    """SDK_MAJOR must describe the installed mcp, not the branch that imported.
 
-    has_v2 = hasattr(mcp.server, "mcpserver")
+    `find_spec` rather than `hasattr(mcp.server, "mcpserver")`: importing a
+    submodule binds it on its parent package, so the attribute check would be
+    reading the shim's own side effect back to itself."""
+    from importlib.util import find_spec
+
+    has_v2 = find_spec("mcp.server.mcpserver") is not None
     assert _sdk.SDK_MAJOR == (2 if has_v2 else 1)
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -114,7 +115,10 @@ def run_session(env: dict[str, str], interact):
         async with stdio_client(params) as (read, write):
             async with ClientSession(read, write) as session:
                 init = await session.initialize()
-                assert init.serverInfo.name == "kvm-pilot"
+                # by_alias: mcp 2.x renamed these model fields to snake_case, but
+                # the wire keys stayed camelCase — assert the wire, not the field
+                # name, so one assertion holds on both SDK majors (#241).
+                assert init.model_dump(by_alias=True)["serverInfo"]["name"] == "kvm-pilot"
                 return await interact(session)
 
     return asyncio.run(asyncio.wait_for(runner(), timeout=60))
@@ -124,6 +128,25 @@ def result_json(result) -> dict:
     """Parse a dict-returning tool's JSON text content."""
     assert result.content[0].type == "text"
     return json.loads(result.content[0].text)
+
+
+def wire(model, key: str):
+    """Read a wire field off an SDK model, on either mcp major (#241).
+
+    mcp 2.x renamed the model fields to snake_case (``isError`` -> ``is_error``,
+    ``mimeType`` -> ``mime_type``) but kept the camelCase keys on the wire. Pass
+    the wire key: it is what the protocol — and therefore the assertion — is
+    actually about, and it reads the same on both majors."""
+    snake = re.sub(r"(?<!^)(?=[A-Z])", "_", key).lower()
+    for field in (key, snake):
+        if field in type(model).model_fields:
+            return getattr(model, field)
+    raise AssertionError(f"{type(model).__name__} has no {key!r}/{snake!r} field")
+
+
+def is_error(result) -> bool:
+    """The ``isError`` flag off a ``CallToolResult``, on either mcp major (#241)."""
+    return wire(result, "isError")
 
 
 def run_session_elicit(env, interact, *, action, content=None):
@@ -158,7 +181,12 @@ def test_handshake_lists_annotated_tools(config_file):
     for name, expected in EXPECTED_ANNOTATIONS.items():
         ann = by_name[name].annotations
         assert ann is not None, name
-        got = (ann.readOnlyHint, ann.destructiveHint, ann.idempotentHint, ann.openWorldHint)
+        # by_alias keeps the camelCase wire keys across both mcp majors (#241).
+        hints = ann.model_dump(by_alias=True)
+        got = tuple(
+            hints[k]
+            for k in ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint")
+        )
         assert got == expected, f"{name}: annotations {got} != expected {expected}"
 
 
@@ -189,7 +217,7 @@ def test_read_only_mode_registers_only_read_tools(config_file):
     tools, health, power = run_session(env, interact)
     assert {t.name for t in tools} == READ_ONLY_MODE_TOOLS
     assert result_json(health)["read_only"] is True
-    assert power.isError  # never registered, so the call can only error
+    assert is_error(power)  # never registered, so the call can only error
 
 
 def test_read_only_mode_forces_gates_closed(monkeypatch):
@@ -286,7 +314,7 @@ def test_session_never_refuses(config_file):
         return await session.call_tool("session", {})
 
     result = run_session(server_env(config_file, KVM_PILOT_MCP_PROFILES=""), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     payload = result_json(result)
     assert payload["gates"]  # posture still served
     assert payload["server"]["profile_allowlist"] == []
@@ -380,25 +408,24 @@ def test_doctrine_serves_bundled_playbooks(config_file):
     assert {"core", "recovery", "interfaces", "setup"} <= set(topics)
     text = result_json(recovery)["text"]
     assert "Wake-on-LAN" in text  # the ladder's first rung is the payload
-    assert bogus.isError
+    assert is_error(bogus)
     assert "recovery" in bogus.content[0].text  # refusal names the valid topics
 
 
 def test_doctrine_also_served_as_resources(config_file):
     """#231: the same playbooks are MCP resources — no tool round-trip for
     resource-capable clients; byte-identical to the tool's text."""
-    from pydantic import AnyUrl
-
     async def interact(session):
         templates = await session.list_resource_templates()
-        res = await session.read_resource(AnyUrl("kvm-pilot://doctrine/recovery"))
+        # A plain str URI: mcp 1.x coerces it to AnyUrl, 2.x requires the str (#241).
+        res = await session.read_resource("kvm-pilot://doctrine/recovery")
         tool = await session.call_tool("doctrine", {"topic": "recovery"})
         return templates, res, tool
 
     templates, res, tool = run_session(server_env(config_file), interact)
     assert any(
-        t.uriTemplate == "kvm-pilot://doctrine/{topic}"
-        for t in templates.resourceTemplates
+        wire(t, "uriTemplate") == "kvm-pilot://doctrine/{topic}"
+        for t in wire(templates, "resourceTemplates")
     )
     assert res.contents[0].text == result_json(tool)["text"]
 
@@ -411,7 +438,7 @@ def test_power_errors_without_operator_gate(config_file):
         return await session.call_tool("power", {"action": "off", "confirm": True})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     payload = result_json(result)
     assert payload["approved"] is False
     assert payload["outcome"] == "gate_closed"
@@ -446,7 +473,7 @@ def test_amt_enable_consent_off_needs_dedicated_gate(config_file):
     # ALLOW_CONFIG on, but the dedicated consent-off gate is NOT — must still refuse.
     env = server_env(config_file, KVM_PILOT_MCP_ALLOW_CONFIG="1")
     result = run_session(env, interact)
-    assert result.isError is True
+    assert is_error(result) is True
     text = result.content[0].text.lower()
     assert "consent" in text and "gate" in text
 
@@ -467,7 +494,7 @@ def test_power_executes_on_fake_driver_when_fully_gated(config_file):
 
     env = server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1")
     result = run_session(env, interact)
-    assert result.isError is False
+    assert is_error(result) is False
     text = result.content[0].text
     assert "requested on host 'fakebox.local' (fake)" in text
     assert "DRY-RUN" not in text
@@ -693,7 +720,7 @@ def test_allowlist_refuses_profile_not_listed(config_file):
 
     env = server_env(config_file, KVM_PILOT_MCP_PROFILES="fakebox")
     result = run_session(env, interact)
-    assert result.isError is True
+    assert is_error(result) is True
     assert "allowlist" in result.content[0].text
 
 
@@ -702,7 +729,7 @@ def test_allowlist_allows_listed_profile(config_file):
         return await session.call_tool("info", {})  # default profile 'fakebox' is listed
 
     env = server_env(config_file, KVM_PILOT_MCP_PROFILES="fakebox")
-    assert run_session(env, interact).isError is False
+    assert is_error(run_session(env, interact)) is False
 
 
 # -- mouse + generation-keyed staleness (#124) -------------------------------
@@ -713,7 +740,7 @@ def test_snapshot_returns_frame_ref(config_file):
         return await session.call_tool("snapshot", {})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     payload = json.loads(result.content[0].text)
     assert payload["host"] == "fakebox.local"
     assert payload["frame_ref"].startswith("fakebox.local:0:")
@@ -896,7 +923,7 @@ def test_ssh_reachable_errors_when_not_configured(config_file):
         return await session.call_tool("ssh_reachable", {})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is True
+    assert is_error(result) is True
     assert "not configured" in result.content[0].text
 
 
@@ -919,7 +946,7 @@ def test_appliance_status_errors_when_not_enabled(config_file):
         return await session.call_tool("appliance_status", {})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is True
+    assert is_error(result) is True
     assert "not enabled" in result.content[0].text
 
 
@@ -930,7 +957,7 @@ def test_access_paths_reports_the_lockout_view(config_file):
         return await session.call_tool("access_paths", {})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     parsed = result_json(result)
     assert "paths" in parsed and "summary" in parsed
     assert any(p["path"] == "kvmd-rest" for p in parsed["paths"])
@@ -945,7 +972,7 @@ def test_ssh_reachable_host_override_unblocks_unconfigured_profile(config_file):
         return await session.call_tool("ssh_reachable", {"host": "127.0.0.1"})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False  # no longer "not configured"
+    assert is_error(result) is False  # no longer "not configured"
     parsed = result_json(result)
     assert parsed["target"] == "127.0.0.1"
     assert "reachable" in parsed
@@ -959,7 +986,7 @@ def test_ssh_reachable_rejects_hyphen_host(config_file):
         return await session.call_tool("ssh_reachable", {"host": "-oProxyCommand=touch /tmp/x"})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is True
+    assert is_error(result) is True
     assert "misparsed" in result.content[0].text
 
 
@@ -970,7 +997,7 @@ def test_ssh_discover_requires_confirm(config_file):
         return await session.call_tool("ssh_discover", {"cidr": "10.0.0.0/30"})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is True
+    assert is_error(result) is True
     assert "not confirmed" in result.content[0].text
 
 
@@ -982,7 +1009,7 @@ def test_dry_run_marks_results_and_skips_the_command(config_file):
 
     env = server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1", KVM_PILOT_MCP_DRY_RUN="1")
     power, info = run_session(env, interact)
-    assert power.isError is False
+    assert is_error(power) is False
     assert "DRY-RUN" in power.content[0].text
     assert "fakebox.local" in power.content[0].text
     # Read-only results carry the dry-run flag too.
@@ -1001,7 +1028,7 @@ def test_read_only_tools_report_provenance(config_file):
     assert parsed["driver"] == "fake"
     # Regression for the get_atx_state AttributeError: power_state must work on
     # a driver without PiKVM's ATX detail endpoint.
-    assert state.isError is False
+    assert is_error(state) is False
     assert result_json(state)["powered_on"] is False
 
 
@@ -1036,7 +1063,7 @@ def test_logs_tool_returns_text_with_provenance(config_file):
         return await session.call_tool("logs", {"seek": 60})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     parsed = result_json(result)
     assert parsed["host"] == "fakebox.local"
     assert parsed["driver"] == "fake"
@@ -1053,7 +1080,7 @@ def test_list_virtual_media_inventories_msd_storage(config_file):
         return await session.call_tool("list_virtual_media", {})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     parsed = result_json(result)
     assert parsed["host"] == "fakebox.local"
     assert "online" in parsed["msd"] and "storage" in parsed["msd"]
@@ -1065,11 +1092,11 @@ def test_snapshot_returns_a_real_image(config_file):
         return await session.call_tool("snapshot", {})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     types = [c.type for c in result.content]
     assert "image" in types
     image = result.content[types.index("image")]
-    assert image.mimeType == "image/jpeg"
+    assert wire(image, "mimeType") == "image/jpeg"
     assert "fakebox.local" in result.content[0].text  # provenance note
 
 
@@ -1108,7 +1135,7 @@ def test_classify_screen_supports_local_backend(config_file):
         KVM_PILOT_VISION_MODEL="test-vlm",
     )
     result = run_session(env, interact)
-    assert result.isError is False
+    assert is_error(result) is False
     parsed = result_json(result)
     assert parsed["phase"] == "power_off"
     assert parsed["host"] == "fakebox.local"
@@ -1125,7 +1152,7 @@ def test_classify_screen_cheap_gate_works_without_any_key(config_file):
 
     # server_env strips ANTHROPIC_API_KEY; the default backend is anthropic.
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     parsed = result_json(result)
     assert parsed["mode"] == "server"
     assert parsed["phase"] == "power_off"
@@ -1138,11 +1165,10 @@ def test_classify_fallback_returns_image_and_prompt():
     before the backend), so the fallback can't be reached end-to-end there."""
     from types import SimpleNamespace
 
-    from mcp.server.fastmcp import Image
-
     from kvm_pilot.drivers import FakeDriver
     from kvm_pilot.errors import VisionError
     from kvm_pilot.mcp import server
+    from kvm_pilot.mcp._sdk import Image
 
     cfg = SimpleNamespace(host="fakebox.local", driver="fake")
     out = server._classify_fallback(
@@ -1165,10 +1191,9 @@ def test_classify_fallback_raises_when_snapshot_also_fails():
     """No image means nothing to delegate -> a clean tool error, not a fallback."""
     from types import SimpleNamespace
 
-    from mcp.server.fastmcp.exceptions import ToolError
-
     from kvm_pilot.errors import VisionError
     from kvm_pilot.mcp import server
+    from kvm_pilot.mcp._sdk import ToolError
 
     class NoSnapshot:
         def snapshot(self):
@@ -1194,7 +1219,7 @@ def test_wait_for_state_reaches_cheap_phase_without_vision_key(config_file):
 
     # server_env strips ANTHROPIC_API_KEY; the default backend is anthropic.
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     parsed = result_json(result)
     assert parsed["reached"] is True
     assert parsed["phase"] == "power_off"
@@ -1212,7 +1237,7 @@ def test_wait_for_state_timeout_returns_same_path_result(config_file):
         return await session.call_tool("wait_for_state", {"phase": "desktop", "timeout": 1})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     parsed = result_json(result)
     assert parsed["reached"] is False
     assert parsed["waited_for"] == "desktop"
@@ -1229,7 +1254,7 @@ def test_wait_for_state_rejects_unknown_phase_fast(config_file):
         return await session.call_tool("wait_for_state", {"phase": "dekstop", "timeout": 300})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is True
+    assert is_error(result) is True
     text = result.content[0].text
     assert "Valid phases" in text
     assert "desktop" in text
@@ -1249,7 +1274,7 @@ def test_wait_for_state_emits_progress(config_file):
         )
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     assert updates
     progress, total, message = updates[0]
     assert total == 1.0
@@ -1306,10 +1331,9 @@ def test_wait_for_state_keyless_refuses_vlm_phase_end_to_end(config_file, monkey
     phase must raise the typed refusal — NOT fall through and burn the timeout.
     Kills the 'delete the gate block' mutation the subprocess fake can't (it is
     BootProgress-capable, so end-to-end it can wait for any phase keylessly)."""
-    from mcp.server.fastmcp.exceptions import ToolError
-
     import kvm_pilot.config as _cfg
     from kvm_pilot.mcp import server
+    from kvm_pilot.mcp._sdk import ToolError
     from kvm_pilot.vision.anthropic import AnthropicBackend
     monkeypatch.setattr(_cfg, "DEFAULT_CONFIG_PATH", config_file)
     monkeypatch.setenv("KVM_PILOT_PROFILE", "fakebox")
@@ -1348,9 +1372,8 @@ def test_wait_timeout_clamped_to_cap_and_rejects_nonpositive():
     """The server-side ceiling without a 300 s test run: in-range values pass
     through, anything above is clamped to the cap; non-positive and non-finite
     (NaN compares False against <= 0) are refused."""
-    from mcp.server.fastmcp.exceptions import ToolError
-
     from kvm_pilot.mcp import server
+    from kvm_pilot.mcp._sdk import ToolError
 
     assert server._clamp_timeout(10) == 10
     assert server._clamp_timeout(1e6) == 300.0
@@ -1369,7 +1392,7 @@ def test_video_tools_error_cleanly_on_capability_less_driver(config_file):
         return await session.call_tool("snapshot", {"profile": "bmc"})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is True
+    assert is_error(result) is True
     text = result.content[0].text
     assert "redfish" in text
     assert "video" in text
@@ -1406,7 +1429,7 @@ def test_support_matrix_unknown_combo_returns_empty_cleanly(config_file):
         return await session.call_tool("support_matrix", {"vendor": "nonexistent"})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     assert result_json(result)["combos"] == []
 
 
@@ -1716,7 +1739,7 @@ def test_set_boot_device_executes_on_fake(config_file):
 
     env = server_env(config_file, KVM_PILOT_MCP_ALLOW_CONFIG="1")
     result = run_session(env, interact)
-    assert result.isError is False
+    assert is_error(result) is False
     text = result.content[0].text
     assert '"target": "pxe"' in text and '"enabled": "Once"' in text
 
@@ -1726,7 +1749,7 @@ def test_boot_options_is_read_only(config_file):
         return await session.call_tool("boot_options", {})
 
     result = run_session(server_env(config_file), interact)
-    assert result.isError is False
+    assert is_error(result) is False
     assert '"enabled": "Disabled"' in result.content[0].text
 
 
@@ -1757,7 +1780,7 @@ def test_wake_requires_mac(config_file):
         return await session.call_tool("wake", {"confirm": True})
 
     result = run_session(server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1"), interact)
-    assert result.isError is True
+    assert is_error(result) is True
     assert "no MAC" in result.content[0].text
 
 
@@ -1767,6 +1790,6 @@ def test_wake_dry_run_reports_without_sending(config_file):
 
     env = server_env(config_file, KVM_PILOT_MCP_ALLOW_POWER="1", KVM_PILOT_MCP_DRY_RUN="1")
     result = run_session(env, interact)
-    assert result.isError is False
+    assert is_error(result) is False
     text = result.content[0].text
     assert '"dry_run": true' in text and "aa:bb:cc:dd:ee:ff" in text


### PR DESCRIPTION
Takes over Dependabot #240, which widened the mcp cap to `<3` and reddened every CI job.

## Why #240 failed

mcp 2.x is **not source-compatible** with 1.x:

- `mcp.server.fastmcp` → `mcp.server.mcpserver`, `FastMCP` → `MCPServer`, taking `Context`/`Image`/`ToolError` with it. This is the `ModuleNotFoundError` from #110, which is why the `<2` cap existed.
- The SDK's pydantic **model fields** were renamed to snake_case (`isError` → `is_error`, `readOnlyHint` → `read_only_hint`, `mimeType`, `serverInfo`, `uriTemplate`). **Wire keys are unchanged** — a Python-API break only.
- `ClientSession.read_resource()` takes a `str` in 2.x and rejects the `AnyUrl` 1.x wanted.

Everything else kvm-pilot uses survived with identical signatures: the `tool`/`resource` decorators (incl. `annotations=`), `Context.elicit`/`.session`/`.report_progress`, `Image(data=, format=)`, `ToolError`, `MCPServer.run()`, and the `_tool_manager`/`remove_tool` pair behind the read-only filter.

## Approach

mcp 2.0.0 is stable, so support **both** majors instead of keeping the cap. Floor stays `>=1.10` so existing installs aren't forced onto a new major; `<3` caps the next unknown break.

- `src/kvm_pilot/mcp/_sdk.py` — the single import site for the SDK, resolving either major, plus accessors for the two renamed model fields read at run time.
- Tool annotations build via `model_validate` on the camelCase wire keys — they're field names on 1.x and aliases on 2.x, so keyword construction only type-checks against whichever mcp is installed.
- Test assertions target the wire shape rather than the renamed Python fields.

## Bug this surfaced

`_apply_read_only_mode()` read `ann.readOnlyHint` by its 1.x field name, so under mcp 2.x **`KVM_PILOT_MCP_READ_ONLY=1` crashed the server at startup** with an `AttributeError` — the least-privilege posture (#196) failing closed but unusable. Only running the suite against 2.x reaches this; an import smoke test does not.

## Guards

The `test` job always resolves the *newest* allowed mcp, so it structurally cannot catch a break in the older major:

- `tests/test_mcp_sdk_shim.py` fails the build if any shipped module imports `mcp.server.*` directly — the thing that silently reintroduces #110.
- New `mcp-majors` CI leg pins each end of the range and runs the MCP suite against both.

## Verification

| | mcp 1.28.1 | mcp 2.0.0 |
|---|---|---|
| full suite | 1221 passed, 10 skipped | pass |
| ruff / mypy | clean | clean |
| coverage | 83.4% (gate 75%) | — |

bandit clean. Clean-room `pip install --pre` of the built wheel resolves **mcp 2.0.0**, and the shipped server, both console scripts and the read-only filter all work — the #110 scenario, now green.

No driver or wire-protocol change; live hardware behaviour is unaffected.

Closes #241. Supersedes #240.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an MCP SDK compatibility shim to unify server/tool behavior across MCP 1.x and 2.x.

- **Bug Fixes**
  - Improved read-only tool handling and normalized tool annotation interpretation across MCP SDK versions.
  - Updated the verified MCP minimum dependency to `mcp>=1.17` for restored compatibility.

- **Tests**
  - Added AST-based protection to prevent direct MCP server SDK imports outside the shim.
  - Enhanced protocol assertions to accommodate wire-level differences between MCP majors.

- **Chores / CI**
  - Expanded CI coverage to run across three MCP version legs and added per-major type-checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->